### PR TITLE
Add NaN validation and fix division-by-zero edge cases

### DIFF
--- a/output/allGlyphs.html
+++ b/output/allGlyphs.html
@@ -117,7 +117,7 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_ba03c14f43c65166)'
 />
 <!-- e -->
-<clipPath id='clip_82f2d7e6d336788c'>
+<clipPath id='clip_79db3baa5d479876'>
 <rect x='-6' y='-306' width='358' height='962'/>
 </clipPath>
 <path
@@ -125,21 +125,21 @@ d='
 M -0,180
 L -0,186
 L 300,186
-C 300,266 249,360 153,360
-C 60,360 6,260 6,183
-C 6,92 67,14 153,6
-C 215,0 269,34 306,66
+C 300,273 246,360 153,360
+C 65,360 6,269 6,183
+C 6,95 60,6 153,6
+C 209,6 259,47 306,66
 L 306,60
-C 258,19 209,-5 153,0
-C 78,7 -0,80 -0,183
-C -0,262 50,366 153,366
-C 244,366 306,275 306,180
+C 244,34 212,-0 153,0
+C 87,0 -0,70 -0,183
+C -0,286 60,366 153,366
+C 239,366 306,280 306,180
 L -0,180
 Z
 '
 transform='translate(1385,1056) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_82f2d7e6d336788c)'
+clip-path='url(#clip_79db3baa5d479876)'
 />
 <!-- f -->
 <clipPath id='clip_2b7d5fb4e1f8249f'>
@@ -306,7 +306,7 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_1b38a4ff09ad8401)'
 />
 <!-- l -->
-<clipPath id='clip_8527fcc720f8c31c'>
+<clipPath id='clip_1fa4b1988b765578'>
 <rect x='-6' y='-306' width='208' height='962'/>
 </clipPath>
 <path
@@ -314,15 +314,15 @@ d='
 M -0,606
 L 6,606
 L 6,183
-C 6,88 107,32 156,6
+C 6,77 79,6 156,6
 L 156,0
-C 104,28 -0,88 -0,183
+C 75,0 -0,73 -0,183
 L -0,606
 Z
 '
 transform='translate(3284,1056) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_8527fcc720f8c31c)'
+clip-path='url(#clip_1fa4b1988b765578)'
 />
 <!-- m -->
 <clipPath id='clip_61df27faed972bdb'>
@@ -2136,7 +2136,7 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_c94067eb82388689)'
 />
 <!-- e -->
-<clipPath id='clip_d2a4df1652efa9c1'>
+<clipPath id='clip_9d4097335687fdb6'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
@@ -2144,21 +2144,21 @@ d='
 M -1,180
 L -1,240
 L 299,240
-C 299,310 240,360 180,360
-C 92,360 62,257 62,210
-C 62,150 95,68 183,60
-C 222,56 300,68 361,120
+C 299,309 237,360 180,360
+C 104,360 61,285 62,210
+C 62,142 94,60 180,60
+C 224,60 319,103 361,120
 L 361,60
-C 300,7 224,-4 177,0
-C 59,11 -2,116 -2,210
-C -1,308 63,420 180,420
-C 304,420 361,283 361,180
+C 296,33 245,-0 180,0
+C 79,0 -2,104 -2,210
+C -1,324 78,420 180,420
+C 298,420 361,295 361,180
 L -1,180
 Z
 '
 transform='translate(1612,3222) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_d2a4df1652efa9c1)'
+clip-path='url(#clip_9d4097335687fdb6)'
 />
 <!-- f -->
 <clipPath id='clip_aa2907fad56f8eee'>
@@ -2325,7 +2325,7 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_db5c50986d21832b)'
 />
 <!-- l -->
-<clipPath id='clip_12c53ed39b9307e0'>
+<clipPath id='clip_74c149a4f3533d47'>
 <rect x='-60' y='-360' width='374' height='1070'/>
 </clipPath>
 <path
@@ -2333,15 +2333,15 @@ d='
 M -1,660
 L 61,660
 L 62,210
-C 62,129 160,88 211,60
+C 62,127 129,60 211,60
 L 211,-0
-C 135,41 -2,101 -2,210
+C 93,0 -2,95 -2,210
 L -1,660
 Z
 '
 transform='translate(3908,3222) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_12c53ed39b9307e0)'
+clip-path='url(#clip_74c149a4f3533d47)'
 />
 <!-- m -->
 <clipPath id='clip_395b1442cc5b6ac5'>
@@ -4155,7 +4155,7 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_ae63ab239700ba36)'
 />
 <!-- e -->
-<clipPath id='clip_4f5a4b8d96624fa8'>
+<clipPath id='clip_3e681861bb8ad3bd'>
 <rect x='-60' y='-360' width='551' height='1070'/>
 </clipPath>
 <path
@@ -4163,21 +4163,21 @@ d='
 M 30,180
 L 30,240
 L 335,240
-C 344,300 304,360 238,360
-C 165,360 102,266 93,206
-C 79,112 127,68 189,60
-C 233,54 315,76 375,120
+C 344,305 305,360 238,360
+C 163,360 103,277 93,206
+C 82,136 111,60 184,60
+C 228,60 336,109 375,120
 L 375,60
-C 316,16 239,-8 180,0
-C 82,14 13,102 30,214
-C 45,311 132,420 238,420
-C 370,420 403,277 388,180
+C 314,42 257,-0 184,0
+C 97,0 11,87 30,214
+C 51,353 162,420 238,420
+C 368,420 402,273 388,180
 L 30,180
 Z
 '
 transform='translate(1612,5442) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_4f5a4b8d96624fa8)'
+clip-path='url(#clip_3e681861bb8ad3bd)'
 />
 <!-- f -->
 <clipPath id='clip_a6b3b9dcca9e5d75'>
@@ -4344,7 +4344,7 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_6b9b095a14a9a115)'
 />
 <!-- l -->
-<clipPath id='clip_3e43fb947ec4ff82'>
+<clipPath id='clip_945a4688d6f8cfcd'>
 <rect x='-60' y='-360' width='379' height='1070'/>
 </clipPath>
 <path
@@ -4352,15 +4352,15 @@ d='
 M 93,660
 L 156,660
 L 93,206
-C 83,133 172,88 216,60
+C 82,128 141,60 216,60
 L 216,-0
-C 147,44 16,112 30,214
+C 102,0 14,101 30,214
 L 93,660
 Z
 '
 transform='translate(3908,5442) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_3e43fb947ec4ff82)'
+clip-path='url(#clip_945a4688d6f8cfcd)'
 />
 <!-- m -->
 <clipPath id='clip_b3169ff2016bef7a'>
@@ -6174,7 +6174,7 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_4e3a2c7a51fc0e45)'
 />
 <!-- e -->
-<clipPath id='clip_43b7d0f949bc1b43'>
+<clipPath id='clip_9e76a5e6fcd273ee'>
 <rect x='-120' y='-420' width='708' height='1190'/>
 </clipPath>
 <path
@@ -6182,21 +6182,21 @@ d='
 M -2,180
 L -2,300
 L 298,300
-C 298,360 218,360 210,360
-C 133,360 123,265 123,240
-C 123,173 155,125 216,120
-C 273,114 375,139 422,180
+C 298,351 225,360 210,360
+C 148,360 123,301 123,240
+C 123,178 135,120 210,120
+C 270,120 366,157 422,180
 L 422,60
-C 360,7 254,-4 204,0
-C 43,15 -3,147 -3,240
-C -3,358 77,480 210,480
-C 366,480 422,318 422,180
+C 367,38 284,-0 210,0
+C 75,0 -3,129 -3,240
+C -3,372 94,480 210,480
+C 354,480 422,314 422,180
 L -2,180
 Z
 '
 transform='translate(1864,7722) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_43b7d0f949bc1b43)'
+clip-path='url(#clip_9e76a5e6fcd273ee)'
 />
 <!-- f -->
 <clipPath id='clip_c29933a59ee1fd7f'>
@@ -6363,7 +6363,7 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_9ee05d7425e7bfcb)'
 />
 <!-- l -->
-<clipPath id='clip_53a8cab3062fe091'>
+<clipPath id='clip_975975848fbe700e'>
 <rect x='-120' y='-420' width='558' height='1190'/>
 </clipPath>
 <path
@@ -6371,15 +6371,15 @@ d='
 M -2,720
 L 122,720
 L 123,240
-C 123,169 223,147 272,120
+C 123,179 179,120 272,120
 L 272,-0
-C 175,52 -3,110 -3,240
+C 111,0 -3,115 -3,240
 L -2,720
 Z
 '
 transform='translate(4601,7722) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_53a8cab3062fe091)'
+clip-path='url(#clip_975975848fbe700e)'
 />
 <!-- m -->
 <clipPath id='clip_46ccf8189c759ef0'>
@@ -8207,8 +8207,8 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_2086cf04484b8b09)'
 />
 <!-- e -->
-<clipPath id='clip_26228d28c4e52d0e'>
-<rect x='-180' y='-480' width='896' height='1310'/>
+<clipPath id='clip_dcd1a22b26ef8f36'>
+<rect x='-180' y='-480' width='892' height='1310'/>
 </clipPath>
 <path
 d='
@@ -8216,22 +8216,22 @@ M 43,180
 C 26,210 -3,236 -4,270
 C -7,305 27,330 43,360
 L 297,360
-C 297,397 265,360 240,360
-C 192,360 184,286 184,270
-C 184,238 199,184 249,180
-C 289,176 341,227 364,248
-C 398,234 437,234 462,209
-C 486,183 478,143 487,111
-C 405,41 331,-9 231,0
-C 128,10 -5,111 -4,270
-C -4,423 109,540 240,540
-C 434,540 483,312 483,180
+C 297,391 263,360 240,360
+C 192,360 184,311 184,270
+C 184,254 190,180 240,180
+C 269,180 366,237 398,250
+C 425,228 462,215 477,184
+C 493,152 472,116 469,84
+C 378,47 329,-0 240,0
+C 131,0 -5,105 -4,270
+C -4,456 134,540 240,540
+C 416,540 483,349 483,180
 L 43,180
 Z
 '
 transform='translate(2116,10122) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_26228d28c4e52d0e)'
+clip-path='url(#clip_dcd1a22b26ef8f36)'
 />
 <!-- f -->
 <clipPath id='clip_df52b6ff97b48460'>
@@ -8420,8 +8420,8 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_a10efa2c4bc17287)'
 />
 <!-- l -->
-<clipPath id='clip_76b28aeb3034fb18'>
-<rect x='-180' y='-480' width='735' height='1310'/>
+<clipPath id='clip_0bc5d96ee8034ab8'>
+<rect x='-180' y='-480' width='744' height='1310'/>
 </clipPath>
 <path
 d='
@@ -8429,16 +8429,16 @@ M -4,735
 C 27,754 55,780 90,780
 C 126,780 152,747 184,735
 L 184,270
-C 185,200 278,173 326,148
-C 326,114 337,79 323,47
-C 308,14 266,6 237,-11
-C 155,34 -5,125 -4,270
+C 185,223 227,180 287,180
+C 304,149 332,124 334,90
+C 337,55 303,30 287,0
+C 121,0 -5,126 -4,270
 L -4,735
 Z
 '
 transform='translate(5294,10122) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_76b28aeb3034fb18)'
+clip-path='url(#clip_0bc5d96ee8034ab8)'
 />
 <!-- m -->
 <clipPath id='clip_fff89692bd874cc3'>
@@ -10447,7 +10447,7 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_09797f33927ad468)'
 />
 <!-- e -->
-<clipPath id='clip_28967bb1e47a8a79'>
+<clipPath id='clip_204d889b82e07fa8'>
 <rect x='-60' y='-360' width='403' height='1070'/>
 </clipPath>
 <path
@@ -10455,21 +10455,21 @@ d='
 M -1,180
 L -1,240
 L 239,240
-C 239,296 209,360 150,360
-C 82,360 62,264 62,210
-C 62,121 117,64 154,60
-C 193,55 219,98 239,120
-L 301,120
-C 253,67 220,-9 146,0
-C 88,7 -2,110 -2,210
-C -1,290 40,420 150,420
-C 247,420 301,272 301,180
+C 239,296 212,360 150,360
+C 80,360 62,259 62,210
+C 62,144 69,60 150,60
+C 182,60 260,95 301,120
+L 301,60
+C 251,30 207,-0 150,0
+C 41,0 -2,133 -2,210
+C -1,317 52,420 150,420
+C 246,420 301,306 301,180
 L -1,180
 Z
 '
 transform='translate(1372,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_28967bb1e47a8a79)'
+clip-path='url(#clip_204d889b82e07fa8)'
 />
 <!-- f -->
 <clipPath id='clip_2429c90cce7f1941'>
@@ -10557,27 +10557,27 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_5c8db5b2e2543e2d)'
 />
 <!-- i -->
-<clipPath id='clip_18fc21259b8470fc'>
-<rect x='-60' y='-360' width='NaN' height='1070'/>
+<clipPath id='clip_4539ddb2fa1f7388'>
+<rect x='-60' y='-360' width='403' height='1070'/>
 </clipPath>
 <path
 d='
-M NaN,360
-L NaN,360
-C NaN,NaN NaN,NaN NaN,-0
-L NaN,-0
-C NaN,NaN NaN,NaN NaN,360
+M -1,420
+L 61,420
+L 61,-0
+L -1,-0
+L -1,420
 Z
-M NaN,515
-C NaN,NaN NaN,NaN NaN,550
-C NaN,NaN NaN,NaN NaN,585
-C NaN,NaN NaN,NaN NaN,550
-C NaN,NaN NaN,NaN NaN,515
+M 30,515
+C 52,515 65,534 65,550
+C 65,569 51,585 30,585
+C 12,585 -5,570 -5,550
+C -5,533 8,515 30,515
 Z
 '
 transform='translate(2744,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_18fc21259b8470fc)'
+clip-path='url(#clip_4539ddb2fa1f7388)'
 />
 <!-- j -->
 <clipPath id='clip_5e35f7bdb0934681'>
@@ -10602,7 +10602,7 @@ C 250,585 235,572 235,550
 C 235,531 251,515 270,515
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(2847,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_5e35f7bdb0934681)'
 />
@@ -10631,12 +10631,12 @@ L 301,-0
 C 203,73 93,110 -1,180
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(3190,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_583c1e81ebcd5a62)'
 />
 <!-- l -->
-<clipPath id='clip_5c512d118512286e'>
+<clipPath id='clip_25ff992879f86b01'>
 <rect x='-60' y='-360' width='403' height='1070'/>
 </clipPath>
 <path
@@ -10644,15 +10644,15 @@ d='
 M -1,660
 L 61,660
 L 62,210
-C 62,95 234,74 301,60
+C 62,148 114,60 301,60
 L 301,-0
-C 220,17 -2,61 -2,210
+C 86,0 -2,115 -2,210
 L -1,660
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(3533,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_5c512d118512286e)'
+clip-path='url(#clip_25ff992879f86b01)'
 />
 <!-- m -->
 <clipPath id='clip_bbeb7b4c326c95b1'>
@@ -10687,7 +10687,7 @@ C 238,260 281,353 218,360
 C 195,363 151,337 181,240
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(3876,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_bbeb7b4c326c95b1)'
 />
@@ -10714,7 +10714,7 @@ C 238,288 225,360 150,360
 C 130,360 51,347 -1,300
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(4219,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_531705b8f5da8aec)'
 />
@@ -10737,7 +10737,7 @@ C 114,360 49,322 61,213
 C 67,161 73,50 146,60
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(4562,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_d0cf128e3afa0a15)'
 />
@@ -10766,7 +10766,7 @@ C 303,107 222,14 156,1
 C 72,-16 24,70 -1,120
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(4905,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_bff84b71af71964a)'
 />
@@ -10795,7 +10795,7 @@ C -6,316 85,408 144,419
 C 220,435 271,370 301,300
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(5248,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_e9c21b1940241a09)'
 />
@@ -10820,7 +10820,7 @@ C 197,351 172,360 150,360
 C 107,360 75,318 61,300
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(5591,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_6e76cc1363b168f1)'
 />
@@ -10847,7 +10847,7 @@ C -19,331 90,420 150,420
 C 217,420 274,341 301,300
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(5934,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_d13c65a40d2d17b5)'
 />
@@ -10874,7 +10874,7 @@ L 301,360
 L -1,360
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(6277,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_8c66f6f659a615c6)'
 />
@@ -10903,7 +10903,7 @@ L 239,-0
 L 239,420
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(6620,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_6a73f77096094332)'
 />
@@ -10923,7 +10923,7 @@ L 119,0
 C 71,144 45,282 -1,420
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(6963,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_e7225d9a32683e78)'
 />
@@ -10949,7 +10949,7 @@ L 59,0
 C 35,145 22,281 -1,420
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(7306,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_4e9b7598b7b6f5d7)'
 />
@@ -10972,7 +10972,7 @@ L -1,-0
 C 92,140 150,286 239,420
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(7649,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_d38cc306d676c80a)'
 />
@@ -11005,7 +11005,7 @@ C 179,-232 238,-150 238,30
 L 239,420
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(7992,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_9c7f0add775f0fb7)'
 />
@@ -11027,7 +11027,7 @@ C 79,121 135,244 213,360
 L -1,360
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(8335,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_8aecbf3072141645)'
 />
@@ -11038,7 +11038,7 @@ clip-path='url(#clip_8aecbf3072141645)'
 <path
 d='
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(8678,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_e3b0c44298fc1c14)'
 />
@@ -11067,7 +11067,7 @@ L -1,-0
 C 89,226 152,443 239,660
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(9021,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_c3e47d3289e08209)'
 />
@@ -11086,7 +11086,7 @@ C 239,206 239,393 239,592
 C 156,571 78,560 -1,540
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(9364,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_332a099f86b9c5f5)'
 />
@@ -11112,7 +11112,7 @@ C 232,542 183,594 145,600
 C 98,608 69,556 61,540
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(9707,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_928dbfb2944a0059)'
 />
@@ -11147,7 +11147,7 @@ C 243,246 207,300 150,300
 L 79,300
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(10050,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_89b17ce933f42af5)'
 />
@@ -11169,7 +11169,7 @@ L 241,660
 L 241,-0
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(10393,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_ccb7af8ce49510a0)'
 />
@@ -11200,7 +11200,7 @@ C 237,291 206,391 145,400
 C 93,408 62,351 61,300
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(10736,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_7df4f959c0b62166)'
 />
@@ -11229,7 +11229,7 @@ C 10,441 29,631 142,659
 C 219,679 281,611 301,540
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(11079,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_dd3601df0346ab45)'
 />
@@ -11248,7 +11248,7 @@ C 121,207 169,401 228,600
 L -1,600
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(11422,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_a979aae044316d1f)'
 />
@@ -11279,7 +11279,7 @@ C 66,424 128,390 171,353
 C 233,298 295,256 301,183
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(11765,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_b31b76d489a8c497)'
 />
@@ -11308,7 +11308,7 @@ C 291,237 264,40 161,2
 C 78,-29 15,46 -1,120
 Z
 '
-transform='translate(NaN,12462) scale(1,-1)'
+transform='translate(12108,12462) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_35d55bae00afc93b)'
 />
@@ -11967,27 +11967,27 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_e3b0c44298fc1c14)'
 />
 <!-- ! -->
-<clipPath id='clip_d7044c2f06f5ead8'>
-<rect x='-60' y='-360' width='NaN' height='1070'/>
+<clipPath id='clip_c80001ca8a9e8c0f'>
+<rect x='-60' y='-360' width='403' height='1070'/>
 </clipPath>
 <path
 d='
-M NaN,600
-L NaN,600
-C NaN,NaN NaN,NaN NaN,150
-L NaN,150
-C NaN,NaN NaN,NaN NaN,600
+M -1,660
+L 61,660
+L 61,150
+L -1,150
+L -1,660
 Z
-M NaN,-5
-C NaN,NaN NaN,NaN NaN,30
-C NaN,NaN NaN,NaN NaN,65
-C NaN,NaN NaN,NaN NaN,30
-C NaN,NaN NaN,NaN NaN,-5
+M 30,-5
+C 49,-5 65,10 65,30
+C 65,49 48,65 30,65
+C 12,65 -5,49 -5,30
+C -5,11 11,-5 30,-5
 Z
 '
 transform='translate(9261,13472) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_d7044c2f06f5ead8)'
+clip-path='url(#clip_c80001ca8a9e8c0f)'
 />
 <!-- " -->
 <clipPath id='clip_5c3dabf4099e6660'>
@@ -12008,7 +12008,7 @@ L 239,500
 L 239,690
 Z
 '
-transform='translate(NaN,13472) scale(1,-1)'
+transform='translate(9364,13472) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_5c3dabf4099e6660)'
 />
@@ -12043,7 +12043,7 @@ L 159,-0
 L 159,660
 Z
 '
-transform='translate(NaN,13472) scale(1,-1)'
+transform='translate(9707,13472) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_8f9ee3e3e979367b)'
 />
@@ -12074,7 +12074,7 @@ L 241,360
 L -1,360
 Z
 '
-transform='translate(NaN,13472) scale(1,-1)'
+transform='translate(10050,13472) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_a12e692d9b78bc22)'
 />
@@ -12107,7 +12107,7 @@ L 119,-30
 L 119,690
 Z
 '
-transform='translate(NaN,13472) scale(1,-1)'
+transform='translate(10393,13472) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_67f1f51c0b765215)'
 />
@@ -12144,7 +12144,7 @@ L -1,-30
 C 89,217 153,452 239,690
 Z
 '
-transform='translate(NaN,13472) scale(1,-1)'
+transform='translate(10736,13472) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_59f8d34ef8b5ac5e)'
 />
@@ -12171,26 +12171,26 @@ C 57,129 84,57 149,60
 C 214,63 239,144 239,210
 Z
 '
-transform='translate(NaN,13472) scale(1,-1)'
+transform='translate(11079,13472) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_eef530bd6ec296ef)'
 />
 <!-- ' -->
-<clipPath id='clip_a5cf268bab44a063'>
-<rect x='-60' y='-360' width='NaN' height='1070'/>
+<clipPath id='clip_2861bbb15b4326a5'>
+<rect x='-60' y='-360' width='403' height='1070'/>
 </clipPath>
 <path
 d='
-M NaN,630
-L NaN,630
-C NaN,NaN NaN,NaN NaN,500
-L NaN,500
-C NaN,NaN NaN,NaN NaN,630
+M -1,690
+L 61,690
+L 61,500
+L -1,500
+L -1,690
 Z
 '
-transform='translate(NaN,13472) scale(1,-1)'
+transform='translate(11422,13472) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_a5cf268bab44a063)'
+clip-path='url(#clip_2861bbb15b4326a5)'
 />
 <!-- ( -->
 <clipPath id='clip_2e3c7bfa7efdd770'>
@@ -12207,7 +12207,7 @@ C 113,30 -8,167 -1,331
 C 2,420 54,578 301,690
 Z
 '
-transform='translate(NaN,13472) scale(1,-1)'
+transform='translate(11525,13472) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_2e3c7bfa7efdd770)'
 />
@@ -12226,7 +12226,7 @@ C 124,78 236,185 239,330
 C 240,443 164,578 -1,630
 Z
 '
-transform='translate(NaN,13472) scale(1,-1)'
+transform='translate(11868,13472) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_ac6b485cfef9590d)'
 />
@@ -12255,7 +12255,7 @@ L 119,120
 L 119,500
 Z
 '
-transform='translate(NaN,13472) scale(1,-1)'
+transform='translate(12211,13472) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_f5594a848e35692e)'
 />
@@ -12278,7 +12278,7 @@ L 119,150
 L 119,510
 Z
 '
-transform='translate(NaN,13472) scale(1,-1)'
+transform='translate(12554,13472) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_60c08d53cd2c1f37)'
 />
@@ -12295,7 +12295,7 @@ L -1,-40
 C 101,2 203,19 301,60
 Z
 '
-transform='translate(NaN,13472) scale(1,-1)'
+transform='translate(12897,13472) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_a8f9d3e93d0e0a56)'
 />
@@ -12312,26 +12312,26 @@ L 301,300
 L -1,300
 Z
 '
-transform='translate(NaN,13472) scale(1,-1)'
+transform='translate(13240,13472) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_fe8e6de976001199)'
 />
 <!-- . -->
-<clipPath id='clip_472a03a28cc64134'>
-<rect x='-60' y='-360' width='NaN' height='1070'/>
+<clipPath id='clip_0858586df518c73b'>
+<rect x='-60' y='-360' width='403' height='1070'/>
 </clipPath>
 <path
 d='
-M NaN,-5
-C NaN,NaN NaN,NaN NaN,30
-C NaN,NaN NaN,NaN NaN,65
-C NaN,NaN NaN,NaN NaN,30
-C NaN,NaN NaN,NaN NaN,-5
+M 30,-5
+C 49,-5 65,10 65,30
+C 65,49 48,65 30,65
+C 12,65 -5,49 -5,30
+C -5,11 11,-5 30,-5
 Z
 '
-transform='translate(NaN,13472) scale(1,-1)'
+transform='translate(13583,13472) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_472a03a28cc64134)'
+clip-path='url(#clip_0858586df518c73b)'
 />
 <!-- / -->
 <clipPath id='clip_a19eebd83dc2692c'>
@@ -12346,7 +12346,7 @@ L 301,690
 C 211,443 147,208 61,-30
 Z
 '
-transform='translate(NaN,13472) scale(1,-1)'
+transform='translate(13686,13472) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_a19eebd83dc2692c)'
 />
@@ -12354,348 +12354,724 @@ clip-path='url(#clip_a19eebd83dc2692c)'
 <g id='Dactyl Stroked6'>
 <text x='0' y='13772' font-size='200'>Dactyl Stroked</text>
 <!-- a -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_27ca4743e80950d6'>
+<rect x='-120' y='-420' width='711' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 301,422
+L 305,422
+L 305,58
+L 301,58
+L 301,422
+Z
+M 341,422
+L 345,422
+L 345,58
+L 341,58
+L 341,422
+Z
+M 381,422
+L 385,422
+L 385,58
+L 381,58
+L 381,422
+Z
+M 421,422
+L 425,422
+L 425,58
+L 421,58
+L 421,422
+Z
+M 407,395
+L 402,395
+C 356,449 279,486 203,477
+C 96,465 -2,365 5,240
+C 11,135 107,23 203,3
+C 278,-14 366,23 402,85
+L 407,85
+C 361,27 278,-11 202,-1
+C 88,12 -6,123 1,240
+C 7,344 102,460 202,481
+C 288,500 374,460 407,395
+Z
+M 375,370
+L 371,370
+C 339,421 270,449 208,438
+C 124,423 45,333 45,240
+C 45,152 118,59 208,42
+C 276,29 341,57 371,110
+L 375,110
+C 353,49 273,22 207,38
+C 117,61 40,141 41,240
+C 42,332 123,425 207,442
+C 279,456 349,426 375,370
+Z
+M 344,346
+L 340,346
+C 315,385 261,406 213,398
+C 145,387 85,309 85,240
+C 86,171 148,96 213,82
+C 260,72 318,93 340,134
+L 344,134
+C 318,90 262,69 213,78
+C 144,91 80,166 81,240
+C 81,312 146,390 213,402
+C 263,411 320,390 344,346
+Z
+M 313,321
+L 309,321
+C 286,344 253,360 219,359
+C 167,356 122,294 125,240
+C 128,189 170,132 219,121
+C 256,113 295,128 309,159
+L 313,159
+C 293,130 254,112 218,117
+C 166,125 120,186 121,240
+C 121,293 168,352 218,363
+C 254,370 296,352 313,321
 Z
 '
 transform='translate(0,14742) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_27ca4743e80950d6)'
 />
 <!-- b -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_acf8c33b3bdb437a'>
+<rect x='-120' y='-420' width='705' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 1,662
+L 5,662
+L 5,58
+L 1,58
+L 1,662
+Z
+M 41,662
+L 45,662
+L 45,58
+L 41,58
+L 41,662
+Z
+M 81,662
+L 85,662
+L 85,58
+L 81,58
+L 81,662
+Z
+M 121,662
+L 125,662
+L 125,58
+L 121,58
+L 121,662
+Z
+M 13,85
+L 18,85
+C 53,20 142,-13 217,3
+C 318,23 412,137 415,240
+C 418,346 320,463 217,477
+C 144,488 61,455 18,395
+L 13,395
+C 49,464 141,498 218,481
+C 322,460 415,344 419,240
+C 423,133 322,14 218,-1
+C 142,-13 54,21 13,85
+Z
+M 45,110
+L 49,110
+C 78,56 150,30 212,42
+C 296,59 373,152 375,240
+C 377,328 299,426 212,438
+C 152,446 86,417 49,370
+L 45,370
+C 74,428 149,455 213,442
+C 297,425 376,327 379,240
+C 382,149 303,52 213,38
+C 150,28 80,58 45,110
+Z
+M 76,134
+L 80,134
+C 103,91 160,72 207,82
+C 273,96 334,171 335,240
+C 336,309 275,388 207,398
+C 161,405 103,385 80,346
+L 76,346
+C 97,390 157,412 207,402
+C 276,388 337,309 339,240
+C 341,167 276,89 207,78
+C 158,70 104,93 76,134
+Z
+M 107,159
+L 111,159
+C 127,128 167,114 201,121
+C 251,132 294,189 295,240
+C 295,292 250,350 201,359
+C 168,364 128,347 111,321
+L 107,321
+C 122,354 165,370 202,363
+C 252,352 298,293 299,240
+C 300,186 252,125 202,117
+C 165,112 126,130 107,159
 Z
 '
 transform='translate(466,14742) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_acf8c33b3bdb437a)'
 />
 <!-- c -->
-<clipPath id='clip_7d5903135c3c256e'>
+<clipPath id='clip_8be348938839528d'>
 <rect x='-120' y='-420' width='693' height='1190'/>
 </clipPath>
 <path
 d='
 M 407,395
 L 402,395
-C 357,456 279,490 203,477
-C 101,460 5,351 5,240
-C 5,125 92,23 204,3
-L 204,-1
-C 96,39 7,122 1,240
-C -5,352 86,462 202,481
-C 290,496 369,463 407,395
+C 356,449 279,486 203,477
+C 96,465 -2,365 5,240
+C 11,135 107,23 203,3
+C 278,-14 366,23 402,85
+L 407,85
+C 361,27 278,-11 202,-1
+C 88,12 -6,123 1,240
+C 7,344 102,460 202,481
+C 288,500 374,460 407,395
 Z
 M 375,370
 L 371,370
-C 334,422 271,449 208,438
-C 125,423 45,332 45,240
-C 45,142 116,55 210,42
-L 210,38
-C 112,68 46,138 41,240
-C 35,340 109,429 207,442
-C 278,451 336,428 375,370
+C 339,421 270,449 208,438
+C 124,423 45,333 45,240
+C 45,152 118,59 208,42
+C 276,29 341,57 371,110
+L 375,110
+C 353,49 273,22 207,38
+C 117,61 40,141 41,240
+C 42,332 123,425 207,442
+C 279,456 349,426 375,370
 Z
 M 344,346
 L 340,346
-C 312,384 261,405 213,398
-C 145,388 84,314 85,240
-C 86,161 143,93 215,82
-L 215,78
-C 147,104 86,160 81,240
-C 76,315 138,390 213,402
-C 264,410 317,393 344,346
+C 315,385 261,406 213,398
+C 145,387 85,309 85,240
+C 86,171 148,96 213,82
+C 260,72 318,93 340,134
+L 344,134
+C 318,90 262,69 213,78
+C 144,91 80,166 81,240
+C 81,312 146,390 213,402
+C 263,411 320,390 344,346
 Z
 M 313,321
 L 309,321
-C 291,352 254,364 219,359
-C 170,350 123,300 125,240
-C 127,187 167,130 221,121
-L 221,117
-C 164,136 123,177 121,240
-C 119,304 167,354 218,363
-C 255,368 294,353 313,321
+C 286,344 253,360 219,359
+C 167,356 122,294 125,240
+C 128,189 170,132 219,121
+C 256,113 295,128 309,159
+L 313,159
+C 293,130 254,112 218,117
+C 166,125 120,186 121,240
+C 121,293 168,352 218,363
+C 254,370 296,352 313,321
 Z
 '
 transform='translate(932,14742) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_7d5903135c3c256e)'
+clip-path='url(#clip_8be348938839528d)'
 />
 <!-- d -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_2d105c20e75372c4'>
+<rect x='-120' y='-420' width='711' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 301,662
+L 305,662
+L 305,58
+L 301,58
+L 301,662
+Z
+M 341,662
+L 345,662
+L 345,58
+L 341,58
+L 341,662
+Z
+M 381,662
+L 385,662
+L 385,58
+L 381,58
+L 381,662
+Z
+M 421,662
+L 425,662
+L 425,58
+L 421,58
+L 421,662
+Z
+M 407,395
+L 402,395
+C 356,449 279,486 203,477
+C 96,465 -2,365 5,240
+C 11,135 107,23 203,3
+C 278,-14 366,23 402,85
+L 407,85
+C 361,27 278,-11 202,-1
+C 88,12 -6,123 1,240
+C 7,344 102,460 202,481
+C 288,500 374,460 407,395
+Z
+M 375,370
+L 371,370
+C 339,421 270,449 208,438
+C 124,423 45,333 45,240
+C 45,152 118,59 208,42
+C 276,29 341,57 371,110
+L 375,110
+C 353,49 273,22 207,38
+C 117,61 40,141 41,240
+C 42,332 123,425 207,442
+C 279,456 349,426 375,370
+Z
+M 344,346
+L 340,346
+C 315,385 261,406 213,398
+C 145,387 85,309 85,240
+C 86,171 148,96 213,82
+C 260,72 318,93 340,134
+L 344,134
+C 318,90 262,69 213,78
+C 144,91 80,166 81,240
+C 81,312 146,390 213,402
+C 263,411 320,390 344,346
+Z
+M 313,321
+L 309,321
+C 286,344 253,360 219,359
+C 167,356 122,294 125,240
+C 128,189 170,132 219,121
+C 256,113 295,128 309,159
+L 313,159
+C 293,130 254,112 218,117
+C 166,125 120,186 121,240
+C 121,293 168,352 218,363
+C 254,370 296,352 313,321
 Z
 '
 transform='translate(1398,14742) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_2d105c20e75372c4)'
 />
 <!-- e -->
-<clipPath id='clip_2d51ae2738661f8c'>
-<rect x='-120' y='-420' width='706' height='1190'/>
+<clipPath id='clip_1dcda4342c4d6231'>
+<rect x='-120' y='-420' width='693' height='1190'/>
 </clipPath>
 <path
 d='
 M 58,178
 L 58,182
-L 416,182
-C 364,296 294,395 211,478
-L 210,479
-C 146,393 78,313 5,241
-L 4,240
-L 211,2
-L 211,-2
-L 2,240
-L 1,241
-C -96,338 14,543 210,481
-L 211,482
-C 391,662 419,190 420,178
+L 404,182
+C 421,305 351,472 206,478
+C 92,483 -6,344 5,239
+C 16,143 107,24 202,3
+C 277,-14 361,25 403,85
+L 407,85
+C 369,20 276,-16 202,-1
+C 97,19 6,135 1,239
+C -5,348 93,488 206,482
+C 329,475 389,308 406,178
 L 58,178
 Z
 M 58,218
 L 58,222
-L 376,222
-C 329,304 273,376 211,438
-L 210,439
-C 159,365 104,299 45,241
-L 44,240
-L 212,42
-L 212,38
-L 42,240
-L 41,241
-C -25,307 26,455 210,441
-L 211,442
-C 342,573 379,229 380,218
+L 372,222
+C 387,320 310,439 209,438
+C 111,437 40,330 45,240
+C 50,156 125,56 208,42
+C 272,31 339,56 371,110
+L 375,110
+C 344,56 271,26 207,38
+C 120,55 45,152 41,240
+C 36,334 116,444 209,442
+C 304,440 355,313 375,218
 L 58,218
 Z
 M 58,258
 L 58,262
-L 359,243
-L 359,239
-C -6555,-22492 -37302,-2295 209,400
-L 210,400
-C 21435,1921 -482,-35150 83,239
-L 83,240
-L 212,78
-L 208,78
-L 62,238
-L 62,242
-L 83,243
-C 178,248 200,378 208,421
-L 212,421
-L 213,400
-C 216,341 246,289 278,244
+L 341,262
+C 341,331 280,397 212,398
+C 140,399 80,316 85,240
+C 90,170 144,93 214,82
+C 264,73 313,98 340,134
+L 344,134
+C 319,92 261,69 213,78
+C 143,90 82,171 81,240
+C 80,311 141,400 211,402
+C 283,404 333,324 344,258
 L 58,258
 Z
 M 58,298
 L 58,302
-L 359,243
-L 359,239
-C 4615,-16658 -32486,-396 209,360
-L 210,360
-C 2735,-434 -18,-1689 123,239
-L 123,240
-L 213,118
-L 209,118
-L 62,238
-L 62,242
-L 123,243
-C 214,244 209,388 208,421
-L 212,421
-L 213,360
-C 214,288 301,256 336,243
+L 309,302
+C 292,337 252,361 215,358
+C 161,354 123,296 125,241
+C 127,190 168,131 219,121
+C 255,115 292,130 308,159
+L 313,159
+C 293,128 256,113 219,117
+C 161,125 119,183 121,241
+C 123,293 165,354 214,362
+C 257,369 300,341 314,298
 L 58,298
 Z
 '
 transform='translate(1864,14742) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_2d51ae2738661f8c)'
+clip-path='url(#clip_1dcda4342c4d6231)'
 />
 <!-- f -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_0b919719ac360096'>
+<rect x='-120' y='-420' width='624' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 169,58
+L 165,58
+L 165,540
+C 165,588 218,615 241,626
+L 241,622
+C 202,621 169,586 169,540
+L 169,58
+Z
+M 129,58
+L 125,58
+L 125,540
+C 125,620 238,640 273,646
+L 269,646
+C 236,639 129,615 129,540
+L 129,58
+Z
+M 89,58
+L 85,58
+L 85,540
+C 85,656 260,666 306,670
+L 301,670
+C 260,666 89,650 89,540
+L 89,58
+Z
+M 49,58
+L 45,58
+L 45,540
+C 45,692 282,693 338,694
+L 334,694
+C 195,759 49,666 49,540
+L 49,58
+Z
+M 58,358
+L 58,362
+L 212,362
+L 212,358
+L 58,358
+Z
+M 58,398
+L 58,402
+L 212,402
+L 212,398
+L 58,398
+Z
+M 58,438
+L 58,442
+L 212,442
+L 212,438
+L 58,438
+Z
+M 58,478
+L 58,482
+L 212,482
+L 212,478
+L 58,478
 Z
 '
 transform='translate(2330,14742) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_0b919719ac360096)'
 />
 <!-- g -->
-<clipPath id='clip_d97b27cf3319a2d7'>
-<rect x='-120' y='-420' width='695' height='1190'/>
+<clipPath id='clip_da605a94a0d0811c'>
+<rect x='-120' y='-420' width='711' height='1190'/>
 </clipPath>
 <path
 d='
 M 301,422
 L 305,422
-C 588,136 426,-182 211,-182
-L 208,-182
-L 208,-178
-L 211,-178
-C 543,-178 321,370 301,422
+L 305,-90
+C 305,-138 264,-176 214,-182
+C 169,-188 125,-169 94,-136
+L 94,-132
+C 123,-166 169,-185 214,-178
+C 262,-171 301,-135 301,-90
+L 301,422
 Z
 M 341,422
 L 345,422
-C 607,87 431,-222 211,-222
-L 208,-222
-L 208,-218
-L 211,-218
-C 553,-218 362,358 341,422
+L 345,-90
+C 345,-157 288,-214 211,-222
+C 157,-228 100,-211 69,-167
+L 69,-163
+C 101,-208 158,-226 211,-218
+C 283,-208 341,-157 341,-90
+L 341,422
 Z
-M 150,293
-C 154,293 157,296 157,300
-C 157,304 154,307 150,307
-C 146,307 143,304 143,300
-C 143,297 146,293 150,293
+M 381,422
+L 385,422
+L 385,-90
+C 385,-182 307,-253 208,-262
+C 147,-268 81,-250 43,-197
+L 43,-193
+C 77,-244 142,-267 208,-258
+C 290,-247 381,-187 381,-90
+L 381,422
 Z
-M 150,293
-C 154,293 157,296 157,300
-C 157,304 154,307 150,307
-C 146,307 143,304 143,300
-C 143,297 146,293 150,293
+M 421,422
+L 425,422
+L 425,-90
+C 425,-219 305,-293 205,-302
+C 132,-308 59,-286 18,-228
+L 18,-224
+C 56,-285 131,-308 205,-298
+C 322,-283 421,-199 421,-90
+L 421,422
 Z
-M 409,392
-L 405,392
-L 210,478
-C 104,449 10,360 5,240
-C 0,118 94,19 212,2
-L 212,-2
-C 106,30 7,116 1,240
-C -5,360 87,464 210,482
-L 409,392
+M 407,395
+L 402,395
+C 356,449 279,486 203,477
+C 96,465 -2,365 5,240
+C 11,135 107,23 203,3
+C 278,-14 366,23 402,85
+L 407,85
+C 361,27 278,-11 202,-1
+C 88,12 -6,123 1,240
+C 7,344 102,460 202,481
+C 288,500 374,460 407,395
 Z
-M 376,369
-L 372,369
-L 210,438
-C 124,413 48,338 45,240
-C 42,141 116,59 212,42
-L 212,38
-C 122,60 43,138 41,240
-C 38,338 110,423 210,442
-L 376,369
+M 375,370
+L 371,370
+C 339,421 270,449 208,438
+C 124,423 45,333 45,240
+C 45,152 118,59 208,42
+C 276,29 341,57 371,110
+L 375,110
+C 353,49 273,22 207,38
+C 117,61 40,141 41,240
+C 42,332 123,425 207,442
+C 279,456 349,426 375,370
 Z
-M 339,351
-L 343,351
-L 210,381
-C 143,366 92,310 85,240
-C 77,159 132,84 212,59
-L 208,59
-C 137,89 82,158 81,240
-C 80,321 132,392 208,421
-L 212,421
-L 339,351
+M 344,346
+L 340,346
+C 315,385 261,406 213,398
+C 145,387 85,309 85,240
+C 86,171 148,96 213,82
+C 260,72 318,93 340,134
+L 344,134
+C 318,90 262,69 213,78
+C 144,91 80,166 81,240
+C 81,312 146,390 213,402
+C 263,411 320,390 344,346
 Z
-M 306,328
-L 310,328
-L 210,301
-C 170,299 140,273 125,240
-C 95,174 145,85 212,59
-L 208,59
-C 153,104 121,170 121,240
-C 121,310 153,377 208,421
-L 212,421
-L 306,328
+M 313,321
+L 309,321
+C 286,344 253,360 219,359
+C 167,356 122,294 125,240
+C 128,189 170,132 219,121
+C 256,113 295,128 309,159
+L 313,159
+C 293,130 254,112 218,117
+C 166,125 120,186 121,240
+C 121,293 168,352 218,363
+C 254,370 296,352 313,321
 Z
 '
 transform='translate(2721,14742) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_d97b27cf3319a2d7)'
+clip-path='url(#clip_da605a94a0d0811c)'
 />
 <!-- h -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_f3ee31586927f200'>
+<rect x='-120' y='-420' width='711' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 1,662
+L 5,662
+L 5,58
+L 1,58
+L 1,662
+Z
+M 41,662
+L 45,662
+L 45,58
+L 41,58
+L 41,662
+Z
+M 81,662
+L 85,662
+L 85,58
+L 81,58
+L 81,662
+Z
+M 121,662
+L 125,662
+L 125,58
+L 121,58
+L 121,662
+Z
+M 102,315
+L 98,315
+C 122,352 166,370 209,362
+C 266,351 305,298 305,240
+L 305,58
+L 301,58
+L 301,240
+C 301,292 267,345 209,358
+C 167,367 123,352 102,315
+Z
+M 70,344
+L 70,348
+C 100,392 155,412 210,402
+C 286,388 345,321 345,240
+L 345,58
+L 341,58
+L 341,240
+C 341,322 277,383 210,398
+C 155,410 96,392 70,344
+Z
+M 42,372
+L 42,376
+C 78,429 144,453 210,442
+C 307,426 385,344 385,240
+L 385,58
+L 381,58
+L 381,240
+C 381,335 310,421 210,438
+C 144,449 76,428 42,372
+Z
+M 14,401
+L 14,405
+C 54,467 132,495 211,482
+C 325,463 425,368 425,240
+L 425,58
+L 421,58
+L 421,240
+C 421,362 328,458 211,478
+C 133,491 50,470 14,401
 Z
 '
 transform='translate(3187,14742) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_f3ee31586927f200)'
 />
 <!-- i -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_fce5110c51bd5966'>
+<rect x='-120' y='-420' width='411' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 1,422
+L 5,422
+L 5,58
+L 1,58
+L 1,422
+Z
+M 41,422
+L 45,422
+L 45,58
+L 41,58
+L 41,422
+Z
+M 81,422
+L 85,422
+L 85,58
+L 81,58
+L 81,422
+Z
+M 121,422
+L 125,422
+L 125,58
+L 121,58
+L 121,422
+Z
+M 60,522
+C 90,522 117,549 118,580
+C 118,613 91,638 60,638
+C 30,638 1,613 2,580
+C 3,550 26,522 60,522
+Z
+M -2,580
+C 0,611 26,642 60,642
+C 91,642 121,610 122,580
+C 123,549 93,518 60,518
+C 25,518 -0,547 -2,580
+Z
+M 60,552
+C 75,552 88,565 88,580
+C 88,595 76,608 60,608
+C 45,608 32,596 32,580
+C 32,565 44,552 60,552
+Z
+M 28,580
+C 28,596 42,612 60,612
+C 77,612 92,595 92,580
+C 92,562 77,548 60,548
+C 44,548 28,564 28,580
 Z
 '
 transform='translate(3653,14742) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_fce5110c51bd5966)'
 />
 <!-- j -->
-<clipPath id='clip_ec8f60c158848a75'>
+<clipPath id='clip_084168eebb51aeeb'>
 <rect x='-120' y='-420' width='636' height='1190'/>
 </clipPath>
 <path
 d='
 M 226,422
 L 230,422
-L 186,-187
-L 186,-183
+L 230,-90
+C 230,-129 223,-170 189,-187
+C 159,-200 126,-183 110,-154
+L 114,-154
+C 129,-182 161,-193 187,-183
+C 224,-168 226,-118 226,-90
 L 226,422
 Z
 M 266,422
 L 270,422
-L 201,-224
-L 201,-220
+L 270,-90
+C 270,-144 253,-201 204,-223
+C 159,-244 102,-221 74,-170
+L 78,-170
+C 105,-211 156,-237 203,-220
+C 255,-200 266,-137 266,-90
 L 266,422
 Z
 M 306,422
 L 310,422
-L 217,-260
-L 217,-256
+L 310,-90
+C 310,-144 293,-231 220,-260
+C 155,-286 86,-246 37,-186
+L 41,-186
+C 84,-239 153,-279 218,-257
+C 284,-234 306,-157 306,-90
 L 306,422
 Z
 M 346,422
 L 350,422
-L 233,-297
-L 233,-293
+L 350,-90
+C 350,-168 317,-263 235,-297
+C 157,-330 62,-282 0,-202
+L 4,-202
+C 58,-283 154,-324 234,-293
+C 313,-263 346,-174 346,-90
 L 346,422
 Z
 M 285,522
@@ -12725,305 +13101,887 @@ Z
 '
 transform='translate(3819,14742) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_ec8f60c158848a75)'
+clip-path='url(#clip_084168eebb51aeeb)'
 />
 <!-- k -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_6dd7722d237d0157'>
+<rect x='-120' y='-420' width='612' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 1,662
+L 5,662
+L 5,58
+L 1,58
+L 1,662
+Z
+M 41,662
+L 45,662
+L 45,58
+L 41,58
+L 41,662
+Z
+M 81,662
+L 85,662
+L 85,58
+L 81,58
+L 81,662
+Z
+M 121,662
+L 125,662
+L 125,58
+L 121,58
+L 121,662
+Z
+M 251,469
+L 251,465
+L 22,285
+L 22,289
+L 251,469
+Z
+M 276,438
+L 276,434
+L 47,254
+L 47,258
+L 276,438
+Z
+M 301,406
+L 301,402
+L 72,222
+L 72,226
+L 301,406
+Z
+M 326,375
+L 326,371
+L 97,191
+L 97,195
+L 326,375
+Z
+M 22,191
+L 22,195
+L 251,15
+L 251,11
+L 22,191
+Z
+M 47,222
+L 47,226
+L 276,46
+L 276,42
+L 47,222
+Z
+M 72,254
+L 72,258
+L 301,78
+L 301,74
+L 72,254
+Z
+M 97,285
+L 97,289
+L 326,109
+L 326,105
+L 97,285
 Z
 '
 transform='translate(4210,14742) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_6dd7722d237d0157)'
 />
 <!-- l -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_83ba05ff0a37a123'>
+<rect x='-120' y='-420' width='509' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 1,662
+L 5,662
+L 5,240
+C 5,106 156,34 223,3
+L 223,-1
+C 108,-7 1,94 1,240
+L 1,662
+Z
+M 41,662
+L 45,662
+L 45,240
+C 45,132 162,70 215,42
+L 215,38
+C 121,43 41,128 41,240
+L 41,662
+Z
+M 81,662
+L 85,662
+L 85,240
+C 85,158 167,106 208,82
+L 208,78
+C 136,90 81,156 81,240
+L 81,662
+Z
+M 121,662
+L 125,662
+L 125,240
+C 125,184 172,143 200,121
+L 200,117
+C 152,138 121,187 121,240
+L 121,662
 Z
 '
 transform='translate(4601,14742) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_83ba05ff0a37a123)'
 />
 <!-- m -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_ffb0edb5ebbc1f66'>
+<rect x='-120' y='-420' width='861' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 1,422
+L 5,422
+L 5,58
+L 1,58
+L 1,422
+Z
+M 41,422
+L 45,422
+L 45,58
+L 41,58
+L 41,422
+Z
+M 81,422
+L 85,422
+L 85,58
+L 81,58
+L 81,422
+Z
+M 121,422
+L 125,422
+L 125,58
+L 121,58
+L 121,422
+Z
+M 116,338
+L 112,338
+C 125,366 158,378 185,368
+C 234,350 230,284 230,240
+L 230,58
+L 226,58
+L 226,240
+C 226,280 228,345 184,365
+C 158,376 129,362 116,338
+Z
+M 78,351
+L 74,351
+C 98,405 157,425 203,404
+C 267,375 270,289 270,240
+L 270,58
+L 266,58
+L 266,240
+C 266,295 258,372 201,400
+C 155,423 102,394 78,351
+Z
+M 40,365
+L 36,365
+C 76,426 151,468 221,440
+C 302,408 310,305 310,240
+L 310,58
+L 306,58
+L 306,240
+C 306,312 289,404 219,436
+C 156,465 85,424 40,365
+Z
+M 3,378
+L -1,378
+C 56,454 152,508 239,475
+C 332,440 350,328 350,240
+L 350,58
+L 346,58
+L 346,240
+C 346,333 318,432 237,472
+C 163,509 62,476 3,378
+Z
+M 343,309
+L 339,309
+C 340,346 371,370 403,365
+C 459,355 455,272 455,240
+L 455,58
+L 451,58
+L 451,240
+C 451,282 450,348 402,361
+C 373,369 341,345 343,309
+Z
+M 304,302
+L 300,302
+C 303,369 360,414 416,403
+C 491,387 495,289 495,240
+L 495,58
+L 491,58
+L 491,240
+C 491,305 477,381 414,399
+C 359,415 307,359 304,302
+Z
+M 264,294
+L 260,294
+C 283,383 351,452 428,441
+C 515,428 535,319 535,240
+L 535,58
+L 531,58
+L 531,240
+C 531,332 497,413 426,437
+C 347,464 261,398 264,294
+Z
+M 225,287
+L 221,287
+C 245,388 328,498 440,479
+C 545,461 575,335 575,240
+L 575,58
+L 571,58
+L 571,240
+C 571,318 541,446 438,475
+C 337,504 244,410 225,287
 Z
 '
 transform='translate(4917,14742) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_ffb0edb5ebbc1f66)'
 />
 <!-- n -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
-</clipPath>
-<path
-d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
-Z
-'
-transform='translate(5533,14742) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
-/>
-<!-- o -->
-<clipPath id='clip_33e883b107810d2e'>
+<clipPath id='clip_3cf0653ae5658357'>
 <rect x='-120' y='-420' width='711' height='1190'/>
 </clipPath>
 <path
 d='
-M 115,241
-C 148,281 157,362 209,362
-C 260,362 305,293 305,240
-C 305,187 259,140 211,118
-C 161,95 42,123 58,181
-C 66,209 95,221 115,241
+M 1,422
+L 5,422
+L 5,58
+L 1,58
+L 1,422
 Z
-M 62,179
-C 65,134 163,111 209,122
-C 258,133 295,207 301,240
-C 309,286 255,377 211,358
-C 162,338 152,279 119,239
-C 99,215 75,205 62,179
+M 41,422
+L 45,422
+L 45,58
+L 41,58
+L 41,422
 Z
-M 75,241
-C 124,302 133,402 209,402
-C 281,402 343,312 345,240
-C 347,168 285,85 211,78
-C 144,72 19,162 58,221
-C 63,229 69,234 75,241
+M 81,422
+L 85,422
+L 85,58
+L 81,58
+L 81,422
 Z
-M 62,219
-C 80,155 146,78 209,82
-C 276,87 332,175 341,240
-C 351,312 273,394 211,398
-C 149,402 130,278 79,239
-C 71,233 66,228 62,219
+M 121,422
+L 125,422
+L 125,58
+L 121,58
+L 121,422
 Z
-M 38,238
-C 34,315 127,441 211,442
-C 287,442 411,316 385,241
-C 350,141 297,26 208,39
-C 125,51 118,307 61,258
-C 53,251 49,242 38,238
+M 102,315
+L 98,315
+C 122,352 166,370 209,362
+C 266,351 305,298 305,240
+L 305,58
+L 301,58
+L 301,240
+C 301,292 267,345 209,358
+C 167,367 123,352 102,315
 Z
-M 59,262
-C 163,249 69,47 212,41
-C 298,38 371,117 381,239
-C 389,331 291,472 209,438
-C 118,402 -33,222 36,242
-C 47,245 46,263 59,262
+M 70,344
+L 70,348
+C 100,392 155,412 210,402
+C 286,388 345,321 345,240
+L 345,58
+L 341,58
+L 341,240
+C 341,322 277,383 210,398
+C 155,410 96,392 70,344
 Z
-M -2,239
-C -26,322 107,481 211,482
-C 313,482 424,341 425,241
-C 426,136 313,-13 208,-1
-C 101,11 147,365 61,298
-C 38,280 29,236 -2,239
+M 42,372
+L 42,376
+C 78,429 144,453 210,442
+C 307,426 385,344 385,240
+L 385,58
+L 381,58
+L 381,240
+C 381,335 310,421 210,438
+C 144,449 76,428 42,372
 Z
-M 59,302
-C 214,280 84,16 212,1
-C 338,-13 399,144 421,239
-C 451,366 322,435 209,478
-C 65,533 -75,216 -4,241
-C 34,256 20,309 59,302
+M 14,401
+L 14,405
+C 54,467 132,495 211,482
+C 325,463 425,368 425,240
+L 425,58
+L 421,58
+L 421,240
+C 421,362 328,458 211,478
+C 133,491 50,470 14,401
+Z
+'
+transform='translate(5533,14742) scale(1,-1)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_3cf0653ae5658357)'
+/>
+<!-- o -->
+<clipPath id='clip_37e897fde2efafa1'>
+<rect x='-120' y='-420' width='711' height='1190'/>
+</clipPath>
+<path
+d='
+M 115,240
+C 114,280 141,362 210,362
+C 264,362 307,302 305,240
+C 303,172 272,123 210,118
+C 137,112 107,185 115,240
+Z
+M 210,122
+C 264,122 304,183 301,240
+C 298,292 265,352 210,358
+C 147,365 117,295 119,240
+C 122,188 145,122 210,122
+Z
+M 75,240
+C 75,298 111,402 210,402
+C 287,402 347,318 345,240
+C 343,151 273,85 210,78
+C 116,68 69,159 75,240
+Z
+M 210,82
+C 280,82 343,163 341,240
+C 339,308 287,393 210,398
+C 136,403 73,329 79,240
+C 84,173 125,82 210,82
+Z
+M 35,240
+C 32,336 104,442 210,442
+C 304,442 389,340 385,240
+C 381,146 305,43 210,38
+C 103,32 30,145 35,240
+Z
+M 210,42
+C 303,42 384,142 381,240
+C 378,340 299,433 210,438
+C 114,443 35,340 39,240
+C 43,144 103,42 210,42
+Z
+M -5,240
+C -4,371 82,482 210,482
+C 325,482 422,349 425,240
+C 428,123 347,-4 210,-2
+C 86,0 -10,109 -5,240
+Z
+M 210,2
+C 329,2 420,115 421,240
+C 422,396 305,475 210,478
+C 89,481 -1,377 -1,240
+C -1,96 78,2 210,2
 Z
 '
 transform='translate(5999,14742) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_33e883b107810d2e)'
+clip-path='url(#clip_37e897fde2efafa1)'
 />
 <!-- p -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_cc91890d1f485490'>
+<rect x='-120' y='-420' width='705' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 1,422
+L 5,422
+L 5,-242
+L 1,-242
+L 1,422
+Z
+M 41,422
+L 45,422
+L 45,-242
+L 41,-242
+L 41,422
+Z
+M 81,422
+L 85,422
+L 85,-242
+L 81,-242
+L 81,422
+Z
+M 121,422
+L 125,422
+L 125,-242
+L 121,-242
+L 121,422
+Z
+M 13,85
+L 18,85
+C 53,20 142,-13 217,3
+C 318,23 412,137 415,240
+C 418,346 320,463 217,477
+C 144,488 61,455 18,395
+L 13,395
+C 49,464 141,498 218,481
+C 322,460 415,344 419,240
+C 423,133 322,14 218,-1
+C 142,-13 54,21 13,85
+Z
+M 45,110
+L 49,110
+C 78,56 150,30 212,42
+C 296,59 373,152 375,240
+C 377,328 299,426 212,438
+C 152,446 86,417 49,370
+L 45,370
+C 74,428 149,455 213,442
+C 297,425 376,327 379,240
+C 382,149 303,52 213,38
+C 150,28 80,58 45,110
+Z
+M 76,134
+L 80,134
+C 103,91 160,72 207,82
+C 273,96 334,171 335,240
+C 336,309 275,388 207,398
+C 161,405 103,385 80,346
+L 76,346
+C 97,390 157,412 207,402
+C 276,388 337,309 339,240
+C 341,167 276,89 207,78
+C 158,70 104,93 76,134
+Z
+M 107,159
+L 111,159
+C 127,128 167,114 201,121
+C 251,132 294,189 295,240
+C 295,292 250,350 201,359
+C 168,364 128,347 111,321
+L 107,321
+C 122,354 165,370 202,363
+C 252,352 298,293 299,240
+C 300,186 252,125 202,117
+C 165,112 126,130 107,159
 Z
 '
 transform='translate(6465,14742) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_cc91890d1f485490)'
 />
 <!-- q -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_1101542843b5d3cb'>
+<rect x='-120' y='-420' width='711' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 301,422
+L 305,422
+L 305,-242
+L 301,-242
+L 301,422
+Z
+M 341,422
+L 345,422
+L 345,-242
+L 341,-242
+L 341,422
+Z
+M 381,422
+L 385,422
+L 385,-242
+L 381,-242
+L 381,422
+Z
+M 421,422
+L 425,422
+L 425,-242
+L 421,-242
+L 421,422
+Z
+M 407,395
+L 402,395
+C 356,449 279,486 203,477
+C 96,465 -2,365 5,240
+C 11,135 107,23 203,3
+C 278,-14 366,23 402,85
+L 407,85
+C 361,27 278,-11 202,-1
+C 88,12 -6,123 1,240
+C 7,344 102,460 202,481
+C 288,500 374,460 407,395
+Z
+M 375,370
+L 371,370
+C 339,421 270,449 208,438
+C 124,423 45,333 45,240
+C 45,152 118,59 208,42
+C 276,29 341,57 371,110
+L 375,110
+C 353,49 273,22 207,38
+C 117,61 40,141 41,240
+C 42,332 123,425 207,442
+C 279,456 349,426 375,370
+Z
+M 344,346
+L 340,346
+C 315,385 261,406 213,398
+C 145,387 85,309 85,240
+C 86,171 148,96 213,82
+C 260,72 318,93 340,134
+L 344,134
+C 318,90 262,69 213,78
+C 144,91 80,166 81,240
+C 81,312 146,390 213,402
+C 263,411 320,390 344,346
+Z
+M 313,321
+L 309,321
+C 286,344 253,360 219,359
+C 167,356 122,294 125,240
+C 128,189 170,132 219,121
+C 256,113 295,128 309,159
+L 313,159
+C 293,130 254,112 218,117
+C 166,125 120,186 121,240
+C 121,293 168,352 218,363
+C 254,370 296,352 313,321
 Z
 '
 transform='translate(6931,14742) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_1101542843b5d3cb)'
 />
 <!-- r -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_306da02d65da3d26'>
+<rect x='-120' y='-420' width='604' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 1,422
+L 5,422
+L 5,58
+L 1,58
+L 1,422
+Z
+M 41,422
+L 45,422
+L 45,58
+L 41,58
+L 41,422
+Z
+M 81,422
+L 85,422
+L 85,58
+L 81,58
+L 81,422
+Z
+M 121,422
+L 125,422
+L 125,58
+L 121,58
+L 121,422
+Z
+M 112,330
+L 108,330
+C 118,349 138,362 160,362
+C 181,362 201,349 212,330
+L 208,330
+C 197,347 179,358 160,358
+C 140,358 122,347 112,330
+Z
+M 77,349
+L 73,349
+C 91,382 125,402 160,402
+C 196,402 229,380 247,349
+L 243,349
+C 225,379 193,398 160,398
+C 125,398 94,378 77,349
+Z
+M 42,367
+L 38,367
+C 64,414 110,442 160,442
+C 211,442 256,412 282,367
+L 278,367
+C 253,412 207,438 160,438
+C 111,438 66,410 42,367
+Z
+M 6,386
+L 2,386
+C 36,445 96,482 160,482
+C 226,482 284,443 318,386
+L 314,386
+C 281,443 222,478 160,478
+C 96,478 38,442 6,386
 Z
 '
 transform='translate(7397,14742) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_306da02d65da3d26)'
 />
 <!-- s -->
-<clipPath id='clip_ab54418b2372e320'>
-<rect x='-120' y='-420' width='695' height='1190'/>
+<clipPath id='clip_588b3e0d56384939'>
+<rect x='-120' y='-420' width='707' height='1190'/>
 </clipPath>
 <path
 d='
-M 409,392
-L 405,392
-L 210,478
-C 102,464 -9,382 9,279
-C 24,192 125,154 210,182
-C 242,205 298,198 309,159
-C 322,112 243,76 208,118
-L 208,122
-C 240,114 305,115 305,158
-C 304,197 243,191 210,178
-C 129,119 21,180 5,278
-C -13,389 90,499 210,482
-L 409,392
+M 396,410
+L 396,406
+C 351,455 284,481 216,478
+C 121,472 -19,384 9,280
+C 26,212 134,205 211,182
+C 247,171 289,190 309,160
+C 328,129 249,105 216,118
+C 173,134 128,136 92,166
+L 92,170
+C 128,135 174,121 217,122
+C 248,122 307,128 304,159
+C 302,191 242,189 212,178
+C 144,153 17,204 5,279
+C -10,364 117,462 217,482
+C 282,494 359,460 396,410
 Z
-M 376,369
-L 372,369
-L 210,438
-C 124,446 30,375 46,294
-C 59,228 141,194 210,222
-C 259,258 336,234 346,173
-C 357,107 273,68 208,78
-L 208,82
-C 270,67 352,100 342,172
-C 334,229 263,250 210,218
-C 147,181 58,216 42,292
-C 24,382 116,455 210,442
-L 376,369
+M 372,378
+L 372,374
+C 336,421 274,448 212,438
+C 132,425 29,367 46,294
+C 59,238 151,244 210,222
+C 259,204 321,219 346,174
+C 373,125 266,73 212,78
+C 159,82 101,95 68,134
+L 68,138
+C 102,100 162,76 212,82
+C 264,88 352,122 342,172
+C 333,217 257,221 211,218
+C 146,214 55,232 42,292
+C 27,364 139,430 212,442
+C 268,451 338,423 372,378
 Z
-M 150,293
-C 154,293 157,296 157,300
-C 157,304 154,307 150,307
-C 146,307 143,304 143,300
-C 143,297 146,293 150,293
+M 348,346
+L 348,342
+C 313,382 250,391 207,398
+C 154,407 51,352 84,308
+C 109,273 163,279 209,262
+C 279,236 355,252 384,188
+C 417,113 287,36 207,38
+C 148,40 75,49 44,102
+L 44,106
+C 79,62 153,33 208,42
+C 281,54 391,118 380,186
+C 369,247 270,266 209,258
+C 161,251 91,261 80,306
+C 67,357 155,395 208,402
+C 257,409 317,384 348,346
 Z
-M 150,293
-C 154,293 157,296 157,300
-C 157,304 154,307 150,307
-C 146,307 143,304 143,300
-C 143,297 146,293 150,293
+M 324,314
+L 324,310
+C 294,336 247,348 202,358
+C 170,366 108,350 121,321
+C 134,293 177,312 208,302
+C 286,277 398,283 421,201
+C 449,105 302,8 203,-2
+C 137,-8 69,25 20,70
+L 20,74
+C 57,23 146,-8 203,2
+C 297,20 433,105 417,200
+C 405,276 289,302 209,298
+C 177,296 124,289 117,320
+C 110,351 173,361 203,362
+C 247,364 293,346 324,314
 Z
 '
 transform='translate(7763,14742) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_ab54418b2372e320)'
+clip-path='url(#clip_588b3e0d56384939)'
 />
 <!-- t -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_ecb051d3cfa02a7d'>
+<rect x='-120' y='-420' width='562' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 76,662
+L 80,662
+L 80,180
+C 80,100 125,31 197,4
+C 223,-6 252,-10 276,4
+L 276,-0
+C 251,-14 222,-11 196,-0
+C 129,27 76,107 76,180
+L 76,662
+Z
+M 116,662
+L 120,662
+L 120,180
+C 120,116 156,63 206,43
+C 227,34 249,32 266,43
+L 266,39
+C 249,26 225,29 205,39
+C 157,62 116,123 116,180
+L 116,662
+Z
+M 156,662
+L 160,662
+L 160,180
+C 160,134 180,97 216,81
+C 231,75 245,74 257,81
+L 257,77
+C 244,70 228,71 215,77
+C 180,94 156,140 156,180
+L 156,662
+Z
+M 196,662
+L 200,662
+L 200,180
+C 200,159 204,131 226,120
+C 233,117 241,116 247,120
+L 247,116
+C 240,111 231,113 224,116
+C 203,128 196,156 196,180
+L 196,662
+Z
+M 58,358
+L 58,362
+L 262,362
+L 262,358
+L 58,358
+Z
+M 58,398
+L 58,402
+L 262,402
+L 262,398
+L 58,398
+Z
+M 58,438
+L 58,442
+L 262,442
+L 262,438
+L 58,438
+Z
+M 58,478
+L 58,482
+L 262,482
+L 262,478
+L 58,478
 Z
 '
 transform='translate(8229,14742) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_ecb051d3cfa02a7d)'
 />
 <!-- u -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_acd816fe6cdc36d6'>
+<rect x='-120' y='-420' width='636' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 1,422
+L 5,422
+L 5,240
+C 5,94 133,-18 230,6
+C 340,33 340,222 340,240
+L 340,422
+L 344,422
+L 344,240
+C 344,195 341,50 232,2
+C 104,-54 1,109 1,240
+L 1,422
+Z
+M 41,422
+L 45,422
+L 45,240
+C 45,76 145,24 215,43
+C 301,67 300,187 300,240
+L 300,422
+L 304,422
+L 304,240
+C 304,202 296,72 217,40
+C 128,3 41,116 41,240
+L 41,422
+Z
+M 81,422
+L 85,422
+L 85,240
+C 85,122 145,68 201,81
+C 268,96 260,199 260,240
+L 260,422
+L 264,422
+L 264,240
+C 264,198 265,104 202,77
+C 128,45 81,169 81,240
+L 81,422
+Z
+M 121,422
+L 125,422
+L 125,240
+C 125,207 126,110 187,118
+C 236,124 220,206 220,240
+L 220,422
+L 224,422
+L 224,240
+C 224,204 234,130 188,114
+C 136,96 121,184 121,240
+L 121,422
+Z
+M 226,422
+L 230,422
+L 230,58
+L 226,58
+L 226,422
+Z
+M 266,422
+L 270,422
+L 270,58
+L 266,58
+L 266,422
+Z
+M 306,422
+L 310,422
+L 310,58
+L 306,58
+L 306,422
+Z
+M 346,422
+L 350,422
+L 350,58
+L 346,58
+L 346,422
 Z
 '
 transform='translate(8595,14742) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_acd816fe6cdc36d6)'
 />
 <!-- v -->
-<clipPath id='clip_cb640a8b04d378fe'>
-<rect x='-120' y='-420' width='498' height='1190'/>
+<clipPath id='clip_4a6c8e3460b8638f'>
+<rect x='-120' y='-420' width='701' height='1190'/>
 </clipPath>
 <path
 d='
 M 5,399
 L 9,399
+L 210,-91
+L 411,399
+L 415,399
 L 212,-98
 L 208,-98
 L 5,399
 Z
 M 42,414
 L 46,414
+L 210,13
+L 374,414
+L 378,414
 L 212,6
 L 208,6
 L 42,414
 Z
 M 79,430
 L 83,430
+L 210,117
+L 337,430
+L 341,430
 L 212,110
 L 208,110
 L 79,430
 Z
 M 116,445
 L 120,445
+L 210,221
+L 300,445
+L 304,445
 L 212,214
 L 208,214
 L 116,445
@@ -13031,11 +13989,11 @@ Z
 '
 transform='translate(8986,14742) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_cb640a8b04d378fe)'
+clip-path='url(#clip_4a6c8e3460b8638f)'
 />
 <!-- w -->
-<clipPath id='clip_ead45ac6bfe4adc6'>
-<rect x='-120' y='-420' width='686' height='1190'/>
+<clipPath id='clip_7581eb301ae25ec3'>
+<rect x='-120' y='-420' width='852' height='1190'/>
 </clipPath>
 <path
 d='
@@ -13044,6 +14002,9 @@ L 8,404
 L 173,-135
 L 340,358
 L 230,358
+L 397,-135
+L 562,404
+L 566,404
 L 400,-143
 L 395,-143
 L 224,362
@@ -13057,6 +14018,9 @@ L 46,416
 L 173,-0
 L 300,398
 L 270,398
+L 397,-0
+L 524,416
+L 528,416
 L 400,-9
 L 395,-9
 L 264,402
@@ -13070,6 +14034,9 @@ L 84,428
 L 172,134
 L 261,442
 L 309,442
+L 398,134
+L 486,428
+L 490,428
 L 400,125
 L 395,125
 L 306,438
@@ -13083,6 +14050,9 @@ L 122,440
 L 172,269
 L 221,482
 L 349,482
+L 398,269
+L 448,440
+L 452,440
 L 400,259
 L 395,259
 L 345,478
@@ -13094,127 +14064,226 @@ Z
 '
 transform='translate(9452,14742) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_ead45ac6bfe4adc6)'
+clip-path='url(#clip_7581eb301ae25ec3)'
 />
 <!-- x -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_f8b27b07a99537f5'>
+<rect x='-120' y='-420' width='696' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 14,384
+L 18,384
+L 318,20
+L 314,20
+L 14,384
+Z
+M 45,409
+L 49,409
+L 349,45
+L 345,45
+L 45,409
+Z
+M 76,435
+L 80,435
+L 380,71
+L 376,71
+L 76,435
+Z
+M 106,460
+L 110,460
+L 410,96
+L 406,96
+L 106,460
+Z
+M 314,460
+L 318,460
+L 18,96
+L 14,96
+L 314,460
+Z
+M 345,435
+L 349,435
+L 49,71
+L 45,71
+L 345,435
+Z
+M 376,409
+L 380,409
+L 80,45
+L 76,45
+L 376,409
+Z
+M 406,384
+L 410,384
+L 110,20
+L 106,20
+L 406,384
 Z
 '
 transform='translate(10068,14742) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_f8b27b07a99537f5)'
 />
 <!-- y -->
-<clipPath id='clip_57e911a931f850b9'>
+<clipPath id='clip_f3645ce314c60495'>
 <rect x='-120' y='-420' width='711' height='1190'/>
 </clipPath>
 <path
 d='
 M 1,422
 L 5,422
-L 212,2
-L 212,-2
+L 5,240
+C 5,108 94,2 210,2
+C 309,2 415,91 415,240
+L 415,422
+L 419,422
+L 419,240
+C 419,117 334,-1 210,-2
+C 105,-3 1,89 1,240
 L 1,422
 Z
 M 41,422
 L 45,422
-L 212,42
-L 212,38
+L 45,240
+C 45,125 119,42 210,42
+C 289,42 375,114 375,240
+L 375,422
+L 379,422
+L 379,240
+C 379,135 309,40 210,38
+C 117,37 41,127 41,240
 L 41,422
 Z
 M 81,422
 L 85,422
-L 212,82
-L 212,78
+L 85,240
+C 85,145 143,82 210,82
+C 265,82 335,133 335,240
+L 335,422
+L 339,422
+L 339,240
+C 339,152 283,80 210,78
+C 150,76 81,128 81,240
 L 81,422
 Z
 M 121,422
 L 125,422
-L 212,122
-L 212,118
+L 125,240
+C 125,162 165,122 210,122
+C 243,122 295,151 295,240
+L 295,422
+L 299,422
+L 299,240
+C 299,190 272,120 210,118
+C 165,117 121,161 121,240
 L 121,422
 Z
 M 301,422
 L 305,422
-L 196,-183
-L 196,-179
+L 305,60
+C 305,-48 282,-162 198,-183
+C 163,-192 122,-180 105,-144
+L 109,-144
+C 122,-174 158,-190 197,-179
+C 288,-154 301,-39 301,60
 L 301,422
 Z
 M 341,422
 L 345,422
-L 204,-222
-L 204,-218
+L 345,60
+C 345,-77 298,-193 207,-222
+C 153,-239 91,-216 72,-167
+L 76,-167
+C 95,-211 149,-235 206,-219
+C 313,-187 341,-60 341,60
 L 341,422
 Z
 M 381,422
 L 385,422
-L 213,-262
-L 213,-258
+L 385,60
+C 385,-53 351,-224 215,-261
+C 151,-279 76,-255 39,-189
+L 43,-189
+C 71,-249 143,-278 214,-258
+C 340,-221 381,-72 381,60
 L 381,422
 Z
 M 421,422
 L 425,422
-L 221,-301
-L 221,-297
+L 425,60
+C 425,-118 355,-264 224,-301
+C 140,-324 49,-289 6,-212
+L 10,-212
+C 51,-284 138,-319 223,-297
+C 366,-259 421,-94 421,60
 L 421,422
 Z
 '
 transform='translate(10534,14742) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_57e911a931f850b9)'
+clip-path='url(#clip_f3645ce314c60495)'
 />
 <!-- z -->
-<clipPath id='clip_d311604a0df9df8a'>
+<clipPath id='clip_9896ddb646759caa'>
 <rect x='-120' y='-420' width='710' height='1190'/>
 </clipPath>
 <path
 d='
 M 58,358
 L 58,362
+L 302,360
 L 304,362
 L 304,358
+L -60,2
+L 362,2
+L 362,-2
 L -67,-2
 L -67,2
-L 297,358
+L 302,360
+L 302,360
 L 58,358
 Z
 M 58,398
 L 58,402
+L 342,400
 L 344,402
-L 22,38
+L 25,42
+L 362,42
+L 362,38
 L 18,38
-L 338,398
+L 342,400
+L 342,400
 L 58,398
 Z
 M 58,438
 L 58,442
+L 382,440
 L 384,442
-L 107,78
+L 110,82
+L 362,82
+L 362,78
 L 103,78
-L 378,438
+L 382,440
+L 382,440
 L 58,438
 Z
 M 58,478
 L 58,482
+L 422,480
 L 424,482
-L 193,118
+L 195,122
+L 362,122
+L 362,118
 L 189,118
-L 418,478
+L 422,480
+L 422,480
 L 58,478
 Z
 '
 transform='translate(11000,14742) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_d311604a0df9df8a)'
+clip-path='url(#clip_9896ddb646759caa)'
 />
 <!--   -->
 <clipPath id='clip_e3b0c44298fc1c14'>
@@ -13228,110 +14297,141 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_e3b0c44298fc1c14)'
 />
 <!-- 0 -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_578bd9fcd34c32f6'>
+<rect x='-120' y='-420' width='711' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 115,360
+C 99,449 113,602 210,602
+C 297,602 312,436 305,360
+C 297,270 301,135 210,118
+C 123,102 88,275 115,360
+Z
+M 210,122
+C 294,122 304,287 301,360
+C 298,430 305,590 210,598
+C 121,606 112,448 119,360
+C 126,268 99,122 210,122
+Z
+M 75,360
+C 59,468 89,642 210,642
+C 315,642 348,448 345,360
+C 342,249 321,95 210,78
+C 90,60 45,257 75,360
+Z
+M 210,82
+C 311,82 346,265 341,360
+C 336,466 320,629 210,638
+C 99,647 75,460 79,360
+C 83,265 83,82 210,82
+Z
+M 35,360
+C 17,485 50,682 210,682
+C 348,682 395,487 385,360
+C 376,246 331,58 210,38
+C 70,15 11,248 35,360
+Z
+M 210,42
+C 329,42 386,240 381,360
+C 376,480 331,668 210,678
+C 79,688 36,482 39,360
+C 43,216 72,42 210,42
+Z
+M -5,360
+C -13,502 40,722 210,722
+C 357,722 430,489 425,360
+C 420,210 354,16 210,-2
+C 58,-21 -31,205 -5,360
+Z
+M 210,2
+C 344,2 426,225 421,360
+C 415,498 358,698 210,718
+C 43,741 -9,504 -1,360
+C 8,214 46,2 210,2
+Z
+M 307,689
+L 311,689
+L 11,85
+L 7,85
+L 307,689
+Z
+M 343,671
+L 347,671
+L 47,67
+L 43,67
+L 343,671
+Z
+M 379,653
+L 383,653
+L 83,49
+L 79,49
+L 379,653
+Z
+M 414,635
+L 418,635
+L 118,31
+L 114,31
+L 414,635
 Z
 '
 transform='translate(11782,14742) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_578bd9fcd34c32f6)'
 />
 <!-- 1 -->
-<clipPath id='clip_3847468b95d2c398'>
-<rect x='-120' y='-420' width='485' height='1190'/>
+<clipPath id='clip_045a1f8d4db866f6'>
+<rect x='-120' y='-420' width='486' height='1190'/>
 </clipPath>
 <path
 d='
 M 98,551
 L 94,551
-L 75,602
-L 79,602
+L 77,600
+L 77,600
+L 80,58
+L 76,58
+L 77,600
+L 77,600
 L 98,551
 Z
 M 73,582
 L 69,582
-L 115,642
-L 119,642
+L 117,640
+L 117,640
+L 120,58
+L 116,58
+L 117,640
+L 117,640
 L 73,582
 Z
 M 44,614
 L 44,618
-L 159,682
-L 159,678
+L 157,680
+L 157,680
+L 160,58
+L 156,58
+L 157,680
+L 157,680
 L 44,614
 Z
 M 19,645
 L 19,649
-L 199,722
-L 199,718
+L 197,720
+L 197,720
+L 200,58
+L 196,58
+L 197,720
+L 197,720
 L 19,645
 Z
 '
 transform='translate(12248,14742) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_3847468b95d2c398)'
+clip-path='url(#clip_045a1f8d4db866f6)'
 />
 <!-- 2 -->
-<clipPath id='clip_aa8ffd5b6064b92b'>
-<rect x='-120' y='-420' width='710' height='1190'/>
-</clipPath>
-<path
-d='
-M 106,560
-L 102,560
-C 122,593 165,610 203,602
-C 252,593 290,547 306,501
-C 375,301 128,47 -80,-2
-L -84,-2
-C 115,36 363,318 302,500
-C 286,547 247,591 202,599
-C 166,604 131,587 106,560
-Z
-M 75,585
-L 71,585
-C 99,631 156,652 208,642
-C 275,630 326,567 345,507
-C 404,324 197,108 17,38
-L 12,38
-C 192,85 392,338 341,506
-C 322,568 269,627 208,638
-C 159,647 107,625 75,585
-Z
-M 44,611
-L 40,611
-C 74,668 147,694 213,682
-C 296,667 364,592 385,514
-C 430,347 266,165 113,78
-L 109,78
-C 266,133 427,350 381,513
-C 358,592 289,664 213,678
-C 152,689 81,659 44,611
-Z
-M 13,636
-L 9,636
-C 49,703 136,736 218,721
-C 316,704 402,619 424,520
-C 457,371 336,191 210,118
-L 206,118
-C 339,176 459,372 420,519
-C 394,617 312,700 218,718
-C 143,731 57,702 13,636
-Z
-'
-transform='translate(12489,14742) scale(1,-1)'
-style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_aa8ffd5b6064b92b)'
-/>
-<!-- 3 -->
-<clipPath id='clip_9e36855887b1278c'>
+<clipPath id='clip_6fb9d254d9ec57bf'>
 <rect x='-120' y='-420' width='710' height='1190'/>
 </clipPath>
 <path
@@ -13339,82 +14439,184 @@ d='
 M 106,560
 L 102,560
 C 123,593 163,610 203,602
-C 253,593 285,547 306,499
-L 302,499
-C 288,548 251,591 203,598
-C 166,604 129,589 106,560
+C 251,594 294,550 306,501
+C 330,401 232,312 171,251
+L -77,2
+L 362,2
+L 362,-2
+L -84,-2
+L -84,-2
+L 168,254
+C 245,331 315,417 302,500
+C 293,557 247,592 202,599
+C 165,604 129,591 106,560
 Z
 M 75,585
 L 71,585
-C 101,630 155,653 208,642
-C 276,629 319,567 345,505
-L 341,505
-C 321,566 276,625 208,638
-C 157,648 106,626 75,585
+C 98,630 152,652 208,642
+C 275,631 331,582 345,507
+C 366,398 272,296 199,223
+L 19,42
+L 362,42
+L 362,38
+L 12,38
+L 196,226
+C 262,292 355,402 341,506
+C 331,582 271,630 208,638
+C 156,645 107,623 75,585
 Z
 M 44,611
 L 40,611
-C 78,667 147,695 213,682
-C 297,666 352,590 385,511
-L 381,511
-C 364,591 302,666 213,678
-C 149,687 86,659 44,611
+C 82,670 149,691 213,682
+C 309,668 371,593 385,514
+C 406,391 308,275 228,194
+L 116,82
+L 362,82
+L 362,78
+L 109,78
+L 225,197
+C 312,287 396,394 381,513
+C 369,603 298,666 213,678
+C 148,687 79,666 44,611
 Z
 M 13,636
 L 9,636
-C 56,701 137,738 218,721
-C 318,701 379,610 424,517
-L 420,517
-C 396,612 322,701 218,718
-C 139,730 62,698 13,636
+C 57,699 139,732 218,721
+C 321,708 406,626 424,520
+C 447,385 347,259 256,166
+L 212,122
+L 362,122
+L 362,118
+L 206,118
+L 253,169
+C 343,265 438,378 420,519
+C 407,623 316,701 218,718
+C 138,731 52,708 13,636
+Z
+'
+transform='translate(12489,14742) scale(1,-1)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_6fb9d254d9ec57bf)'
+/>
+<!-- 3 -->
+<clipPath id='clip_12d49e674309b930'>
+<rect x='-120' y='-420' width='710' height='1190'/>
+</clipPath>
+<path
+d='
+M 106,560
+L 102,560
+C 124,593 166,606 203,602
+C 255,597 309,556 306,501
+C 303,451 256,418 210,418
+L 158,418
+L 158,422
+L 210,422
+C 252,422 297,457 302,501
+C 307,552 265,592 203,598
+C 167,602 123,593 106,560
+Z
+M 75,585
+L 71,585
+C 102,631 150,650 208,642
+C 257,635 343,594 345,507
+C 347,434 279,378 210,378
+L 158,378
+L 158,382
+L 210,382
+C 274,382 341,432 341,507
+C 341,575 279,631 208,638
+C 158,643 101,624 75,585
+Z
+M 44,611
+L 40,611
+C 72,661 139,693 213,682
+C 295,669 378,598 385,513
+C 393,415 303,338 210,338
+L 158,338
+L 158,342
+L 210,342
+C 298,342 390,411 381,513
+C 373,592 296,666 213,678
+C 151,686 75,669 44,611
+Z
+M 13,636
+L 9,636
+C 49,696 132,735 218,721
+C 313,706 413,635 424,520
+C 436,396 320,298 210,298
+L 158,298
+L 158,302
+L 210,302
+C 328,302 433,390 420,519
+C 410,621 309,699 218,718
+C 139,733 44,714 13,636
 Z
 M 158,298
 L 158,302
-C 225,318 301,285 306,219
-C 310,161 250,127 201,118
-L 201,122
-C 258,112 312,163 302,219
-C 291,279 224,307 158,298
+L 210,302
+C 258,302 302,265 306,219
+C 311,155 258,123 203,118
+C 161,113 119,123 102,160
+L 106,160
+C 128,130 168,117 203,122
+C 251,127 303,166 302,219
+C 300,264 260,298 210,298
+L 158,298
 Z
 M 158,338
 L 158,342
-C 242,356 346,305 345,213
-C 345,136 272,91 206,78
-L 206,82
-C 282,73 352,139 341,213
-C 330,288 240,322 158,338
+L 210,342
+C 276,342 345,284 345,213
+C 346,145 278,86 208,78
+C 157,72 99,92 71,135
+L 75,135
+C 105,95 153,76 208,82
+C 269,89 340,133 341,213
+C 342,280 276,338 210,338
+L 158,338
 Z
 M 158,378
 L 158,382
-C 269,392 378,319 385,207
-C 391,106 307,24 211,38
-L 211,42
-C 306,34 390,112 381,207
-C 371,311 259,364 158,378
+L 210,382
+C 305,382 390,309 385,207
+C 381,122 309,48 213,38
+C 147,31 73,57 40,109
+L 44,109
+C 76,61 142,31 213,42
+C 298,55 373,128 381,207
+C 390,303 305,378 210,378
+L 158,378
 Z
 M 158,418
 L 158,422
-C 291,433 429,342 424,200
-C 421,89 323,11 216,-2
-L 216,2
-C 328,-5 430,87 420,201
-C 409,325 285,384 158,418
+L 210,422
+C 334,422 434,330 424,200
+C 417,95 320,3 218,-1
+C 133,-5 77,35 9,84
+L 13,84
+C 63,18 142,-8 218,2
+C 315,16 408,105 420,201
+C 436,331 317,418 210,418
+L 158,418
 Z
 '
 transform='translate(12955,14742) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_9e36855887b1278c)'
+clip-path='url(#clip_12d49e674309b930)'
 />
 <!-- 4 -->
-<clipPath id='clip_2a240f97dc99dca1'>
-<rect x='-120' y='-420' width='632' height='1190'/>
+<clipPath id='clip_a821c49951af55a3'>
+<rect x='-120' y='-420' width='648' height='1190'/>
 </clipPath>
 <path
 d='
 M 344,58
 L 340,58
 L 342,906
-L -32,148
+L -31,152
+L 362,152
+L 362,148
 L -37,148
 L 342,916
 L 346,916
@@ -13423,7 +14625,9 @@ Z
 M 304,58
 L 300,58
 L 302,736
-L 32,188
+L 33,192
+L 362,192
+L 362,188
 L 28,188
 L 302,747
 L 306,747
@@ -13432,7 +14636,9 @@ Z
 M 264,58
 L 260,58
 L 262,567
-L 97,228
+L 98,232
+L 362,232
+L 362,228
 L 93,228
 L 262,577
 L 266,577
@@ -13441,7 +14647,9 @@ Z
 M 224,58
 L 220,58
 L 222,397
-L 162,268
+L 163,272
+L 362,272
+L 362,268
 L 158,268
 L 222,408
 L 226,408
@@ -13450,760 +14658,1222 @@ Z
 '
 transform='translate(13421,14742) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_2a240f97dc99dca1)'
+clip-path='url(#clip_a821c49951af55a3)'
 />
 <!-- 5 -->
-<clipPath id='clip_839aead4c20fd8d0'>
+<clipPath id='clip_e51f25c972f05e59'>
 <rect x='-120' y='-420' width='711' height='1190'/>
 </clipPath>
 <path
 d='
 M 362,722
 L 362,718
-L 0,718
+L 4,718
+L 5,358
+L 1,358
 L 0,722
 L 362,722
 Z
 M 362,682
 L 362,678
-L 40,678
+L 44,678
+L 45,358
+L 41,358
 L 40,682
 L 362,682
 Z
 M 362,642
 L 362,638
-L 80,638
+L 84,638
+L 85,358
+L 81,358
 L 80,642
 L 362,642
 Z
 M 362,602
 L 362,598
-L 120,598
+L 124,598
+L 125,358
+L 121,358
 L 120,602
 L 362,602
 Z
 M 117,341
 L 113,341
-C 122,386 163,407 204,402
-C 276,395 310,317 305,261
-C 300,191 255,139 198,117
-L 198,121
-C 257,139 297,202 301,261
-C 305,328 263,393 204,398
-C 161,402 128,378 117,341
+C 117,383 164,408 204,402
+C 261,395 307,318 305,261
+C 303,202 260,127 201,117
+C 165,111 124,128 104,158
+L 108,158
+C 125,128 166,113 200,121
+C 254,134 299,206 301,261
+C 303,320 260,393 204,398
+C 166,402 129,376 117,341
 Z
 M 78,352
 L 74,352
-C 83,410 144,451 208,442
-C 294,430 350,339 345,260
-C 340,175 282,105 205,78
-L 205,82
-C 280,95 340,176 341,260
-C 342,351 286,431 208,438
-C 150,444 101,406 78,352
+C 88,413 146,451 208,442
+C 281,431 347,341 345,260
+C 343,183 286,92 207,78
+C 157,69 97,89 72,134
+L 76,134
+C 103,91 157,72 207,82
+C 283,97 339,187 341,260
+C 343,338 284,430 208,438
+C 156,444 99,408 78,352
 Z
 M 40,364
 L 36,364
-C 48,446 132,493 213,482
-C 325,466 390,356 385,260
-C 380,160 306,72 212,38
-L 212,42
-C 311,61 379,162 381,260
-C 383,368 315,469 212,478
-C 136,484 70,430 40,364
+C 48,446 136,493 213,482
+C 312,468 389,358 385,260
+C 382,166 313,58 214,38
+C 151,26 81,53 39,110
+L 44,110
+C 80,57 148,28 214,42
+C 306,62 379,167 381,260
+C 382,357 310,466 212,478
+C 139,486 60,435 40,364
 Z
 M 2,375
 L -2,375
-C 19,472 113,536 217,522
-C 347,504 431,375 425,259
-C 419,126 320,34 219,-1
-L 219,3
-C 338,25 418,142 421,259
-C 424,394 342,503 216,518
-C 124,529 29,472 2,375
+C 10,477 116,536 217,522
+C 334,505 425,383 425,259
+C 425,145 330,21 221,-1
+C 139,-18 46,12 7,86
+L 11,86
+C 60,24 134,-13 220,3
+C 330,23 423,144 421,259
+C 419,380 335,503 216,518
+C 129,528 29,470 2,375
 Z
 '
 transform='translate(13887,14742) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_839aead4c20fd8d0)'
+clip-path='url(#clip_e51f25c972f05e59)'
 />
 <!-- 6 -->
-<clipPath id='clip_cb005b316427f889'>
+<clipPath id='clip_110cc929b3a1e664'>
 <rect x='-120' y='-420' width='705' height='1190'/>
 </clipPath>
 <path
 d='
 M 410,631
 L 406,631
-C 380,706 269,742 197,716
-C 74,672 30,486 5,362
-C -2,326 -0,292 5,256
-C 21,150 97,2 208,2
-C 313,2 412,156 415,262
-C 418,369 315,492 212,518
-L 212,522
-C 320,497 417,373 419,262
-C 422,150 320,-11 208,-2
-C 99,6 24,147 1,256
-C -7,292 -7,327 1,362
-C 31,495 69,675 196,720
-C 268,745 377,705 410,631
+C 376,699 268,741 197,716
+C 71,672 30,486 5,362
+C -2,327 -0,292 5,256
+C 23,142 98,2 208,2
+C 316,2 412,153 415,263
+C 417,369 325,507 218,517
+C 103,528 -24,345 10,233
+L 6,233
+C -26,349 99,520 219,521
+C 331,523 420,373 419,263
+C 418,144 321,-13 208,-2
+C 98,9 25,149 1,256
+C -7,291 -7,327 1,362
+C 33,495 68,675 196,720
+C 268,746 377,701 410,631
 Z
 M 376,609
 L 372,609
-C 352,665 266,695 207,678
-C 94,644 63,476 45,361
-C 40,327 42,294 45,259
-C 54,164 118,42 210,42
-C 294,42 378,170 375,260
-C 371,351 296,455 209,478
-L 209,482
-C 303,457 376,355 379,261
-C 382,167 304,32 209,38
-C 114,44 52,167 41,259
-C 37,293 35,326 41,361
-C 63,480 93,641 206,681
-C 266,703 351,666 376,609
+C 350,663 265,696 207,678
+C 95,642 67,475 45,361
+C 39,327 40,295 45,259
+C 57,171 118,42 209,42
+C 300,42 374,171 375,261
+C 376,350 301,470 212,478
+C 114,486 16,344 47,250
+L 42,250
+C 17,344 117,481 213,482
+C 307,482 380,354 379,261
+C 378,166 302,31 209,38
+C 114,46 61,169 41,258
+C 33,293 34,328 41,361
+C 66,478 93,641 206,681
+C 265,703 349,666 376,609
 Z
 M 343,587
 L 339,587
-C 324,630 256,651 216,639
-C 119,608 102,460 85,359
-C 80,327 81,295 85,261
-C 93,189 136,82 211,82
-C 280,82 336,189 335,259
-C 334,332 276,419 206,438
-L 206,442
-C 279,418 333,336 339,260
-C 345,187 287,76 211,78
-C 133,80 84,188 81,261
-C 79,297 79,326 81,359
-C 86,463 118,607 215,643
-C 261,659 324,632 343,587
+C 325,630 259,651 216,639
+C 119,610 102,463 85,359
+C 79,326 81,294 85,261
+C 93,190 134,82 211,82
+C 284,82 334,189 335,259
+C 336,331 279,430 206,438
+C 138,446 61,334 83,266
+L 79,266
+C 58,338 134,442 207,442
+C 284,442 340,334 339,259
+C 338,184 285,79 211,78
+C 135,77 94,188 81,261
+C 75,294 76,326 81,359
+C 97,459 118,605 215,643
+C 259,660 325,631 343,587
 Z
 M 309,565
 L 305,565
-C 292,593 256,603 225,600
-C 142,589 127,443 125,358
-C 124,326 123,296 125,264
-C 128,213 152,122 212,122
-C 264,122 301,207 295,258
-C 288,315 258,386 203,398
-L 203,402
-C 256,380 293,315 299,258
-C 305,204 269,119 212,118
-C 154,117 122,206 121,264
-C 120,296 118,326 121,358
-C 128,448 142,573 224,604
-C 255,615 300,597 309,565
+C 290,591 255,606 225,600
+C 142,583 135,443 125,358
+C 121,326 119,295 125,264
+C 135,208 155,122 212,122
+C 264,122 294,206 295,257
+C 296,312 258,394 200,399
+C 153,402 103,328 119,283
+L 115,283
+C 100,332 151,403 201,403
+C 258,402 299,314 299,257
+C 299,203 269,120 212,118
+C 156,116 130,207 121,264
+C 116,295 117,327 121,358
+C 133,448 141,572 224,604
+C 253,615 298,595 309,565
 Z
 '
 transform='translate(14353,14742) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_cb005b316427f889)'
+clip-path='url(#clip_110cc929b3a1e664)'
 />
 <!-- 7 -->
-<clipPath id='clip_c3c8f06e057bd1fa'>
-<rect x='-120' y='-420' width='737' height='1190'/>
+<clipPath id='clip_7eeb009b3981c8ec'>
+<rect x='-120' y='-420' width='738' height='1190'/>
 </clipPath>
 <path
 d='
 M 58,598
 L 58,602
-L 278,602
-L 278,598
+L 279,602
+L 84,79
+L 80,79
+L 273,598
 L 58,598
 Z
 M 58,638
 L 58,642
-L 336,642
-L 336,638
+L 337,642
+L 121,65
+L 117,65
+L 331,638
 L 58,638
 Z
 M 58,678
 L 58,682
-L 393,682
-L 393,678
+L 394,682
+L 159,51
+L 154,51
+L 388,678
 L 58,678
 Z
 M 58,718
 L 58,722
-L 451,722
-L 451,718
+L 452,722
+L 196,37
+L 192,37
+L 446,718
 L 58,718
 Z
 '
 transform='translate(14819,14742) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_c3c8f06e057bd1fa)'
+clip-path='url(#clip_7eeb009b3981c8ec)'
 />
 <!-- 8 -->
-<clipPath id='clip_1aabf11835e9ca84'>
+<clipPath id='clip_414843c951208e53'>
 <rect x='-120' y='-420' width='710' height='1190'/>
 </clipPath>
 <path
 d='
-M 234,413
-C 219,464 120,464 114,518
-C 111,558 168,602 210,602
-C 255,602 308,562 306,518
-C 303,469 231,439 185,412
-C 110,367 10,305 6,218
-C 1,119 113,2 210,2
-C 308,2 443,122 415,217
-C 395,288 236,231 208,300
-C 193,336 239,374 234,413
+M 235,412
+C 193,435 121,464 114,518
+C 110,560 169,602 210,602
+C 251,602 309,559 306,518
+C 302,464 232,439 185,412
+C 108,368 9,306 6,218
+C 2,123 105,2 210,2
+C 307,2 428,124 414,218
+C 402,301 304,362 235,412
 Z
-M 212,300
-C 249,239 394,292 417,220
-C 449,123 312,2 210,-2
-C 107,-5 -3,118 1,218
-C 6,309 116,355 184,415
-C 224,452 288,466 301,518
-C 312,560 253,600 210,598
-C 169,596 116,559 118,519
-C 122,464 224,466 238,414
-C 248,375 197,335 212,300
+M 419,219
+C 418,114 314,2 210,-2
+C 107,-6 -4,119 1,219
+C 7,312 119,359 184,415
+C 226,452 285,465 301,518
+C 313,558 252,601 210,598
+C 168,595 114,560 119,518
+C 123,473 195,451 236,415
+C 310,351 412,313 419,219
 Z
-M 216,378
-C 197,441 81,449 75,512
-C 69,575 147,642 210,642
-C 273,642 348,578 345,513
-C 342,445 252,420 203,376
-C 145,324 53,290 45,213
-C 38,135 130,42 210,42
-C 289,42 381,132 375,211
-C 370,282 204,270 208,340
-C 209,353 218,365 216,378
+M 217,376
+C 164,413 79,444 75,513
+C 71,573 150,642 210,642
+C 270,642 348,573 345,513
+C 342,447 259,405 203,376
+C 145,346 47,288 45,212
+C 43,136 133,42 210,42
+C 293,42 384,137 375,212
+C 366,288 281,340 217,376
 Z
-M 212,340
-C 235,276 371,280 378,214
-C 387,131 289,36 210,38
-C 129,40 45,135 41,213
-C 37,290 147,326 201,380
-C 248,425 335,448 341,513
-C 347,576 270,635 210,638
-C 150,641 79,572 79,514
-C 78,450 208,441 220,378
-C 222,365 209,353 212,340
+M 379,213
+C 380,132 292,46 210,38
+C 129,30 33,126 41,213
+C 48,293 141,330 201,380
+C 255,423 317,449 341,513
+C 363,572 278,646 210,638
+C 154,632 72,581 79,513
+C 85,453 168,423 219,380
+C 281,326 375,292 379,213
 Z
-M 202,341
-C 130,316 35,432 35,508
-C 35,596 131,682 210,682
-C 291,682 385,587 385,507
-C 385,430 272,399 221,340
-C 180,292 86,270 85,207
-C 84,146 151,82 210,82
-C 268,82 332,150 335,208
-C 340,277 271,413 212,379
-C 200,373 213,349 202,341
+M 199,340
+C 144,380 46,429 35,507
+C 25,582 130,682 210,682
+C 289,682 396,587 385,507
+C 374,430 288,376 221,340
+C 165,310 90,271 85,207
+C 80,150 153,82 210,82
+C 267,82 338,150 335,207
+C 332,271 250,308 199,340
 Z
-M 208,381
-C 275,394 340,281 339,206
-C 339,146 275,77 210,78
-C 150,79 79,149 81,208
-C 83,273 173,298 219,344
-C 275,398 380,437 381,508
-C 382,586 289,688 210,678
-C 130,668 35,587 39,507
-C 43,432 126,323 198,343
-C 212,347 194,378 208,381
+M 339,207
+C 341,146 273,83 210,78
+C 147,73 61,148 81,207
+C 103,273 169,298 219,344
+C 280,400 373,427 381,508
+C 388,589 292,683 210,678
+C 120,672 34,590 39,508
+C 44,433 134,389 201,344
+C 253,308 335,277 339,207
 Z
-M 184,306
-C 95,277 -4,413 -4,502
-C -5,601 112,722 210,722
-C 314,722 424,598 424,501
-C 425,413 305,363 239,305
-C 201,270 126,253 124,201
-C 123,164 169,122 210,122
-C 248,122 286,165 296,203
-C 314,276 281,447 212,419
-C 175,404 217,329 184,306
+M 181,305
+C 105,361 -0,411 -4,501
+C -9,600 111,722 210,722
+C 309,722 427,595 424,501
+C 422,411 318,343 239,305
+C 192,282 130,252 124,202
+C 120,165 172,122 210,122
+C 247,122 299,164 296,202
+C 292,245 228,278 181,305
 Z
-M 208,421
-C 283,427 314,276 299,201
-C 291,159 252,119 210,118
-C 170,117 116,162 120,202
-C 125,256 201,274 237,308
-C 303,371 414,411 420,502
-C 427,601 304,712 210,718
-C 110,725 -5,603 -0,501
-C 4,409 98,285 180,307
-C 221,318 165,418 208,421
+M 300,202
+C 301,160 252,120 210,118
+C 167,116 110,158 120,202
+C 133,256 191,276 237,308
+C 315,362 416,408 420,502
+C 425,605 313,724 210,718
+C 108,713 -8,605 -0,502
+C 6,415 114,370 183,308
+C 222,273 295,255 300,202
 Z
 '
 transform='translate(15285,14742) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_1aabf11835e9ca84)'
+clip-path='url(#clip_414843c951208e53)'
 />
 <!-- 9 -->
-<clipPath id='clip_1c5895443519d1ce'>
+<clipPath id='clip_1f5f6e6ab8443567'>
 <rect x='-120' y='-420' width='705' height='1190'/>
 </clipPath>
 <path
 d='
 M 10,89
 L 14,89
-C 47,20 150,-23 223,4
-C 350,49 388,225 415,358
-C 422,393 420,427 415,464
-C 398,572 321,699 212,718
-C 101,737 4,569 5,458
-C 6,349 105,227 208,202
-L 208,198
-C 98,206 0,348 1,458
-C 2,569 101,722 212,722
-C 323,722 399,566 419,464
-C 426,429 427,393 419,358
-C 390,227 349,49 224,-0
-C 149,-30 41,19 10,89
+C 48,22 151,-22 223,4
+C 349,49 385,228 415,358
+C 423,393 422,429 415,464
+C 393,570 320,705 212,718
+C 101,731 5,573 5,457
+C 5,351 90,201 202,203
+C 318,204 442,374 410,487
+L 414,487
+C 446,372 328,191 201,199
+C 91,206 -1,352 1,457
+C 3,567 100,722 212,722
+C 325,722 407,573 419,464
+C 423,428 425,393 419,358
+C 394,218 339,45 224,-0
+C 153,-28 41,20 10,89
 Z
 M 44,111
 L 48,111
-C 72,55 152,20 213,42
-C 324,82 358,243 375,359
-C 380,395 379,426 375,461
-C 364,552 302,665 210,678
-C 121,691 37,549 45,460
-C 54,370 119,267 211,242
-L 211,238
-C 122,259 44,370 41,459
-C 38,548 120,682 211,682
-C 301,682 369,553 379,461
-C 383,427 385,393 379,359
-C 360,245 336,83 214,39
-C 153,16 67,52 44,111
+C 72,56 156,21 213,42
+C 324,83 349,244 375,359
+C 382,393 382,427 375,461
+C 357,550 301,669 211,678
+C 119,687 45,550 45,459
+C 45,369 115,241 208,242
+C 302,243 400,381 373,470
+L 378,470
+C 407,379 302,236 207,238
+C 115,240 41,368 41,459
+C 41,551 117,682 211,682
+C 305,682 363,550 379,462
+C 385,428 387,392 379,359
+C 351,238 327,80 214,39
+C 157,17 69,55 44,111
 Z
 M 77,133
 L 81,133
-C 97,90 160,65 204,81
-C 300,118 324,258 335,361
-C 338,394 339,426 335,459
-C 325,531 276,630 209,638
-C 138,647 72,532 85,461
-C 98,388 142,307 214,282
-L 214,278
-C 144,300 86,385 81,460
-C 76,533 136,642 209,642
-C 284,642 329,531 339,459
-C 344,426 345,395 339,361
-C 322,263 300,109 205,77
-C 160,62 94,89 77,133
+C 98,91 160,64 204,81
+C 300,118 316,260 335,361
+C 341,393 341,426 335,459
+C 322,531 283,630 209,638
+C 137,646 84,533 85,461
+C 86,387 139,282 214,282
+C 284,282 359,386 337,454
+L 341,454
+C 366,379 285,275 213,278
+C 138,281 80,391 81,461
+C 82,533 132,642 209,642
+C 284,642 333,531 339,459
+C 342,426 344,393 339,361
+C 321,250 302,110 205,77
+C 161,63 93,89 77,133
 Z
 M 111,155
 L 115,155
-C 122,124 164,109 195,120
-C 268,148 300,274 295,362
-C 293,395 296,423 295,456
-C 294,515 253,586 208,598
-C 157,612 116,513 125,462
-C 135,403 169,344 217,322
-L 217,318
-C 167,346 126,404 121,462
-C 116,516 152,602 208,602
-C 265,602 297,515 299,456
-C 301,425 301,395 299,362
-C 294,277 280,137 196,116
-C 164,109 123,126 111,155
+C 124,126 166,110 195,120
+C 277,150 290,275 295,362
+C 297,394 299,426 295,456
+C 287,512 265,590 208,598
+C 155,605 122,518 125,463
+C 128,406 160,322 220,321
+C 267,321 316,390 301,437
+L 305,437
+C 321,390 269,316 219,317
+C 162,319 120,405 121,463
+C 121,517 153,602 208,602
+C 265,602 294,512 299,456
+C 302,425 304,393 299,362
+C 285,276 280,139 196,116
+C 165,108 121,124 111,155
 Z
 '
 transform='translate(15751,14742) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_1c5895443519d1ce)'
+clip-path='url(#clip_1f5f6e6ab8443567)'
 />
 <!-- A -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_8ec67b8629bc66ac'>
+<rect x='-120' y='-420' width='709' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 117,43
+L 113,43
+L 265,598
+L 155,598
+L 307,43
+L 303,43
+L 149,602
+L 271,602
+L 117,43
+Z
+M 79,53
+L 74,53
+L 225,638
+L 195,638
+L 346,53
+L 341,53
+L 189,642
+L 231,642
+L 79,53
+Z
+M 40,63
+L 36,63
+L 186,682
+L 234,682
+L 384,63
+L 380,63
+L 230,678
+L 190,678
+L 40,63
+Z
+M 1,73
+L -3,73
+L 146,722
+L 274,722
+L 423,73
+L 419,73
+L 270,718
+L 150,718
+L 1,73
+Z
+M 133,148
+L 133,152
+L 287,152
+L 287,148
+L 133,148
+Z
+M 133,188
+L 133,192
+L 287,192
+L 287,188
+L 133,188
+Z
+M 133,228
+L 133,232
+L 287,232
+L 287,228
+L 133,228
+Z
+M 133,268
+L 133,272
+L 287,272
+L 287,268
+L 133,268
 Z
 '
 transform='translate(0,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_8ec67b8629bc66ac)'
 />
 <!-- B -->
-<clipPath id='clip_dfb842a816965a23'>
+<clipPath id='clip_97e43397b9816fcd'>
 <rect x='-120' y='-420' width='711' height='1190'/>
 </clipPath>
 <path
 d='
-M 58,298
-L 58,302
-C 150,340 307,319 302,212
-C 298,133 194,102 116,122
-L 116,598
-L 301,508
-L 301,512
-L 120,602
-L 120,118
-C 201,77 306,116 304,208
-C 303,307 157,335 58,298
+M 92,310
+L 92,314
+C 175,344 290,303 305,210
+C 321,113 206,31 115,89
+L 115,631
+C 209,651 300,598 305,510
+C 311,407 185,354 92,406
+L 92,410
+C 179,379 286,421 301,510
+C 317,606 207,680 119,629
+L 119,91
+C 205,79 296,126 301,210
+C 307,312 178,351 92,310
 Z
-M 150,293
-C 154,293 157,296 157,300
-C 157,304 154,307 150,307
-C 146,307 143,304 143,300
-C 143,297 146,293 150,293
+M 68,342
+L 68,346
+C 193,387 336,330 345,210
+C 356,71 185,30 75,69
+L 75,651
+C 198,692 343,627 345,510
+C 348,388 180,345 68,374
+L 68,378
+C 189,340 328,395 341,510
+C 355,636 189,727 79,649
+L 79,71
+C 209,42 338,104 341,210
+C 345,324 185,365 68,342
 Z
-M 58,378
-L 58,382
-C 201,440 387,363 385,211
-C 382,51 179,5 55,59
-L 55,661
-L 385,508
-L 381,508
-L 59,661
-L 59,59
-C 210,-3 366,75 381,209
-C 398,355 199,438 58,378
+M 44,374
+L 44,378
+C 190,424 382,358 385,210
+C 388,61 174,9 35,49
+L 35,671
+C 180,719 362,649 385,510
+C 412,348 201,204 44,342
+L 44,346
+C 179,302 373,365 381,510
+C 389,661 181,720 39,669
+L 39,51
+C 192,-8 375,65 381,210
+C 387,365 179,411 44,374
 Z
-M 58,418
-L 58,422
-C 230,477 437,388 425,211
-C 414,51 192,-16 55,59
-L 55,661
-L 425,508
-L 421,508
-L 59,661
-L 59,59
-C 229,3 402,63 421,209
-C 443,373 221,438 58,418
+M 20,406
+L 20,410
+C 190,465 412,399 425,210
+C 439,6 152,-72 -5,29
+L -5,691
+C 193,776 412,680 425,510
+C 439,326 190,245 20,310
+L 20,314
+C 208,269 415,346 421,510
+C 427,686 173,740 -1,689
+L -1,31
+C 199,-54 403,48 421,210
+C 442,399 193,493 20,406
 Z
 '
 transform='translate(466,15812) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_dfb842a816965a23)'
+clip-path='url(#clip_97e43397b9816fcd)'
 />
 <!-- C -->
-<clipPath id='clip_98282da533c68c75'>
+<clipPath id='clip_39018d51a8bc6db8'>
 <rect x='-120' y='-420' width='696' height='1190'/>
 </clipPath>
 <path
 d='
 M 410,631
 L 405,631
-C 368,703 274,736 198,717
-C 64,682 -6,498 5,360
-C 17,219 84,75 199,4
-L 199,-0
-C 74,69 6,221 1,360
-C -4,492 45,680 197,720
-C 282,743 369,708 410,631
+C 357,696 273,730 198,717
+C 65,692 -2,497 5,360
+C 12,227 73,43 198,3
+C 276,-22 371,14 405,89
+L 410,89
+C 371,17 275,-22 197,-0
+C 60,37 -4,222 1,360
+C 5,495 64,683 197,720
+C 274,743 369,710 410,631
 Z
 M 376,609
 L 372,609
-C 345,667 269,693 207,678
-C 90,648 32,482 45,360
-C 58,239 109,108 208,43
-L 208,39
-C 96,97 43,238 41,360
-C 39,479 82,648 206,681
-C 274,700 344,668 376,609
+C 336,662 268,688 207,678
+C 90,657 35,479 45,360
+C 56,240 91,77 207,42
+C 268,24 342,49 372,111
+L 376,111
+C 348,49 270,24 206,39
+C 87,66 35,240 41,360
+C 47,479 89,647 206,681
+C 273,701 348,668 376,609
 Z
 M 343,587
 L 339,587
-C 318,630 262,649 216,639
-C 117,617 73,463 85,360
-C 97,257 135,148 217,81
-L 217,77
-C 128,138 89,247 81,360
-C 73,475 109,618 215,642
-C 266,654 319,632 343,587
+C 318,628 262,650 216,639
+C 114,614 76,464 85,360
+C 94,257 118,111 216,81
+C 265,66 322,87 339,133
+L 343,133
+C 316,89 263,69 215,78
+C 115,95 75,262 81,360
+C 87,460 119,612 215,642
+C 263,658 323,633 343,587
 Z
 M 310,565
 L 305,565
-C 294,595 256,607 224,600
-C 143,579 112,445 125,360
-C 139,269 160,183 226,120
-L 226,116
-C 161,169 128,270 121,360
-C 114,446 128,581 224,603
-C 260,612 298,599 310,565
+C 285,589 255,603 224,600
+C 143,591 119,445 125,360
+C 131,278 141,145 224,120
+C 256,111 297,124 305,155
+L 310,155
+C 293,125 256,113 224,117
+C 143,126 108,276 121,360
+C 134,444 141,580 224,603
+C 259,613 299,597 310,565
 Z
 '
 transform='translate(932,15812) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_98282da533c68c75)'
+clip-path='url(#clip_39018d51a8bc6db8)'
 />
 <!-- D -->
-<clipPath id='clip_b8beda00b01b052a'>
-<rect x='-120' y='-420' width='704' height='1190'/>
+<clipPath id='clip_ab32b962fb592154'>
+<rect x='-120' y='-420' width='705' height='1190'/>
 </clipPath>
 <path
 d='
 M 1,662
 L 5,662
 L 4,2
-L 414,372
-L 418,372
-L 0,-2
+C 220,-13 418,150 415,360
+C 412,562 226,686 58,718
+L 58,722
+C 265,729 435,558 419,360
+C 403,157 203,35 0,-2
 L 1,662
 Z
 M 41,662
 L 45,662
 L 44,42
-L 375,365
-L 379,365
-L 40,38
+C 232,39 380,187 375,360
+C 370,522 231,655 58,678
+L 58,682
+C 233,683 379,536 379,360
+C 380,178 228,24 40,38
 L 41,662
 Z
 M 81,662
 L 85,662
-L 65,59
-L 61,59
-L 339,359
-L 339,355
-L 62,92
+L 84,82
+C 231,92 339,217 335,360
+C 331,504 212,625 58,638
+L 58,642
+C 215,638 347,513 339,360
+C 332,222 216,125 80,78
 L 81,662
 Z
 M 121,662
 L 125,662
-L 65,59
-L 61,59
-L 300,352
-L 300,348
-L 64,91
+L 124,123
+C 231,147 310,247 295,360
+C 279,478 168,551 58,598
+L 58,602
+C 185,592 299,493 299,360
+C 300,253 221,161 120,117
 L 121,662
 Z
 '
 transform='translate(1398,15812) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_b8beda00b01b052a)'
+clip-path='url(#clip_ab32b962fb592154)'
 />
 <!-- E -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_54ec4eb280aaa099'>
+<rect x='-120' y='-420' width='648' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 362,722
+L 362,718
+L 4,718
+L 4,2
+L 362,2
+L 362,-2
+L 0,-2
+L 0,722
+L 362,722
+Z
+M 362,682
+L 362,678
+L 44,678
+L 44,42
+L 362,42
+L 362,38
+L 40,38
+L 40,682
+L 362,682
+Z
+M 362,642
+L 362,638
+L 84,638
+L 84,82
+L 362,82
+L 362,78
+L 80,78
+L 80,642
+L 362,642
+Z
+M 362,602
+L 362,598
+L 124,598
+L 124,122
+L 362,122
+L 362,118
+L 120,118
+L 120,602
+L 362,602
+Z
+M 58,298
+L 58,302
+L 362,302
+L 362,298
+L 58,298
+Z
+M 58,338
+L 58,342
+L 362,342
+L 362,338
+L 58,338
+Z
+M 58,378
+L 58,382
+L 362,382
+L 362,378
+L 58,378
+Z
+M 58,418
+L 58,422
+L 362,422
+L 362,418
+L 58,418
 Z
 '
 transform='translate(1864,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_54ec4eb280aaa099)'
 />
 <!-- F -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_2635705d2077a380'>
+<rect x='-120' y='-420' width='648' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 119,58
+L 115,58
+L 116,602
+L 362,602
+L 362,598
+L 120,598
+L 119,58
+Z
+M 79,58
+L 75,58
+L 76,642
+L 362,642
+L 362,638
+L 80,638
+L 79,58
+Z
+M 39,58
+L 35,58
+L 36,682
+L 362,682
+L 362,678
+L 40,678
+L 39,58
+Z
+M -1,58
+L -5,58
+L -4,722
+L 362,722
+L 362,718
+L -0,718
+L -1,58
+Z
+M 58,298
+L 58,302
+L 287,302
+L 287,298
+L 58,298
+Z
+M 58,338
+L 58,342
+L 287,342
+L 287,338
+L 58,338
+Z
+M 58,378
+L 58,382
+L 287,382
+L 287,378
+L 58,378
+Z
+M 58,418
+L 58,422
+L 287,422
+L 287,418
+L 58,418
 Z
 '
 transform='translate(2330,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_2635705d2077a380)'
 />
 <!-- G -->
-<clipPath id='clip_dc2e4db2b037d468'>
+<clipPath id='clip_618a75d8d54cd02e'>
 <rect x='-120' y='-420' width='706' height='1190'/>
 </clipPath>
 <path
 d='
-M 409,632
-L 405,632
-C 359,695 276,728 198,717
-C 28,691 -25,494 5,360
-C -60,197 26,3 198,4
-C 372,5 441,241 416,422
+M 410,631
+L 405,631
+C 369,711 274,739 198,717
+C 73,680 6,479 5,360
+C 5,278 27,30 197,4
+C 306,-13 414,93 415,210
+L 416,418
+L 208,418
+L 208,422
 L 420,422
-C 516,243 410,-10 196,-0
-C 34,7 -83,197 1,360
-C 23,503 65,676 197,721
-C 280,749 370,708 409,632
+L 419,210
+C 419,103 303,-12 196,-0
+C 56,15 -12,218 1,360
+C 11,473 62,678 197,720
+C 284,748 374,704 410,631
 Z
 M 376,609
 L 372,609
-C 350,676 272,697 207,678
-C 97,644 23,498 45,360
-C -37,218 53,42 207,42
-C 362,43 426,253 376,382
+C 345,665 267,692 207,678
+C 97,651 40,480 45,360
+C 50,242 87,61 206,43
+C 289,29 374,124 375,210
+L 376,378
+L 208,378
+L 208,382
 L 380,382
-C 467,249 384,30 206,39
-C 67,45 -49,206 41,360
-C 62,486 90,642 206,682
-C 274,705 347,673 376,609
+L 379,210
+C 379,123 293,34 205,39
+C 68,45 31,244 41,360
+C 51,476 96,647 206,681
+C 279,704 345,669 376,609
 Z
 M 343,587
 L 339,587
-C 325,636 268,655 217,639
-C 119,611 51,461 102,360
-C 53,243 101,83 217,81
-C 330,79 359,241 336,342
+C 319,630 261,649 216,639
+C 117,615 78,465 85,360
+C 92,258 120,96 216,81
+C 279,72 334,145 335,210
+L 336,338
+L 208,338
+L 208,342
 L 340,342
-C 396,208 321,92 214,78
-C 73,59 -5,227 62,358
-L 62,362
-C 55,476 98,616 213,641
-C 266,653 321,633 343,587
+L 339,210
+C 339,145 280,76 215,77
+C 112,80 68,253 81,360
+C 93,461 123,612 215,642
+C 263,659 325,634 343,587
 Z
-M 310,564
-L 306,564
-C 295,595 256,607 225,600
-C 138,580 129,419 182,360
-C 139,291 128,129 225,120
-C 303,113 332,227 296,302
+M 310,565
+L 305,565
+C 288,592 259,604 224,600
+C 140,589 116,443 125,360
+C 134,278 150,129 225,120
+C 270,115 294,169 295,210
+L 296,298
+L 208,298
+L 208,302
 L 300,302
-C 367,238 306,127 223,117
-C 142,106 7,188 62,358
-L 62,362
-C 96,466 126,581 222,603
-C 258,611 297,599 310,564
+L 299,210
+C 299,170 268,124 225,116
+C 140,101 110,273 121,360
+C 131,440 137,578 224,603
+C 258,614 299,598 310,565
 Z
 '
 transform='translate(2796,15812) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_dc2e4db2b037d468)'
+clip-path='url(#clip_618a75d8d54cd02e)'
 />
 <!-- H -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_91b5a542cf363595'>
+<rect x='-120' y='-420' width='711' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 1,662
+L 5,662
+L 5,58
+L 1,58
+L 1,662
+Z
+M 41,662
+L 45,662
+L 45,58
+L 41,58
+L 41,662
+Z
+M 81,662
+L 85,662
+L 85,58
+L 81,58
+L 81,662
+Z
+M 121,662
+L 125,662
+L 125,58
+L 121,58
+L 121,662
+Z
+M 58,298
+L 58,302
+L 362,302
+L 362,298
+L 58,298
+Z
+M 58,338
+L 58,342
+L 362,342
+L 362,338
+L 58,338
+Z
+M 58,378
+L 58,382
+L 362,382
+L 362,378
+L 58,378
+Z
+M 58,418
+L 58,422
+L 362,422
+L 362,418
+L 58,418
+Z
+M 301,662
+L 305,662
+L 305,58
+L 301,58
+L 301,662
+Z
+M 341,662
+L 345,662
+L 345,58
+L 341,58
+L 341,662
+Z
+M 381,662
+L 385,662
+L 385,58
+L 381,58
+L 381,662
+Z
+M 421,662
+L 425,662
+L 425,58
+L 421,58
+L 421,662
 Z
 '
 transform='translate(3262,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_91b5a542cf363595)'
 />
 <!-- I -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_22cf6cf594ef5434'>
+<rect x='-120' y='-420' width='648' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 58,598
+L 58,602
+L 362,602
+L 362,598
+L 58,598
+Z
+M 58,638
+L 58,642
+L 362,642
+L 362,638
+L 58,638
+Z
+M 58,678
+L 58,682
+L 362,682
+L 362,678
+L 58,678
+Z
+M 58,718
+L 58,722
+L 362,722
+L 362,718
+L 58,718
+Z
+M 151,662
+L 155,662
+L 155,58
+L 151,58
+L 151,662
+Z
+M 191,662
+L 195,662
+L 195,58
+L 191,58
+L 191,662
+Z
+M 231,662
+L 235,662
+L 235,58
+L 231,58
+L 231,662
+Z
+M 271,662
+L 275,662
+L 275,58
+L 271,58
+L 271,662
+Z
+M 58,-2
+L 58,2
+L 362,2
+L 362,-2
+L 58,-2
+Z
+M 58,38
+L 58,42
+L 362,42
+L 362,38
+L 58,38
+Z
+M 58,78
+L 58,82
+L 362,82
+L 362,78
+L 58,78
+Z
+M 58,118
+L 58,122
+L 362,122
+L 362,118
+L 58,118
 Z
 '
 transform='translate(3728,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_22cf6cf594ef5434)'
 />
 <!-- J -->
-<clipPath id='clip_77e34631c6c9e093'>
-<rect x='-120' y='-420' width='710' height='1190'/>
+<clipPath id='clip_44ab2f8858d85db0'>
+<rect x='-120' y='-420' width='711' height='1190'/>
 </clipPath>
 <path
 d='
 M 58,598
 L 58,602
 L 304,602
-L 196,117
-L 196,121
+L 305,360
+C 305,265 279,138 198,117
+C 163,107 122,122 105,156
+L 109,156
+C 122,125 159,110 197,121
+C 290,147 301,263 301,360
 L 300,598
 L 58,598
 Z
 M 58,638
 L 58,642
 L 344,642
-L 204,78
-L 204,82
+L 345,360
+C 345,239 313,103 207,78
+C 156,65 100,88 72,133
+L 76,133
+C 96,88 150,65 206,81
+C 319,115 341,257 341,360
 L 340,638
 L 58,638
 Z
 M 58,678
 L 58,682
 L 384,682
-L 213,38
-L 213,42
+L 385,360
+C 385,248 345,76 215,39
+C 149,19 72,45 39,111
+L 43,111
+C 70,51 141,20 214,42
+C 345,82 381,234 381,360
 L 380,678
 L 58,678
 Z
 M 58,718
 L 58,722
 L 424,722
-L 221,-1
-L 221,3
+L 425,360
+C 426,193 361,34 224,-1
+C 143,-21 57,15 6,88
+L 10,88
+C 49,16 137,-19 223,3
+C 368,42 421,209 421,360
 L 420,718
 L 58,718
 Z
 '
 transform='translate(4194,15812) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_77e34631c6c9e093)'
+clip-path='url(#clip_44ab2f8858d85db0)'
 />
 <!-- K -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
-</clipPath>
-<path
-d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
-Z
-'
-transform='translate(4660,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
-/>
-<!-- L -->
-<clipPath id='clip_e5b38142ba318bf7'>
-<rect x='-120' y='-420' width='411' height='1190'/>
+<clipPath id='clip_07567444ed3694c5'>
+<rect x='-120' y='-420' width='693' height='1190'/>
 </clipPath>
 <path
 d='
 M 1,662
 L 5,662
-L 4,-2
+L 5,58
+L 1,58
+L 1,662
+Z
+M 41,662
+L 45,662
+L 45,58
+L 41,58
+L 41,662
+Z
+M 81,662
+L 85,662
+L 85,58
+L 81,58
+L 81,662
+Z
+M 121,662
+L 125,662
+L 125,58
+L 121,58
+L 121,662
+Z
+M 318,704
+L 322,704
+L 22,400
+L 18,400
+L 318,704
+Z
+M 346,676
+L 350,676
+L 50,372
+L 46,372
+L 346,676
+Z
+M 374,648
+L 378,648
+L 78,344
+L 74,344
+L 374,648
+Z
+M 402,620
+L 407,620
+L 107,316
+L 102,316
+L 402,620
+Z
+M 18,320
+L 22,320
+L 322,16
+L 318,16
+L 18,320
+Z
+M 46,348
+L 50,348
+L 350,44
+L 346,44
+L 46,348
+Z
+M 74,376
+L 78,376
+L 378,72
+L 374,72
+L 74,376
+Z
+M 102,404
+L 107,404
+L 407,100
+L 402,100
+L 102,404
+Z
+'
+transform='translate(4660,15812) scale(1,-1)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_07567444ed3694c5)'
+/>
+<!-- L -->
+<clipPath id='clip_f14575d43962757a'>
+<rect x='-120' y='-420' width='648' height='1190'/>
+</clipPath>
+<path
+d='
+M 1,662
+L 5,662
+L 4,2
+L 362,2
+L 362,-2
 L 0,-2
 L 1,662
 Z
 M 41,662
 L 45,662
-L 44,38
+L 44,42
+L 362,42
+L 362,38
 L 40,38
 L 41,662
 Z
 M 81,662
 L 85,662
-L 84,78
+L 84,82
+L 362,82
+L 362,78
 L 80,78
 L 81,662
 Z
 M 121,662
 L 125,662
-L 124,118
+L 124,122
+L 362,122
+L 362,118
 L 120,118
 L 121,662
 Z
 '
 transform='translate(5126,15812) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_e5b38142ba318bf7)'
+clip-path='url(#clip_f14575d43962757a)'
 />
 <!-- M -->
-<clipPath id='clip_c2bb21e3c875c264'>
-<rect x='-120' y='-420' width='860' height='1190'/>
+<clipPath id='clip_6587b2703b7ec6fe'>
+<rect x='-120' y='-420' width='861' height='1190'/>
 </clipPath>
 <path
 d='
@@ -14213,7 +15883,9 @@ L 116,598
 L 5,598
 L 285,-105
 L 565,598
-L 450,598
+L 454,598
+L 455,58
+L 451,58
 L 450,602
 L 571,602
 L 287,-113
@@ -14228,7 +15900,9 @@ L 76,638
 L 45,638
 L 285,9
 L 525,638
-L 490,638
+L 494,638
+L 495,58
+L 491,58
 L 490,642
 L 531,642
 L 287,1
@@ -14244,7 +15918,9 @@ L 84,682
 L 285,123
 L 486,682
 L 534,682
-L 534,678
+L 535,58
+L 531,58
+L 530,678
 L 489,678
 L 287,115
 L 283,115
@@ -14259,7 +15935,9 @@ L 124,722
 L 285,237
 L 446,722
 L 574,722
-L 574,718
+L 575,58
+L 571,58
+L 570,718
 L 449,718
 L 287,229
 L 283,229
@@ -14270,10 +15948,10 @@ Z
 '
 transform='translate(5592,15812) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_c2bb21e3c875c264)'
+clip-path='url(#clip_6587b2703b7ec6fe)'
 />
 <!-- N -->
-<clipPath id='clip_82638db2e36c4d41'>
+<clipPath id='clip_c1b16659dc7c1b42'>
 <rect x='-120' y='-420' width='707' height='1190'/>
 </clipPath>
 <path
@@ -14282,6 +15960,9 @@ M 119,58
 L 115,58
 L 116,598
 L 6,598
+L 417,-186
+L 415,662
+L 419,662
 L 421,-196
 L 417,-196
 L 0,602
@@ -14292,6 +15973,9 @@ M 79,58
 L 75,58
 L 76,638
 L 45,638
+L 377,-16
+L 375,662
+L 379,662
 L 381,-27
 L 377,-27
 L 40,642
@@ -14302,6 +15986,9 @@ M 39,58
 L 35,58
 L 36,682
 L 83,682
+L 337,154
+L 335,662
+L 339,662
 L 341,143
 L 337,143
 L 81,678
@@ -14312,6 +15999,9 @@ M -1,58
 L -5,58
 L -4,722
 L 123,722
+L 297,324
+L 295,662
+L 299,662
 L 301,312
 L 297,312
 L 121,718
@@ -14321,315 +16011,515 @@ Z
 '
 transform='translate(6208,15812) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_82638db2e36c4d41)'
+clip-path='url(#clip_c1b16659dc7c1b42)'
 />
 <!-- O -->
-<clipPath id='clip_15d7478d1f4d6fa4'>
+<clipPath id='clip_eb9f8f3a49bfa3bd'>
 <rect x='-120' y='-420' width='711' height='1190'/>
 </clipPath>
 <path
 d='
-M 115,361
-C 159,431 117,602 209,602
-C 296,602 305,450 305,360
-C 306,268 299,144 211,118
-C 131,95 14,226 58,301
-C 73,327 98,338 115,361
+M 115,360
+C 99,449 113,602 210,602
+C 297,602 312,436 305,360
+C 297,270 301,135 210,118
+C 123,102 88,275 115,360
 Z
-M 62,299
-C 53,240 133,110 209,122
-C 292,135 291,284 301,360
-C 313,454 279,638 211,598
-C 141,558 177,417 119,359
-C 99,339 76,323 62,299
+M 210,122
+C 294,122 304,287 301,360
+C 298,430 305,590 210,598
+C 121,606 112,448 119,360
+C 126,268 99,122 210,122
 Z
-M 75,361
-C 129,448 106,642 209,642
-C 317,642 339,467 345,360
-C 351,252 319,66 211,78
-C 102,91 -14,256 58,341
-C 65,348 70,353 75,361
+M 75,360
+C 59,468 89,642 210,642
+C 315,642 348,448 345,360
+C 342,249 321,95 210,78
+C 90,60 45,257 75,360
 Z
-M 62,339
-C 53,243 133,79 209,82
-C 318,86 331,269 341,360
-C 352,459 305,634 211,638
-C 95,643 156,423 79,359
-C 71,352 66,346 62,339
+M 210,82
+C 311,82 346,265 341,360
+C 336,466 320,629 210,638
+C 99,647 75,460 79,360
+C 83,265 83,82 210,82
 Z
-M 38,359
-C 14,451 94,681 211,681
-C 335,682 414,458 385,361
-C 345,225 317,31 209,39
-C 90,47 145,453 61,378
-C 53,372 49,362 38,359
+M 35,360
+C 17,485 50,682 210,682
+C 348,682 395,487 385,360
+C 376,246 331,58 210,38
+C 70,15 11,248 35,360
 Z
-M 59,382
-C 230,354 91,46 211,41
-C 377,36 398,253 381,359
-C 364,465 346,707 209,679
-C 76,651 -59,350 36,361
-C 49,363 45,385 59,382
+M 210,42
+C 329,42 386,240 381,360
+C 376,480 331,668 210,678
+C 79,688 36,482 39,360
+C 43,216 72,42 210,42
 Z
-M -1,359
-C -43,462 75,721 211,721
-C 375,722 413,484 425,361
-C 436,241 365,-15 208,-1
-C 65,11 178,492 61,418
-C 35,402 30,366 -1,359
+M -5,360
+C -13,502 40,722 210,722
+C 357,722 430,489 425,360
+C 420,210 354,16 210,-2
+C 58,-21 -31,205 -5,360
 Z
-M 59,422
-C 285,377 92,12 212,1
-C 328,-9 391,230 421,359
-C 459,525 353,781 209,719
-C 34,643 -133,340 -5,361
-C 38,368 23,430 59,422
+M 210,2
+C 344,2 426,225 421,360
+C 415,498 358,698 210,718
+C 43,741 -9,504 -1,360
+C 8,214 46,2 210,2
 Z
 '
 transform='translate(6674,15812) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_15d7478d1f4d6fa4)'
+clip-path='url(#clip_eb9f8f3a49bfa3bd)'
 />
 <!-- P -->
-<clipPath id='clip_2e8032270b8c6bfd'>
-<rect x='-120' y='-420' width='709' height='1190'/>
+<clipPath id='clip_b4495f074f9eac53'>
+<rect x='-120' y='-420' width='711' height='1190'/>
 </clipPath>
 <path
 d='
 M 119,58
 L 115,58
-L 116,598
-C 126,599 410,616 305,511
-L 304,510
-L 59,418
-L 59,422
-L 302,510
-L 301,511
-C 249,563 181,588 120,602
+L 115,631
+C 209,651 300,598 305,510
+C 311,407 185,354 92,406
+L 92,410
+C 179,379 286,421 301,510
+C 317,606 207,680 119,629
 L 119,58
 Z
 M 79,58
 L 75,58
-L 76,638
-C 93,639 495,661 345,511
-L 344,510
-L 59,378
-L 59,382
-L 342,510
-L 341,511
-C 266,586 167,622 80,642
+L 75,651
+C 198,692 343,627 345,510
+C 348,388 180,345 68,374
+L 68,378
+C 189,340 328,395 341,510
+C 355,636 189,727 79,649
 L 79,58
 Z
 M 39,58
 L 35,58
-L 55,660
-C 74,637 379,255 383,509
-L 383,510
-L 59,338
-L 59,342
-L 362,508
-L 362,512
-L 383,513
-C 543,521 510,917 59,662
+L 35,671
+C 180,719 362,649 385,510
+C 412,348 201,204 44,342
+L 44,346
+C 179,302 373,365 381,510
+C 389,661 181,720 39,669
 L 39,58
 Z
 M -1,58
 L -5,58
-L 55,662
-C 64,650 403,230 423,509
-L 423,510
-L 59,298
-L 59,302
-L 362,508
-L 362,512
-L 423,513
-C 51010,1342 11759,56461 59,660
+L -5,691
+C 193,776 412,680 425,510
+C 439,326 190,245 20,310
+L 20,314
+C 208,269 415,346 421,510
+C 427,686 173,740 -1,689
 L -1,58
 Z
 '
 transform='translate(7140,15812) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_2e8032270b8c6bfd)'
+clip-path='url(#clip_b4495f074f9eac53)'
 />
 <!-- Q -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_c9634850eeaed452'>
+<rect x='-120' y='-420' width='711' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 115,360
+C 99,449 113,602 210,602
+C 297,602 312,436 305,360
+C 297,270 301,135 210,118
+C 123,102 88,275 115,360
+Z
+M 210,122
+C 294,122 304,287 301,360
+C 298,430 305,590 210,598
+C 121,606 112,448 119,360
+C 126,268 99,122 210,122
+Z
+M 75,360
+C 59,468 89,642 210,642
+C 315,642 348,448 345,360
+C 342,249 321,95 210,78
+C 90,60 45,257 75,360
+Z
+M 210,82
+C 311,82 346,265 341,360
+C 336,466 320,629 210,638
+C 99,647 75,460 79,360
+C 83,265 83,82 210,82
+Z
+M 35,360
+C 17,485 50,682 210,682
+C 348,682 395,487 385,360
+C 376,246 331,58 210,38
+C 70,15 11,248 35,360
+Z
+M 210,42
+C 329,42 386,240 381,360
+C 376,480 331,668 210,678
+C 79,688 36,482 39,360
+C 43,216 72,42 210,42
+Z
+M -5,360
+C -13,502 40,722 210,722
+C 357,722 430,489 425,360
+C 420,210 354,16 210,-2
+C 58,-21 -31,205 -5,360
+Z
+M 210,2
+C 344,2 426,225 421,360
+C 415,498 358,698 210,718
+C 43,741 -9,504 -1,360
+C 8,214 46,2 210,2
+Z
+M 402,100
+L 398,100
+L 248,254
+L 252,254
+L 402,100
+Z
+M 374,72
+L 370,72
+L 220,226
+L 224,226
+L 374,72
+Z
+M 346,44
+L 342,44
+L 192,198
+L 196,198
+L 346,44
+Z
+M 318,16
+L 313,16
+L 163,170
+L 168,170
+L 318,16
 Z
 '
 transform='translate(7606,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_c9634850eeaed452)'
 />
 <!-- R -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_3e1437fea209d39f'>
+<rect x='-120' y='-420' width='710' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 119,58
+L 115,58
+L 115,636
+C 220,671 316,600 306,518
+C 296,442 205,418 135,418
+L 58,418
+L 58,422
+L 135,422
+C 195,422 293,441 302,519
+C 311,610 179,624 119,634
+L 119,58
+Z
+M 79,58
+L 75,58
+L 75,653
+C 204,703 354,630 345,512
+C 339,419 236,378 135,378
+L 58,378
+L 58,382
+L 135,382
+C 215,382 323,421 341,513
+C 369,659 182,680 79,651
+L 79,58
+Z
+M 39,58
+L 35,58
+L 35,669
+C 210,738 390,652 385,507
+C 381,393 260,338 135,338
+L 58,338
+L 58,342
+L 135,342
+C 234,342 375,386 381,507
+C 387,659 164,666 39,668
+L 39,58
+Z
+M -1,58
+L -5,58
+L -5,686
+C 194,756 426,676 424,501
+C 424,372 292,298 135,298
+L 58,298
+L 58,302
+L 135,302
+C 260,302 406,364 420,502
+C 441,693 154,730 -1,684
+L -1,58
+Z
+M 157,335
+L 161,335
+L 311,31
+L 307,31
+L 157,335
+Z
+M 193,353
+L 197,353
+L 347,49
+L 343,49
+L 193,353
+Z
+M 229,371
+L 233,371
+L 383,67
+L 379,67
+L 229,371
+Z
+M 264,389
+L 268,389
+L 418,85
+L 414,85
+L 264,389
 Z
 '
 transform='translate(8072,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_3e1437fea209d39f)'
 />
 <!-- S -->
-<clipPath id='clip_a8bfa21e5cd9dce7'>
+<clipPath id='clip_c6919a17a56512d1'>
 <rect x='-120' y='-420' width='705' height='1190'/>
 </clipPath>
 <path
 d='
 M 419,513
 L 415,513
-C 424,609 316,724 215,718
-C 97,711 -28,541 11,433
-C 39,357 120,342 191,305
-C 231,285 283,277 312,233
-C 339,191 264,136 213,118
-L 213,122
-C 261,121 319,187 308,231
-C 296,276 236,290 190,302
-C 120,319 27,361 8,431
-C -23,542 93,713 215,722
-C 310,729 426,608 419,513
+C 405,615 308,733 215,718
+C 97,698 -30,548 11,433
+C 37,360 126,344 191,305
+C 235,279 285,274 312,233
+C 338,191 265,119 215,118
+C 167,117 113,170 115,217
+L 119,217
+C 122,170 171,120 215,122
+C 263,124 322,186 308,231
+C 294,274 236,294 190,302
+C 117,313 25,359 8,431
+C -19,545 105,714 215,722
+C 311,729 427,609 419,513
 Z
 M 379,510
 L 375,510
-C 383,588 304,680 211,678
-C 116,676 8,537 47,452
-C 74,391 144,377 205,343
-C 259,313 307,298 347,252
-C 396,194 285,70 209,78
-L 209,82
-C 283,86 363,184 343,250
-C 327,304 257,331 204,339
-C 137,350 62,390 43,450
-C 15,541 123,676 212,682
-C 290,687 384,587 379,510
+C 379,591 292,689 211,678
+C 109,663 22,541 47,452
+C 65,388 148,376 205,343
+C 256,314 319,296 347,252
+C 387,188 286,82 211,78
+C 142,74 72,147 75,214
+L 79,214
+C 82,148 150,78 212,82
+C 279,86 364,182 343,250
+C 327,302 258,331 204,339
+C 139,349 61,387 43,450
+C 18,538 118,676 212,682
+C 291,687 380,589 379,510
 Z
 M 339,506
 L 335,506
-C 341,573 276,635 208,638
-C 130,642 36,533 82,470
-C 111,432 166,411 218,381
-C 282,344 348,333 382,270
-C 429,184 299,51 206,38
-L 206,42
-C 297,51 400,183 378,268
-C 363,332 279,365 217,377
-C 163,388 99,417 78,468
-C 53,533 139,637 208,642
-C 269,646 353,566 339,506
+C 340,573 271,642 208,638
+C 139,634 43,529 82,470
+C 115,421 171,409 218,381
+C 271,350 359,337 382,270
+C 413,181 307,42 208,38
+C 123,35 32,125 35,210
+L 39,210
+C 44,133 124,36 208,42
+C 299,48 401,181 378,268
+C 362,331 280,367 217,377
+C 162,386 97,416 78,468
+C 55,536 137,638 208,642
+C 270,646 342,567 339,506
 Z
 M 299,503
 L 295,503
-C 301,549 253,599 204,598
-C 155,598 98,531 118,489
-C 140,441 183,440 232,418
-C 295,390 386,360 418,289
-C 469,174 315,30 202,-2
-L 202,2
-C 316,16 441,180 414,287
-C 395,361 304,394 230,415
-C 186,427 128,443 114,487
-C 99,533 156,600 204,602
-C 250,604 307,547 299,503
+C 299,549 252,598 204,598
+C 155,598 95,530 118,489
+C 141,446 195,438 232,418
+C 302,381 393,365 418,289
+C 455,174 326,14 204,-2
+C 102,-15 -7,105 -5,207
+L -1,207
+C -6,110 104,-5 204,2
+C 319,11 440,173 414,287
+C 398,358 302,396 230,415
+C 186,426 127,443 114,487
+C 100,532 156,600 204,602
+C 250,604 302,548 299,503
 Z
 '
 transform='translate(8538,15812) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_a8bfa21e5cd9dce7)'
+clip-path='url(#clip_c6919a17a56512d1)'
 />
 <!-- T -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_0bef90fe1e94948b'>
+<rect x='-120' y='-420' width='648' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 58,598
+L 58,602
+L 362,602
+L 362,598
+L 58,598
+Z
+M 58,638
+L 58,642
+L 362,642
+L 362,638
+L 58,638
+Z
+M 58,678
+L 58,682
+L 362,682
+L 362,678
+L 58,678
+Z
+M 58,718
+L 58,722
+L 362,722
+L 362,718
+L 58,718
+Z
+M 151,662
+L 155,662
+L 155,58
+L 151,58
+L 151,662
+Z
+M 191,662
+L 195,662
+L 195,58
+L 191,58
+L 191,662
+Z
+M 231,662
+L 235,662
+L 235,58
+L 231,58
+L 231,662
+Z
+M 271,662
+L 275,662
+L 275,58
+L 271,58
+L 271,662
 Z
 '
 transform='translate(9004,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_0bef90fe1e94948b)'
 />
 <!-- U -->
-<clipPath id='clip_11c0332b5a7ec844'>
-<rect x='-120' y='-420' width='498' height='1190'/>
+<clipPath id='clip_002f191da8deb3a8'>
+<rect x='-120' y='-420' width='705' height='1190'/>
 </clipPath>
 <path
 d='
 M 1,662
 L 5,662
-L 212,2
-L 212,-2
+L 5,360
+C 5,225 38,2 210,2
+C 278,2 415,55 415,360
+L 415,662
+L 419,662
+L 419,360
+C 419,266 404,5 210,-2
+C 119,-5 1,70 1,360
 L 1,662
 Z
 M 41,662
 L 45,662
-L 212,42
-L 212,38
+L 45,360
+C 45,170 99,42 210,42
+C 261,42 375,80 375,360
+L 375,662
+L 379,662
+L 379,360
+C 379,237 351,48 210,38
+C 84,29 41,194 41,360
 L 41,662
 Z
 M 81,662
 L 85,662
-L 212,82
-L 212,78
+L 85,360
+C 85,254 92,82 210,82
+C 256,82 335,119 335,360
+L 335,662
+L 339,662
+L 339,360
+C 339,285 335,94 210,78
+C 68,60 81,301 81,360
 L 81,662
 Z
 M 121,662
 L 125,662
-L 212,122
-L 212,118
+L 125,360
+C 125,271 103,122 210,122
+C 308,122 295,320 295,360
+L 295,662
+L 299,662
+L 299,360
+C 299,271 308,129 210,118
+C 99,106 121,305 121,360
 L 121,662
 Z
 '
 transform='translate(9470,15812) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_11c0332b5a7ec844)'
+clip-path='url(#clip_002f191da8deb3a8)'
 />
 <!-- V -->
-<clipPath id='clip_454fd74fdf1cc480'>
-<rect x='-120' y='-420' width='498' height='1190'/>
+<clipPath id='clip_be0b33b20cdc7a0a'>
+<rect x='-120' y='-420' width='703' height='1190'/>
 </clipPath>
 <path
 d='
 M 3,647
 L 7,647
+L 210,-179
+L 413,647
+L 417,647
 L 212,-189
 L 208,-189
 L 3,647
 Z
 M 41,657
 L 46,657
+L 210,-14
+L 374,657
+L 379,657
 L 212,-24
 L 208,-24
 L 41,657
 Z
 M 80,667
 L 84,667
+L 210,151
+L 336,667
+L 340,667
 L 212,140
 L 208,140
 L 80,667
 Z
 M 119,677
 L 123,677
+L 210,316
+L 297,677
+L 301,677
 L 212,305
 L 208,305
 L 119,677
@@ -14637,11 +16527,11 @@ Z
 '
 transform='translate(9936,15812) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_454fd74fdf1cc480)'
+clip-path='url(#clip_be0b33b20cdc7a0a)'
 />
 <!-- W -->
-<clipPath id='clip_45a387bd3b19421d'>
-<rect x='-120' y='-420' width='686' height='1190'/>
+<clipPath id='clip_cfaa940e2b5fbbea'>
+<rect x='-120' y='-420' width='854' height='1190'/>
 </clipPath>
 <path
 d='
@@ -14650,6 +16540,9 @@ L 6,651
 L 173,-255
 L 340,598
 L 230,598
+L 397,-255
+L 564,651
+L 568,651
 L 400,-268
 L 395,-268
 L 225,602
@@ -14663,6 +16556,9 @@ L 45,658
 L 173,-38
 L 300,638
 L 270,638
+L 397,-38
+L 525,658
+L 529,658
 L 400,-51
 L 395,-51
 L 265,642
@@ -14676,6 +16572,9 @@ L 85,666
 L 172,180
 L 261,682
 L 309,682
+L 398,180
+L 485,666
+L 489,666
 L 400,167
 L 395,167
 L 305,678
@@ -14689,6 +16588,9 @@ L 124,673
 L 172,398
 L 221,722
 L 349,722
+L 398,398
+L 446,673
+L 450,673
 L 400,384
 L 395,384
 L 345,718
@@ -14700,84 +16602,197 @@ Z
 '
 transform='translate(10402,15812) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_45a387bd3b19421d)'
+clip-path='url(#clip_cfaa940e2b5fbbea)'
 />
 <!-- X -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_d48d53d447525970'>
+<rect x='-120' y='-420' width='704' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 7,635
+L 11,635
+L 311,31
+L 307,31
+L 7,635
+Z
+M 43,653
+L 47,653
+L 347,49
+L 343,49
+L 43,653
+Z
+M 79,671
+L 83,671
+L 383,67
+L 379,67
+L 79,671
+Z
+M 114,689
+L 118,689
+L 418,85
+L 414,85
+L 114,689
+Z
+M 307,689
+L 311,689
+L 11,85
+L 7,85
+L 307,689
+Z
+M 343,671
+L 347,671
+L 47,67
+L 43,67
+L 343,671
+Z
+M 379,653
+L 383,653
+L 83,49
+L 79,49
+L 379,653
+Z
+M 414,635
+L 418,635
+L 118,31
+L 114,31
+L 414,635
 Z
 '
 transform='translate(11018,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_d48d53d447525970)'
 />
 <!-- Y -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_089e25990a2b69df'>
+<rect x='-120' y='-420' width='699' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 7,635
+L 11,635
+L 210,230
+L 409,635
+L 413,635
+L 212,224
+L 208,224
+L 7,635
+Z
+M 43,653
+L 47,653
+L 210,320
+L 373,653
+L 377,653
+L 212,313
+L 208,313
+L 43,653
+Z
+M 79,671
+L 83,671
+L 210,409
+L 337,671
+L 341,671
+L 212,403
+L 208,403
+L 79,671
+Z
+M 114,689
+L 118,689
+L 210,499
+L 302,689
+L 306,689
+L 212,492
+L 208,492
+L 114,689
+Z
+M 151,362
+L 155,362
+L 155,58
+L 151,58
+L 151,362
+Z
+M 191,362
+L 195,362
+L 195,58
+L 191,58
+L 191,362
+Z
+M 231,362
+L 235,362
+L 235,58
+L 231,58
+L 231,362
+Z
+M 271,362
+L 275,362
+L 275,58
+L 271,58
+L 271,362
 Z
 '
 transform='translate(11484,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_089e25990a2b69df)'
 />
 <!-- Z -->
-<clipPath id='clip_3580d66b8f90670c'>
-<rect x='-120' y='-420' width='711' height='1190'/>
+<clipPath id='clip_7932d8bc7a3c9446'>
+<rect x='-120' y='-420' width='708' height='1190'/>
 </clipPath>
 <path
 d='
 M 58,598
 L 58,602
+L 302,600
 L 304,602
-L -32,-2
+L -31,2
+L 362,2
+L 362,-2
 L -37,-2
-L 299,598
+L -37,-2
+L 302,600
+L 302,600
 L 58,598
 Z
 M 58,638
 L 58,642
+L 342,640
 L 344,642
-L 32,38
+L 34,42
+L 362,42
+L 362,38
 L 28,38
-L 339,638
+L 342,640
+L 342,640
 L 58,638
 Z
 M 58,678
 L 58,682
+L 382,680
 L 384,682
-L 97,78
+L 98,82
+L 362,82
+L 362,78
 L 93,78
-L 379,678
+L 382,680
+L 382,680
 L 58,678
 Z
 M 58,718
 L 58,722
-L 425,722
-L 162,118
-L 158,118
-L 419,718
+L 422,720
+L 422,720
+L 163,122
+L 362,122
+L 362,118
+L 156,118
+L 422,720
+L 422,720
 L 58,718
 Z
 '
 transform='translate(11950,15812) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_3580d66b8f90670c)'
+clip-path='url(#clip_7932d8bc7a3c9446)'
 />
 <!--   -->
 <clipPath id='clip_e3b0c44298fc1c14'>
@@ -14791,320 +16806,944 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_e3b0c44298fc1c14)'
 />
 <!-- ! -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_bf9e69b2d39a0f61'>
+<rect x='-120' y='-420' width='411' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 1,662
+L 5,662
+L 5,208
+L 1,208
+L 1,662
+Z
+M 41,662
+L 45,662
+L 45,208
+L 41,208
+L 41,662
+Z
+M 81,662
+L 85,662
+L 85,208
+L 81,208
+L 81,662
+Z
+M 121,662
+L 125,662
+L 125,208
+L 121,208
+L 121,662
+Z
+M 60,2
+C 90,2 117,29 118,60
+C 118,93 91,118 60,118
+C 30,118 1,93 2,60
+C 3,30 26,2 60,2
+Z
+M -2,60
+C 0,91 26,122 60,122
+C 91,122 121,90 122,60
+C 123,29 93,-2 60,-2
+C 25,-2 -0,27 -2,60
+Z
+M 60,32
+C 75,32 88,45 88,60
+C 88,75 76,88 60,88
+C 45,88 32,76 32,60
+C 32,45 44,32 60,32
+Z
+M 28,60
+C 28,76 42,92 60,92
+C 77,92 92,75 92,60
+C 92,42 77,28 60,28
+C 44,28 28,44 28,60
 Z
 '
 transform='translate(12732,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_bf9e69b2d39a0f61)'
 />
 <!-- " -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_7373937b86b88a3a'>
+<rect x='-120' y='-420' width='611' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 101,722
+L 105,722
+L 105,558
+L 101,558
+L 101,722
+Z
+M 141,722
+L 145,722
+L 145,558
+L 141,558
+L 141,722
+Z
+M 181,722
+L 185,722
+L 185,558
+L 181,558
+L 181,722
+Z
+M 221,722
+L 225,722
+L 225,558
+L 221,558
+L 221,722
+Z
+M 201,722
+L 205,722
+L 205,558
+L 201,558
+L 201,722
+Z
+M 241,722
+L 245,722
+L 245,558
+L 241,558
+L 241,722
+Z
+M 281,722
+L 285,722
+L 285,558
+L 281,558
+L 281,722
+Z
+M 321,722
+L 325,722
+L 325,558
+L 321,558
+L 321,722
 Z
 '
 transform='translate(12898,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_7373937b86b88a3a)'
 />
 <!-- # -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_fa13e6ff16263172'>
+<rect x='-120' y='-420' width='648' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 58,398
+L 58,402
+L 362,402
+L 362,398
+L 58,398
+Z
+M 58,438
+L 58,442
+L 362,442
+L 362,438
+L 58,438
+Z
+M 58,478
+L 58,482
+L 362,482
+L 362,478
+L 58,478
+Z
+M 58,518
+L 58,522
+L 362,522
+L 362,518
+L 58,518
+Z
+M 58,198
+L 58,202
+L 362,202
+L 362,198
+L 58,198
+Z
+M 58,238
+L 58,242
+L 362,242
+L 362,238
+L 58,238
+Z
+M 58,278
+L 58,282
+L 362,282
+L 362,278
+L 58,278
+Z
+M 58,318
+L 58,322
+L 362,322
+L 362,318
+L 58,318
+Z
+M 101,662
+L 105,662
+L 105,58
+L 101,58
+L 101,662
+Z
+M 141,662
+L 145,662
+L 145,58
+L 141,58
+L 141,662
+Z
+M 181,662
+L 185,662
+L 185,58
+L 181,58
+L 181,662
+Z
+M 221,662
+L 225,662
+L 225,58
+L 221,58
+L 221,662
+Z
+M 201,662
+L 205,662
+L 205,58
+L 201,58
+L 201,662
+Z
+M 241,662
+L 245,662
+L 245,58
+L 241,58
+L 241,662
+Z
+M 281,662
+L 285,662
+L 285,58
+L 281,58
+L 281,662
+Z
+M 321,662
+L 325,662
+L 325,58
+L 321,58
+L 321,662
 Z
 '
 transform='translate(13264,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_fa13e6ff16263172)'
 />
 <!-- £ -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_5a4b3ee2cc6ad528'>
+<rect x='-120' y='-420' width='687' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 401,646
+L 401,642
+C 360,702 274,720 211,718
+C 109,715 3,632 5,540
+C 6,480 44,448 61,393
+C 103,262 4,117 -69,2
+L 362,2
+L 362,-2
+L -79,-2
+L -79,2
+C 1,100 109,251 58,391
+C 39,443 3,483 1,539
+C -2,618 123,708 211,722
+C 276,733 347,698 401,646
+Z
+M 374,617
+L 374,613
+C 334,660 269,689 210,678
+C 138,664 50,612 45,540
+C 42,490 78,457 97,412
+C 144,294 68,161 22,42
+L 362,42
+L 362,38
+L 14,38
+L 14,42
+C 71,134 148,283 93,410
+C 74,455 42,490 41,540
+C 39,607 141,672 210,682
+C 266,690 328,663 374,617
+Z
+M 346,587
+L 346,583
+C 320,630 259,644 210,638
+C 152,631 92,591 85,540
+C 79,499 111,470 132,430
+C 189,327 118,197 113,82
+L 362,82
+L 362,78
+L 107,78
+C 143,197 176,327 129,428
+C 111,466 78,499 81,540
+C 84,591 159,635 210,642
+C 256,648 311,627 346,587
+Z
+M 319,558
+L 319,554
+C 292,583 251,599 209,598
+C 174,597 133,575 125,540
+C 117,506 144,476 168,449
+C 240,366 219,235 205,122
+L 362,122
+L 362,118
+L 199,118
+C 201,231 220,360 164,447
+C 145,477 115,506 121,541
+C 127,574 176,598 209,602
+C 248,606 295,589 319,558
+Z
+M 58,358
+L 58,362
+L 287,362
+L 287,358
+L 58,358
+Z
+M 58,398
+L 58,402
+L 287,402
+L 287,398
+L 58,398
+Z
+M 58,438
+L 58,442
+L 287,442
+L 287,438
+L 58,438
+Z
+M 58,478
+L 58,482
+L 287,482
+L 287,478
+L 58,478
 Z
 '
 transform='translate(13730,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_5a4b3ee2cc6ad528)'
 />
 <!-- $ -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_fdd131275fdd3afd'>
+<rect x='-120' y='-420' width='705' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 419,513
+L 415,513
+C 405,615 308,733 215,718
+C 97,698 -30,548 11,433
+C 37,360 126,344 191,305
+C 235,279 285,274 312,233
+C 338,191 265,119 215,118
+C 167,117 113,170 115,217
+L 119,217
+C 122,170 171,120 215,122
+C 263,124 322,186 308,231
+C 294,274 236,294 190,302
+C 117,313 25,359 8,431
+C -19,545 105,714 215,722
+C 311,729 427,609 419,513
+Z
+M 379,510
+L 375,510
+C 379,591 292,689 211,678
+C 109,663 22,541 47,452
+C 65,388 148,376 205,343
+C 256,314 319,296 347,252
+C 387,188 286,82 211,78
+C 142,74 72,147 75,214
+L 79,214
+C 82,148 150,78 212,82
+C 279,86 364,182 343,250
+C 327,302 258,331 204,339
+C 139,349 61,387 43,450
+C 18,538 118,676 212,682
+C 291,687 380,589 379,510
+Z
+M 339,506
+L 335,506
+C 340,573 271,642 208,638
+C 139,634 43,529 82,470
+C 115,421 171,409 218,381
+C 271,350 359,337 382,270
+C 413,181 307,42 208,38
+C 123,35 32,125 35,210
+L 39,210
+C 44,133 124,36 208,42
+C 299,48 401,181 378,268
+C 362,331 280,367 217,377
+C 162,386 97,416 78,468
+C 55,536 137,638 208,642
+C 270,646 342,567 339,506
+Z
+M 299,503
+L 295,503
+C 299,549 252,598 204,598
+C 155,598 95,530 118,489
+C 141,446 195,438 232,418
+C 302,381 393,365 418,289
+C 455,174 326,14 204,-2
+C 102,-15 -7,105 -5,207
+L -1,207
+C -6,110 104,-5 204,2
+C 319,11 440,173 414,287
+C 398,358 302,396 230,415
+C 186,426 127,443 114,487
+C 100,532 156,600 204,602
+C 250,604 302,548 299,503
+Z
+M 151,722
+L 155,722
+L 155,-2
+L 151,-2
+L 151,722
+Z
+M 191,722
+L 195,722
+L 195,-2
+L 191,-2
+L 191,722
+Z
+M 231,722
+L 235,722
+L 235,-2
+L 231,-2
+L 231,722
+Z
+M 271,722
+L 275,722
+L 275,-2
+L 271,-2
+L 271,722
 Z
 '
 transform='translate(14196,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_fdd131275fdd3afd)'
 />
 <!-- % -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_732d4d95a40de362'>
+<rect x='-120' y='-420' width='706' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 97,716
+C 63,633 33,540 97,504
+C 117,492 132,495 148,504
+C 209,537 161,672 97,716
+Z
+M 149,500
+C 132,494 114,494 96,500
+C 28,523 16,711 96,720
+C 170,729 204,547 149,500
+Z
+M 106,677
+C 82,628 68,565 106,543
+C 119,535 128,537 139,543
+C 177,562 155,647 106,677
+Z
+M 140,539
+C 128,535 117,534 105,539
+C 61,554 55,675 105,681
+C 153,687 179,563 140,539
+Z
+M 116,639
+C 103,619 99,591 116,581
+C 121,578 125,579 129,581
+C 146,591 133,626 116,639
+Z
+M 130,577
+C 123,576 120,576 115,577
+C 97,582 89,641 115,643
+C 140,644 144,593 130,577
+Z
+M 125,604
+C 129,604 128,615 125,616
+C 123,617 122,617 120,616
+C 116,614 120,603 125,604
+Z
+M 119,620
+C 121,621 123,621 126,620
+C 133,617 133,602 126,600
+C 118,597 115,616 119,620
+Z
+M 323,4
+C 396,13 387,193 323,216
+C 308,222 289,223 272,216
+C 208,192 248,-5 323,4
+Z
+M 271,220
+C 292,227 299,229 324,220
+C 406,193 427,12 324,-0
+C 219,-12 215,171 271,220
+Z
+M 314,43
+C 360,48 354,163 314,177
+C 304,181 293,181 281,177
+C 240,163 266,37 314,43
+Z
+M 280,181
+C 293,186 299,187 315,181
+C 367,163 382,42 315,39
+C 248,35 243,147 280,181
+Z
+M 304,81
+C 324,84 320,133 304,139
+C 300,140 295,140 291,139
+C 276,133 284,79 304,81
+Z
+M 290,143
+C 297,144 299,144 305,143
+C 327,137 333,77 305,77
+C 278,78 274,119 290,143
+Z
+M 295,116
+C 293,112 292,106 295,104
+C 297,103 298,103 300,104
+C 304,106 300,114 295,116
+Z
+M 301,100
+C 299,99 296,99 294,100
+C 288,102 287,119 294,120
+C 302,121 305,106 301,100
+Z
+M 305,745
+L 309,745
+L 9,21
+L 5,21
+L 305,745
+Z
+M 342,730
+L 346,730
+L 46,6
+L 42,6
+L 342,730
+Z
+M 379,714
+L 383,714
+L 83,-10
+L 79,-10
+L 379,714
+Z
+M 416,699
+L 420,699
+L 120,-25
+L 116,-25
+L 416,699
 Z
 '
 transform='translate(14662,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_732d4d95a40de362)'
 />
 <!-- & -->
-<clipPath id='clip_fffa79ff2cb5ae7b'>
+<clipPath id='clip_d9d2306918e57f68'>
 <rect x='-120' y='-420' width='711' height='1190'/>
 </clipPath>
 <path
 d='
-M 301,212
-L 305,212
-C 303,166 262,121 216,118
-C 169,114 122,160 115,205
-C 96,331 298,384 340,506
-C 368,587 254,678 173,716
-L 173,720
-C 259,700 358,592 344,505
-C 326,392 108,327 119,206
-C 123,159 172,119 216,122
-C 264,124 299,169 301,212
+M 301,215
+L 305,215
+C 302,169 253,118 207,118
+C 162,118 122,159 114,202
+C 93,327 293,387 340,506
+C 372,590 264,711 174,716
+C 78,721 -41,562 14,478
+L 315,25
+L 311,25
+L 11,476
+C -48,563 80,717 175,720
+C 268,723 366,593 344,505
+C 315,391 109,326 119,202
+C 122,161 164,121 207,122
+C 252,123 292,171 301,215
 Z
-M 341,212
-L 345,212
-C 344,147 279,79 212,78
-C 147,76 78,141 75,209
-C 68,339 275,382 300,509
-C 314,580 230,647 162,677
-L 162,681
-C 239,664 308,582 304,508
-C 297,392 91,334 79,209
-C 73,148 149,81 212,82
-C 283,83 338,152 341,212
+M 341,213
+L 345,213
+C 346,147 274,78 209,78
+C 146,78 77,143 75,207
+C 70,335 257,389 300,509
+C 325,579 239,678 164,677
+C 87,676 6,563 48,500
+L 348,47
+L 344,47
+L 44,498
+C 2,562 88,678 165,681
+C 255,685 318,579 304,508
+C 283,402 86,330 79,207
+C 76,145 148,82 209,82
+C 273,82 334,153 341,213
 Z
-M 381,212
-L 385,212
-C 392,123 294,34 207,38
-C 124,42 29,131 35,212
-C 45,344 250,381 260,512
-C 264,567 207,618 152,639
-L 152,643
-C 213,631 264,568 264,512
-C 265,385 64,337 39,211
-C 24,138 128,43 208,42
-C 288,42 382,132 381,212
+M 381,211
+L 385,211
+C 385,129 295,40 211,38
+C 128,36 31,132 35,213
+C 41,344 234,389 260,511
+C 272,567 210,642 154,639
+C 105,636 54,563 81,522
+L 381,69
+L 377,69
+L 77,520
+C 48,565 102,639 155,643
+C 218,647 271,566 264,511
+C 250,394 65,337 39,212
+C 24,139 128,42 211,42
+C 295,42 371,146 381,211
 Z
-M 421,212
-L 425,212
-C 425,103 310,-3 203,-2
-C 102,-0 -27,117 -5,215
-C 23,340 230,390 220,515
-C 217,556 181,591 142,600
-L 142,604
-C 182,599 218,559 224,515
-C 243,376 35,331 -1,214
-C -30,119 109,4 203,2
-C 299,1 422,113 421,212
+M 421,209
+L 425,209
+C 421,111 316,1 214,-2
+C 109,-5 -26,121 -4,219
+C 24,344 215,388 220,514
+C 222,553 182,609 143,600
+C 121,595 102,563 114,544
+L 414,91
+L 410,91
+L 111,542
+C 95,565 116,601 144,604
+C 182,609 223,554 224,514
+C 227,388 26,354 -0,217
+C -19,124 123,2 213,2
+C 301,2 427,135 421,209
 Z
 '
 transform='translate(15128,15812) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_fffa79ff2cb5ae7b)'
+clip-path='url(#clip_d9d2306918e57f68)'
 />
 <!-- ' -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_bcffe3fe32914ef2'>
+<rect x='-120' y='-420' width='411' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 1,722
+L 5,722
+L 5,558
+L 1,558
+L 1,722
+Z
+M 41,722
+L 45,722
+L 45,558
+L 41,558
+L 41,722
+Z
+M 81,722
+L 85,722
+L 85,558
+L 81,558
+L 81,722
+Z
+M 121,722
+L 125,722
+L 125,558
+L 121,558
+L 121,722
 Z
 '
 transform='translate(15594,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_bcffe3fe32914ef2)'
 />
 <!-- ( -->
-<clipPath id='clip_164f04ecf8ba6952'>
+<clipPath id='clip_5e7a1a228e62fea5'>
 <rect x='-120' y='-420' width='481' height='1190'/>
 </clipPath>
 <path
 d='
 M 81,746
 L 85,746
-L 5,358
-L 1,358
-L 81,746
+C 32,624 5,493 5,360
+C 5,227 32,96 85,-26
+L 81,-26
+C 28,96 1,227 1,360
+C 1,493 28,624 81,746
 Z
 M 117,730
 L 121,730
-L 45,358
-L 41,358
-L 117,730
+C 71,613 45,487 45,360
+C 45,233 71,107 121,-10
+L 117,-10
+C 67,107 41,233 41,360
+C 41,487 67,613 117,730
 Z
 M 154,714
 L 158,714
-L 85,358
-L 81,358
-L 154,714
+C 110,602 85,482 85,360
+C 85,238 110,118 158,6
+L 154,6
+C 106,118 81,238 81,360
+C 81,482 105,602 154,714
 Z
 M 191,698
 L 195,698
-L 125,358
-L 121,358
-L 191,698
+C 149,591 125,476 125,360
+C 125,244 149,129 195,22
+L 191,22
+C 145,129 121,244 121,360
+C 121,476 144,591 191,698
 Z
 '
 transform='translate(15760,15812) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_164f04ecf8ba6952)'
+clip-path='url(#clip_5e7a1a228e62fea5)'
 />
 <!-- ) -->
-<clipPath id='clip_568f565c0ed9ca5f'>
+<clipPath id='clip_12b276e41f87d348'>
 <rect x='-120' y='-420' width='486' height='1190'/>
 </clipPath>
 <path
 d='
 M 6,698
 L 10,698
-L 80,358
-L 76,358
-L 6,698
+C 56,591 80,476 80,360
+C 80,244 56,129 10,22
+L 6,22
+C 52,129 76,244 76,360
+C 76,476 52,591 6,698
 Z
 M 42,714
 L 46,714
-L 120,358
-L 116,358
-L 42,714
+C 95,602 120,482 120,360
+C 120,238 95,118 46,6
+L 42,6
+C 91,118 116,238 116,360
+C 116,482 91,602 42,714
 Z
 M 79,730
 L 83,730
-L 160,358
-L 156,358
-L 79,730
+C 134,613 160,487 160,360
+C 160,233 134,107 83,-10
+L 79,-10
+C 130,107 156,233 156,360
+C 156,487 129,613 79,730
 Z
 M 116,746
 L 120,746
-L 200,358
-L 196,358
-L 116,746
+C 173,624 200,493 200,360
+C 200,227 173,96 120,-26
+L 116,-26
+C 169,96 196,227 196,360
+C 196,493 168,624 116,746
 Z
 '
 transform='translate(16001,15812) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_568f565c0ed9ca5f)'
+clip-path='url(#clip_12b276e41f87d348)'
 />
 <!-- * -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_8ab38775f732838b'>
+<rect x='-120' y='-420' width='680' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 29,367
+L 29,371
+L 333,191
+L 333,187
+L 29,367
+Z
+M 49,401
+L 49,405
+L 353,225
+L 353,221
+L 49,401
+Z
+M 70,435
+L 70,439
+L 374,259
+L 374,255
+L 70,435
+Z
+M 90,469
+L 90,473
+L 394,293
+L 394,289
+L 90,469
+Z
+M 87,187
+L 87,191
+L 391,371
+L 391,367
+L 87,187
+Z
+M 67,221
+L 67,225
+L 371,405
+L 371,401
+L 67,221
+Z
+M 46,255
+L 46,259
+L 350,439
+L 350,435
+L 46,255
+Z
+M 26,289
+L 26,293
+L 330,473
+L 330,469
+L 26,289
+Z
+M 151,502
+L 155,502
+L 155,178
+L 151,178
+L 151,502
+Z
+M 191,502
+L 195,502
+L 195,178
+L 191,178
+L 191,502
+Z
+M 231,502
+L 235,502
+L 235,178
+L 231,178
+L 231,502
+Z
+M 271,502
+L 275,502
+L 275,178
+L 271,178
+L 271,502
 Z
 '
 transform='translate(16242,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_8ab38775f732838b)'
 />
 <!-- + -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_3a21037cea30cf18'>
+<rect x='-120' y='-420' width='648' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 58,298
+L 58,302
+L 362,302
+L 362,298
+L 58,298
+Z
+M 58,338
+L 58,342
+L 362,342
+L 362,338
+L 58,338
+Z
+M 58,378
+L 58,382
+L 362,382
+L 362,378
+L 58,378
+Z
+M 58,418
+L 58,422
+L 362,422
+L 362,418
+L 58,418
+Z
+M 151,512
+L 155,512
+L 155,208
+L 151,208
+L 151,512
+Z
+M 191,512
+L 195,512
+L 195,208
+L 191,208
+L 191,512
+Z
+M 231,512
+L 235,512
+L 235,208
+L 231,208
+L 231,512
+Z
+M 271,512
+L 275,512
+L 275,208
+L 271,208
+L 271,512
 Z
 '
 transform='translate(16708,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_3a21037cea30cf18)'
 />
 <!-- , -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_9bcb2133a63fc138'>
+<rect x='-120' y='-420' width='473' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 87,98
+L 91,98
+L 16,-6
+L 12,-6
+L 87,98
+Z
+M 119,74
+L 123,74
+L 48,-30
+L 44,-30
+L 119,74
+Z
+M 151,50
+L 155,50
+L 80,-54
+L 76,-54
+L 151,50
+Z
+M 183,26
+L 187,26
+L 112,-78
+L 108,-78
+L 183,26
 Z
 '
 transform='translate(17174,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_9bcb2133a63fc138)'
 />
 <!-- - -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_e7d4346cfe54f03f'>
+<rect x='-120' y='-420' width='648' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 58,298
+L 58,302
+L 362,302
+L 362,298
+L 58,298
+Z
+M 58,338
+L 58,342
+L 362,342
+L 362,338
+L 58,338
+Z
+M 58,378
+L 58,382
+L 362,382
+L 362,378
+L 58,378
+Z
+M 58,418
+L 58,422
+L 362,422
+L 362,418
+L 58,418
 Z
 '
 transform='translate(17415,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_e7d4346cfe54f03f)'
 />
 <!-- . -->
 <clipPath id='clip_b6b99cdd1eb60239'>
@@ -15142,21 +17781,39 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_b6b99cdd1eb60239)'
 />
 <!-- / -->
-<clipPath id='clip_ba0967ad7e4384c9'>
-<rect x='-120' y='-420' width='436' height='1190'/>
+<clipPath id='clip_f22b4c75eff96a93'>
+<rect x='-120' y='-420' width='701' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 115,-25
+L 111,-25
+L 411,699
+L 415,699
+L 115,-25
+Z
+M 78,-10
+L 74,-10
+L 374,714
+L 378,714
+L 78,-10
+Z
+M 41,6
+L 37,6
+L 337,730
+L 341,730
+L 41,6
+Z
+M 4,21
+L -0,21
+L 300,745
+L 304,745
+L 4,21
 Z
 '
 transform='translate(18047,15812) scale(1,-1)'
-style='fill:#e00000;fill-rule:nonzero;stroke:#e00000;stroke-width:5'
-clip-path='url(#clip_ba0967ad7e4384c9)'
+style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
+clip-path='url(#clip_f22b4c75eff96a93)'
 />
 </g>
 <g id='Dactyl Scratch7'>
@@ -15383,119 +18040,80 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_f43bd6b703a30f66)'
 />
 <!-- e -->
-<clipPath id='clip_833087a3956d032e'>
-<rect x='-120' y='-420' width='726' height='1190'/>
+<clipPath id='clip_0683524ba28f1631'>
+<rect x='-120' y='-420' width='710' height='1190'/>
 </clipPath>
 <path
 d='
 M 0,161
 L 38,200
-L 395,200
-L 394,241
-C 390,343 216,363 211,460
-L 210,479
-L 209,460
-C 202,329 117,246 26,241
-L 7,240
-L 26,239
-C 127,234 119,58 209,20
-C 282,-11 346,109 423,97
-C 398,23 243,-15 209,-20
-C -33,-58 -130,233 -20,239
-L -1,240
-L -20,241
-C -112590566987,5925819555 -3301683466,62731990317 209,500
-L 210,481
-L 211,500
-C 216,600 438,651 440,241
-L 440,160
+L 391,200
+C 429,323 321,463 208,460
+C 108,457 19,339 26,239
+C 32,153 115,41 205,20
+C 283,2 379,36 424,105
+C 385,24 287,-30 199,-19
+C 84,-5 -16,124 -20,238
+C -24,359 82,509 204,500
+C 341,490 407,297 418,160
 L 0,161
 Z
 M 0,221
 L 38,260
-L 354,241
-L 340,228
-C 307,198 221,202 211,400
-L 210,419
-L 209,400
-C 204,297 143,244 86,241
-L 67,240
-L 86,239
-C 159,235 149,109 211,80
-C 265,55 320,158 380,140
-C 356,76 221,43 209,40
-C -10,-9 -53,234 40,239
-L 59,240
-L 40,241
-C -85025509395,4475027053 -2493346649,47373590748 209,440
-L 210,421
-L 211,440
-C 214,493 326,542 374,254
-L 380,220
+L 341,260
+C 347,330 282,402 212,400
+C 138,398 82,312 86,240
+C 90,169 146,97 214,80
+C 271,66 346,94 377,142
+C 352,72 273,33 207,40
+C 119,50 42,153 40,240
+C 38,331 116,442 208,440
+C 302,438 363,314 375,220
 L 0,221
 Z
-M -3,293
-L 43,324
-L 379,261
-L 379,221
-L 297,221
-C 99,222 125,359 188,360
-L 210,360
-L 232,360
-C 5353925986,-80432646 -187329404,-1358965583 123,221
-L 126,240
-L 123,259
-C 109,362 133,136 232,128
-C 264,126 286,160 305,189
-C 285,149 236,83 190,112
-C 154,134 165,218 123,219
-L 42,220
-L 42,260
-L 123,261
-C 148,261 184,282 186,360
-L 188,439
-L 232,439
-L 234,360
-C 235,319 305,300 297,261
-L 294,247
-L -3,293
+M 0,281
+L 38,320
+L 281,320
+C 267,339 240,345 217,340
+C 178,331 145,284 146,241
+C 147,197 180,151 222,139
+C 260,128 308,147 329,180
+C 318,132 266,96 216,100
+C 153,105 99,176 100,241
+C 101,303 150,374 211,380
+C 269,386 321,334 342,280
+L 0,281
 Z
 '
 transform='translate(1864,17082) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_833087a3956d032e)'
+clip-path='url(#clip_0683524ba28f1631)'
 />
 <!-- f -->
-<clipPath id='clip_f5bc522f22eef252'>
-<rect x='-120' y='-420' width='602' height='1190'/>
+<clipPath id='clip_251218b149b9f8da'>
+<rect x='-120' y='-420' width='632' height='1190'/>
 </clipPath>
 <path
 d='
 M 186,3
 L 145,40
 L 144,540
-C 144,613 224,657 284,620
-L 316,600
-L 284,580
-C 256,563 190,576 190,540
+C 144,605 241,615 270,618
+C 248,610 190,587 190,540
 L 186,3
 Z
 M 126,3
 L 85,40
 L 84,540
-C 84,665 204,730 284,680
-L 316,660
-L 284,640
-C 234,609 130,603 130,540
+C 84,664 232,719 305,637
+C 204,672 130,613 130,540
 L 126,3
 Z
 M 66,3
 L 25,40
 L 24,540
-C 24,721 183,803 284,740
-L 316,720
-L 284,700
-C 212,656 71,632 70,540
+C 24,665 186,755 346,669
+C 236,757 71,679 70,540
 L 66,3
 Z
 M 0,341
@@ -15516,109 +18134,78 @@ Z
 '
 transform='translate(2330,17082) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_f5bc522f22eef252)'
+clip-path='url(#clip_251218b149b9f8da)'
 />
 <!-- g -->
-<clipPath id='clip_fd8b822ca8bdfed2'>
-<rect x='-120' y='-420' width='740' height='1190'/>
+<clipPath id='clip_3c23a810d76f4348'>
+<rect x='-120' y='-420' width='743' height='1190'/>
 </clipPath>
 <path
 d='
 M 284,477
 L 325,440
 L 326,-90
-C 326,-273 214,-251 211,-200
-L 210,-181
-L 209,-200
-C 206,-257 89,-274 85,-125
-C 133,-80 206,-108 209,-160
-L 210,-179
-L 211,-160
-C 213,-125 280,-123 280,-90
+C 326,-148 277,-196 214,-200
+C 152,-204 97,-170 73,-115
+C 115,-146 163,-171 215,-160
+C 257,-151 280,-120 280,-90
 L 284,477
 Z
 M 344,477
 L 385,440
 L 386,-90
-C 386,-372 215,-337 211,-260
-L 210,-241
-L 209,-260
-C 205,-338 44,-361 39,-157
-C 70,-154 205,-141 209,-220
-L 210,-239
-L 211,-220
-C 214,-155 340,-152 340,-90
+C 386,-186 304,-256 208,-260
+C 134,-263 59,-227 33,-163
+C 81,-213 149,-232 212,-220
+C 284,-207 340,-154 340,-90
 L 344,477
 Z
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 404,477
+L 445,440
+L 446,-90
+C 446,-220 333,-315 203,-320
+C 112,-323 29,-285 -5,-210
+C 44,-269 125,-294 208,-280
+C 313,-262 399,-186 400,-90
+L 404,477
 Z
-M 454,355
-L 399,367
-C 334,308 217,353 211,460
-L 210,479
-L 209,460
-C 204,357 44,337 26,240
-C 8,139 204,114 209,20
-L 210,1
-L 211,20
-C 217,139 353,183 423,110
-C 478,-141 218,-147 211,-20
-L 210,-1
-L 209,-20
-C 201,-170 -62,-47 -20,240
-C 44,679 204,596 209,500
-L 210,481
-L 211,500
-C 222,708 446,366 454,355
+M 457,364
+L 401,369
+C 365,436 279,471 205,460
+C 111,445 24,340 26,240
+C 28,143 110,40 205,20
+C 287,4 381,35 424,105
+C 377,24 292,-25 199,-19
+C 80,-12 -23,115 -20,240
+C -17,354 83,480 199,499
+C 305,516 411,458 457,364
 Z
-M 407,323
-L 352,332
-C 296,291 215,329 211,400
-L 210,419
-L 209,400
-C 205,328 98,308 86,240
-C 74,169 205,147 209,80
-L 210,61
-L 211,80
-C 215,161 345,146 375,143
-C 355,-59 215,-27 211,40
-L 210,59
-L 209,40
-C 202,-87 11,29 40,240
-C 92,619 206,505 209,440
-L 210,421
-L 211,440
-C 220,610 402,331 407,323
+M 410,326
+L 354,332
+C 327,380 267,409 214,400
+C 144,389 86,312 86,240
+C 86,169 144,94 214,80
+C 274,67 341,93 377,142
+C 355,73 280,32 207,40
+C 115,50 38,140 40,240
+C 41,330 124,426 207,440
+C 288,454 377,396 410,326
 Z
-M 282,380
-L 328,348
-C 272,362 139,359 188,360
-L 210,360
-L 232,360
-C 282,359 155,248 146,240
-C 113,209 326,122 232,120
-L 210,120
-L 188,120
-C 115,121 251,118 305,126
-C 271,162 235,143 234,120
-L 232,41
-L 188,41
-L 186,120
-C 185,172 108,190 100,240
-C 91,292 185,311 186,360
-L 188,439
-L 232,439
-L 234,360
-C 235,322 281,378 282,380
+M 363,288
+L 307,295
+C 289,327 256,345 222,341
+C 178,335 143,286 146,240
+C 149,195 179,150 222,139
+C 262,129 304,148 330,180
+C 318,131 264,96 215,100
+C 151,104 98,176 100,240
+C 102,306 156,371 215,380
+C 277,390 338,342 363,288
 Z
 '
 transform='translate(2721,17082) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_fd8b822ca8bdfed2)'
+clip-path='url(#clip_3c23a810d76f4348)'
 />
 <!-- h -->
 <clipPath id='clip_0227f348ef9663c2'>
@@ -15674,7 +18261,7 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_0227f348ef9663c2)'
 />
 <!-- i -->
-<clipPath id='clip_f12c2924d4b38f06'>
+<clipPath id='clip_add547b5e0c36854'>
 <rect x='-120' y='-420' width='431' height='1190'/>
 </clipPath>
 <path
@@ -15695,40 +18282,36 @@ L 123,32
 L 104,477
 Z
 M 60,527
-C 94,542 109,557 110,580
-C 112,608 79,636 60,633
-C 32,630 14,605 10,580
-C 6,556 35,532 60,527
-C 60,527 60,527 60,527
+C 87,527 110,549 110,580
+C 110,614 85,633 60,633
+C 33,633 10,605 10,580
+C 9,548 30,527 60,527
 Z
-M 60,513
-C 69,545 0,549 -10,580
-C -19,609 20,647 60,647
-C 99,647 134,613 130,580
-C 126,550 33,535 60,513
-C 60,513 60,513 60,513
+M -10,580
+C -6,613 21,647 60,647
+C 94,647 128,613 130,580
+C 131,545 95,513 60,513
+C 25,514 -7,543 -10,580
 Z
 M 60,557
-C 74,563 80,569 80,580
-C 81,591 68,605 60,603
-C 49,602 42,591 40,580
-C 37,570 49,559 60,557
-C 60,557 60,557 60,557
+C 70,557 81,567 80,580
+C 79,593 71,603 60,603
+C 48,604 39,592 40,580
+C 40,569 47,557 60,557
 Z
-M 60,543
-C 65,561 26,563 20,580
-C 15,596 38,617 60,617
-C 82,617 102,599 100,580
-C 98,563 45,555 60,543
-C 60,543 60,543 60,543
+M 20,580
+C 22,599 40,617 60,617
+C 78,617 99,600 100,580
+C 101,553 78,543 60,543
+C 37,544 21,561 20,580
 Z
 '
 transform='translate(3653,17082) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_f12c2924d4b38f06)'
+clip-path='url(#clip_add547b5e0c36854)'
 />
 <!-- j -->
-<clipPath id='clip_1702237fd4daab75'>
+<clipPath id='clip_05b7d71fd55dd0fe'>
 <rect x='-120' y='-420' width='657' height='1190'/>
 </clipPath>
 <path
@@ -15761,37 +18344,33 @@ C 299,-249 325,-166 325,-90
 L 329,477
 Z
 M 285,527
-C 319,542 334,557 335,580
-C 337,608 304,636 285,633
-C 257,630 239,605 235,580
-C 231,556 260,532 285,527
-C 285,527 285,527 285,527
+C 312,527 335,549 335,580
+C 335,614 310,633 285,633
+C 258,633 235,605 235,580
+C 234,548 255,527 285,527
 Z
-M 285,513
-C 294,545 225,549 215,580
-C 206,609 245,647 285,647
-C 324,647 359,613 355,580
-C 351,550 258,535 285,513
-C 285,513 285,513 285,513
+M 215,580
+C 219,613 246,647 285,647
+C 319,647 353,613 355,580
+C 356,545 320,513 285,513
+C 250,514 218,543 215,580
 Z
 M 285,557
-C 299,563 305,569 305,580
-C 306,591 293,605 285,603
-C 274,602 267,591 265,580
-C 262,570 274,559 285,557
-C 285,557 285,557 285,557
+C 295,557 306,567 305,580
+C 304,593 296,603 285,603
+C 273,604 264,592 265,580
+C 265,569 272,557 285,557
 Z
-M 285,543
-C 290,561 251,563 245,580
-C 240,596 263,617 285,617
-C 307,617 327,599 325,580
-C 323,563 270,555 285,543
-C 285,543 285,543 285,543
+M 245,580
+C 247,599 265,617 285,617
+C 303,617 324,600 325,580
+C 326,553 303,543 285,543
+C 262,544 246,561 245,580
 Z
 '
 transform='translate(3819,17082) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_1702237fd4daab75)'
+clip-path='url(#clip_05b7d71fd55dd0fe)'
 />
 <!-- k -->
 <clipPath id='clip_9f7f6aac85c3ce3a'>
@@ -15962,7 +18541,7 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_2525c9937f5271b4)'
 />
 <!-- n -->
-<clipPath id='clip_e5c441839c08ed78'>
+<clipPath id='clip_b8e487fa585035f6'>
 <rect x='-120' y='-420' width='732' height='1190'/>
 </clipPath>
 <path
@@ -15982,109 +18561,84 @@ L 145,440
 L 123,32
 L 104,477
 Z
-M 80,271
-L 75,325
-C 83,334 204,482 209,380
-L 210,361
-L 211,380
-C 214,440 350,459 326,240
+M 74,263
+L 69,316
+C 99,366 156,389 211,380
+C 282,369 333,307 326,240
 L 303,32
 L 280,240
-C 275,283 213,299 211,340
-L 210,359
-L 209,340
-C 206,274 106,272 80,271
+C 275,284 251,328 207,340
+C 161,353 111,324 74,263
 Z
-M 38,303
-L 27,355
-C 32,363 201,585 209,440
-L 210,421
-L 211,440
-C 216,531 421,557 386,240
+M 28,307
+L 27,361
+C 63,420 135,450 210,440
+C 317,426 397,340 386,240
 L 363,32
 L 340,240
-C 332,312 215,330 211,400
-L 210,419
-L 209,400
-C 204,312 75,305 38,303
+C 332,316 282,382 210,400
+C 134,419 58,377 28,307
 Z
-M -19,449
-L 27,417
-C 84,463 361,482 232,480
-L 210,480
-L 188,480
-C -75,484 475,505 446,240
+M -16,351
+L -16,404
+C 27,476 118,513 211,500
+C 328,483 462,385 446,240
 L 423,32
 L 400,240
-C 390,328 238,663 234,480
-L 232,401
-L 188,401
-L 186,480
-C 184,553 57,597 -19,449
+C 388,348 314,440 212,460
+C 123,477 32,433 -16,351
 Z
 '
 transform='translate(5533,17082) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_e5c441839c08ed78)'
+clip-path='url(#clip_b8e487fa585035f6)'
 />
 <!-- o -->
-<clipPath id='clip_ba442ca31ec179c3'>
-<rect x='-120' y='-420' width='718' height='1190'/>
+<clipPath id='clip_58d2c94c536be948'>
+<rect x='-120' y='-420' width='719' height='1190'/>
 </clipPath>
 <path
 d='
-M 110,245
-C 70,276 171,366 207,366
-C 269,367 305,288 312,238
-C 320,188 259,143 215,114
-C 171,85 63,133 51,182
-C 44,212 145,237 117,247
-C 115,248 112,244 110,245
+M 107,240
+C 106,299 142,367 210,367
+C 268,367 313,299 313,240
+C 312,176 268,118 210,113
+C 149,108 99,176 107,240
 Z
-M 117,233
-C 95,221 64,202 69,178
-C 78,131 160,112 205,126
-C 252,139 292,194 294,242
-C 295,287 258,348 213,354
-C 166,359 169,252 124,235
-C 122,235 119,234 117,233
+M 210,127
+C 262,127 296,188 293,240
+C 291,284 266,348 210,353
+C 148,360 123,296 127,240
+C 130,185 157,127 210,127
 Z
-M 57,233
-C 137,204 128,425 214,426
-C 294,427 371,324 372,242
-C 374,156 284,27 205,54
-C 130,80 65,158 60,233
-C 60,238 62,246 57,247
-C 53,248 52,235 57,233
+M 47,240
+C 46,336 97,427 210,427
+C 312,427 378,330 373,240
+C 367,142 300,62 210,53
+C 108,43 38,140 47,240
 Z
-M 57,233
-C 63,233 55,245 60,247
-C 134,268 164,65 215,66
-C 301,67 362,170 354,238
-C 343,319 275,385 206,414
-C 144,440 83,315 57,247
-C 55,242 53,234 57,233
+M 210,67
+C 287,67 357,155 353,240
+C 350,315 296,407 210,413
+C 129,420 59,340 67,240
+C 72,173 108,67 210,67
 Z
-M 4,235
-C 127,224 115,484 215,486
-C 302,487 425,336 432,242
-C 439,143 301,-42 203,-4
-C 104,34 188,289 64,294
-C 36,295 4,272 -3,247
-C -4,242 -2,236 4,235
+M -13,240
+C -9,346 69,487 210,487
+C 331,487 432,352 433,240
+C 433,122 340,-4 210,-7
+C 73,-9 -10,118 -13,240
 Z
-M -3,233
-C 26,231 28,309 56,306
-C 162,296 90,19 217,4
-C 307,-6 396,140 414,238
-C 433,342 294,409 205,474
-C 132,528 13,341 -10,245
-C -11,240 -9,234 -3,233
+M 210,7
+C 321,7 415,126 413,240
+C 412,365 311,467 210,473
+C 95,480 1,361 7,240
+C 12,122 91,7 210,7
 Z
 '
 transform='translate(5999,17082) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_ba442ca31ec179c3)'
+clip-path='url(#clip_58d2c94c536be948)'
 />
 <!-- p -->
 <clipPath id='clip_8881debf957251d4'>
@@ -16252,75 +18806,60 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_b0551c67aa8cb403)'
 />
 <!-- s -->
-<clipPath id='clip_7df3af433fda580a'>
-<rect x='-120' y='-420' width='740' height='1190'/>
+<clipPath id='clip_757719c9ff0fc00e'>
+<rect x='-120' y='-420' width='739' height='1190'/>
 </clipPath>
 <path
 d='
-M 454,355
-L 399,367
-C 334,308 217,353 211,460
-L 210,479
-L 209,460
-C 204,372 15,371 28,286
-C 38,217 206,266 209,200
-L 210,181
-L 211,200
-C 214,261 332,261 329,163
-C 326,50 214,36 211,100
-L 210,119
-L 209,100
-C 206,43 89,26 85,175
-C 133,220 206,192 209,140
-L 210,121
-L 211,140
-C 212,168 282,129 284,154
-C 286,174 212,140 211,160
-L 210,179
-L 209,160
-C 203,51 -9,31 -14,271
-C -23,649 204,601 209,500
-L 210,481
-L 211,500
-C 222,708 446,366 454,355
+M 453,385
+L 397,380
+C 355,434 284,466 215,460
+C 127,452 9,371 29,285
+C 44,216 139,222 207,200
+C 251,185 306,197 329,163
+C 356,125 255,87 210,100
+C 156,116 93,130 67,181
+C 117,153 167,139 223,139
+C 243,139 285,134 284,155
+C 283,178 234,171 217,161
+C 146,118 2,177 -16,274
+C -33,369 109,482 218,500
+C 296,512 407,457 453,385
 Z
-M 407,323
-L 352,332
-C 296,291 215,329 211,400
-L 210,419
-L 209,400
-C 206,345 80,361 84,307
-C 87,262 207,302 209,260
-L 210,241
-L 211,260
-C 215,333 377,345 384,187
-C 396,-77 215,-39 211,40
-L 210,59
-L 209,40
-C 205,-38 44,-61 39,143
-C 70,146 205,159 209,80
-L 210,61
-L 211,80
-C 214,137 345,117 341,173
-C 338,220 213,177 211,220
-L 210,239
-L 209,220
-C 205,145 50,101 41,293
-C 32,519 205,515 209,440
-L 210,421
-L 211,440
-C 220,610 402,331 407,323
+M 417,340
+L 362,332
+C 327,380 268,398 207,400
+C 154,402 54,350 84,307
+C 109,271 164,276 209,260
+C 275,236 356,252 384,187
+C 415,115 286,39 207,40
+C 147,41 63,79 33,137
+C 76,94 152,70 212,80
+C 261,87 351,122 341,173
+C 333,218 257,224 211,220
+C 145,214 55,232 41,293
+C 26,364 140,431 212,440
+C 286,449 378,401 417,340
 Z
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 384,300
+L 330,285
+C 291,319 238,324 197,341
+C 178,349 132,345 142,325
+C 151,305 182,325 203,320
+C 293,298 424,296 441,206
+C 462,100 311,-5 201,-20
+C 123,-30 44,26 -2,90
+C 41,34 133,5 204,20
+C 289,38 415,117 397,195
+C 382,262 279,292 213,280
+C 173,273 102,275 97,317
+C 91,357 168,378 209,380
+C 273,383 346,348 384,300
 Z
 '
 transform='translate(7763,17082) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_7df3af433fda580a)'
+clip-path='url(#clip_757719c9ff0fc00e)'
 />
 <!-- t -->
 <clipPath id='clip_481fbc2a950091de'>
@@ -16638,45 +19177,51 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_34b437ac4852f71c)'
 />
 <!-- z -->
-<clipPath id='clip_61f162ff254539f2'>
+<clipPath id='clip_adb320406a762ea8'>
 <rect x='-120' y='-420' width='730' height='1190'/>
 </clipPath>
 <path
 d='
 M 0,341
 L 38,380
+L 302,360
 L 324,380
 L 324,340
 L -14,20
 L 391,-0
 L -88,-20
 L -88,20
-L 250,340
+L 299,360
+L 302,360
 L 0,341
 Z
 M 0,401
 L 38,440
+L 362,420
 L 384,440
 L 108,80
 L 391,60
 L 41,40
-L 317,400
+L 359,420
+L 362,420
 L 0,401
 Z
 M 0,461
 L 38,500
+L 422,480
 L 444,500
 L 230,140
 L 391,120
 L 169,100
 L 169,100
-L 383,460
+L 419,480
+L 422,480
 L 0,461
 Z
 '
 transform='translate(11000,17082) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_61f162ff254539f2)'
+clip-path='url(#clip_adb320406a762ea8)'
 />
 <!--   -->
 <clipPath id='clip_e3b0c44298fc1c14'>
@@ -16690,58 +19235,46 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_e3b0c44298fc1c14)'
 />
 <!-- 0 -->
-<clipPath id='clip_0775a074b635c60d'>
+<clipPath id='clip_dccfec9d4868d9c3'>
 <rect x='-120' y='-420' width='732' height='1190'/>
 </clipPath>
 <path
 d='
-M 109,364
-C 49,412 118,606 207,606
-C 300,607 340,462 313,359
-C 291,280 299,119 215,114
-C 136,110 16,231 52,304
-C 63,325 142,360 117,367
-C 114,367 112,363 109,364
+M 107,360
+C 95,453 109,607 210,607
+C 299,607 318,438 313,360
+C 307,268 303,127 210,113
+C 115,99 83,271 107,360
 Z
-M 117,353
-C 95,340 70,321 68,296
-C 61,226 133,115 205,126
-C 288,139 293,283 293,361
-C 294,447 293,583 213,594
-C 132,604 196,396 125,356
-C 123,355 120,354 117,353
+M 210,127
+C 300,127 295,308 293,360
+C 292,418 306,578 210,593
+C 107,610 122,428 127,360
+C 132,279 92,127 210,127
 Z
-M 57,353
-C 172,324 93,665 215,665
-C 328,666 369,473 372,362
-C 375,247 320,47 204,55
-C 93,62 72,244 60,353
-C 59,358 61,365 57,367
-C 53,368 52,355 57,353
+M 47,360
+C 27,479 76,667 210,667
+C 329,667 381,475 373,360
+C 364,247 350,72 210,53
+C 80,36 19,247 47,360
 Z
-M 57,353
-C 63,353 54,366 60,367
-C 146,378 109,64 216,65
-C 315,67 355,256 354,358
-C 352,487 314,639 205,655
-C 104,669 82,432 57,367
-C 55,363 53,354 57,353
+M 210,67
+C 315,67 358,257 353,360
+C 349,461 335,645 210,653
+C 93,661 61,482 67,360
+C 71,262 69,67 210,67
 Z
-M 4,355
-C 143,358 52,724 216,725
-C 349,726 400,485 432,362
-C 470,217 331,-47 203,-5
-C 77,37 205,402 64,414
-C 37,416 3,389 -3,367
-C -4,362 -2,355 4,355
+M -13,360
+C -25,483 -2,727 210,727
+C 362,727 439,500 433,360
+C 427,232 364,16 210,-7
+C 46,-30 -59,201 -13,360
 Z
-M -3,353
-C 22,352 24,431 56,426
-C 200,403 78,14 217,5
-C 345,-4 405,229 414,358
-C 423,484 328,777 204,715
-C 130,678 26,514 -10,365
-C -11,360 -9,354 -3,353
+M 210,7
+C 344,7 420,223 413,360
+C 407,494 352,700 210,713
+C 64,727 -1,501 7,360
+C 15,210 52,7 210,7
 Z
 M 318,746
 L 339,696
@@ -16761,40 +19294,45 @@ Z
 '
 transform='translate(11782,17082) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_0775a074b635c60d)'
+clip-path='url(#clip_dccfec9d4868d9c3)'
 />
 <!-- 1 -->
-<clipPath id='clip_d697b6d7cdf95d09'>
-<rect x='-120' y='-420' width='505' height='1190'/>
+<clipPath id='clip_88a0c1cc2400c8b7'>
+<rect x='-120' y='-420' width='485' height='1190'/>
 </clipPath>
 <path
 d='
 M 136,507
 L 83,527
-L 87,551
+L 75,600
+L 79,600
 L 78,32
-L 55,620
-L 99,620
+L 75,600
+L 80,600
 L 136,507
 Z
 M 22,551
 L 27,604
-L 159,680
+L 136,660
+L 139,660
 L 138,32
-L 116,620
+L 135,660
+L 138,660
 L 22,551
 Z
 M -27,608
 L -8,658
-L 219,750
+L 197,720
+L 199,720
 L 198,32
-L 175,690
+L 195,720
+L 198,720
 L -27,608
 Z
 '
 transform='translate(12248,17082) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_d697b6d7cdf95d09)'
+clip-path='url(#clip_88a0c1cc2400c8b7)'
 />
 <!-- 2 -->
 <clipPath id='clip_e7eae414b382081f'>
@@ -17035,72 +19573,66 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_0fe18008270b14e3)'
 />
 <!-- 6 -->
-<clipPath id='clip_e1f24a78d9cba8bd'>
+<clipPath id='clip_6993277f32e9ff8e'>
 <rect x='-120' y='-420' width='741' height='1190'/>
 </clipPath>
 <path
 d='
 M 455,593
 L 400,605
-C 381,674 273,721 203,699
-C 83,662 50,484 26,361
-C 19,326 19,292 26,258
-C 45,156 107,20 209,20
-C 308,20 391,161 394,261
-C 397,361 309,515 212,500
-C 113,485 88,339 26,261
-L 3,232
-L -20,261
-C -97,359 96,541 217,540
-C 337,538 439,381 440,262
-C 441,142 331,-34 207,-20
-C 83,-6 -2,138 -20,254
-C -25,291 -25,326 -20,363
-C 1,504 52,698 191,738
-C 287,765 424,690 455,593
+C 377,673 272,723 203,699
+C 87,659 48,485 26,361
+C 19,324 22,292 26,258
+C 37,161 108,20 209,20
+C 309,20 394,167 394,262
+C 394,358 315,487 215,500
+C 100,514 -21,326 22,210
+C -28,330 96,531 222,539
+C 342,546 441,379 440,264
+C 438,143 329,-33 207,-20
+C 88,-8 -5,137 -20,254
+C -24,291 -26,327 -20,363
+C 4,508 53,697 191,738
+C 286,766 425,689 455,593
 Z
 M 406,562
 L 351,572
-C 337,622 265,655 216,641
-C 118,611 102,460 86,359
-C 81,327 80,294 86,261
-C 100,190 136,80 211,80
-C 281,80 334,185 334,260
-C 334,332 284,449 208,440
-C 136,431 130,317 86,261
-L 63,232
-L 40,261
-C -20,337 120,480 211,480
-C 307,480 381,352 380,260
-C 379,167 302,34 209,40
-C 117,46 58,168 40,259
-C 33,294 34,327 40,361
-C 62,476 90,645 205,679
-C 278,701 386,638 406,562
+C 340,622 265,654 216,641
+C 116,614 97,462 86,359
+C 82,327 83,294 86,261
+C 93,188 136,80 211,80
+C 284,80 334,188 334,259
+C 334,332 281,430 206,440
+C 125,451 45,307 77,235
+C 34,321 119,473 213,480
+C 308,487 381,353 380,261
+C 379,167 302,31 209,40
+C 119,49 55,168 40,259
+C 34,293 32,327 40,361
+C 66,477 90,646 205,679
+C 281,702 387,638 406,562
 Z
 M 359,533
 L 303,539
-C 298,569 257,586 228,582
-C 148,570 149,441 146,358
-C 145,327 144,296 146,264
-C 148,220 162,140 212,140
-C 253,140 276,215 274,258
-C 272,305 253,388 206,380
-C 161,373 172,295 146,261
-L 123,232
-L 100,261
-C 58,314 142,419 205,420
-C 274,421 318,320 320,258
-C 322,195 278,99 212,100
-C 146,101 107,199 100,264
-C 96,296 95,326 100,358
-C 116,453 130,593 222,621
-C 274,638 350,588 359,533
+C 298,569 257,588 228,582
+C 150,566 155,436 146,358
+C 142,326 142,296 146,264
+C 152,217 164,140 212,140
+C 256,140 275,213 274,256
+C 273,305 248,376 198,381
+C 151,385 106,299 131,260
+C 97,311 143,415 204,421
+C 270,427 321,325 320,258
+C 319,192 277,98 212,100
+C 146,102 106,199 100,264
+C 97,296 94,327 100,358
+C 117,453 129,595 222,621
+C 274,637 349,588 359,533
 Z
 '
 transform='translate(14353,17082) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_e1f24a78d9cba8bd)'
+clip-path='url(#clip_6993277f32e9ff8e)'
 />
 <!-- 7 -->
 <clipPath id='clip_3f8647a0452f0562'>
@@ -17135,155 +19667,137 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_3f8647a0452f0562)'
 />
 <!-- 8 -->
-<clipPath id='clip_30389541c96dffdf'>
+<clipPath id='clip_786822744ba80241'>
 <rect x='-120' y='-420' width='718' height='1190'/>
 </clipPath>
 <path
 d='
-M 226,412
-C 174,410 108,465 107,516
-C 107,562 165,607 211,607
-C 255,607 313,565 313,518
-C 313,463 228,446 188,407
-C 124,346 13,303 13,218
-C 14,123 117,7 212,6
-C 305,6 432,116 412,212
-C 396,287 233,233 200,299
-C 182,337 274,405 236,420
-C 232,422 230,413 226,412
+M 232,407
+C 191,432 113,459 107,518
+C 103,562 166,607 210,607
+C 254,607 315,562 313,518
+C 311,463 241,432 188,407
+C 110,371 16,300 13,217
+C 10,123 108,7 210,7
+C 304,7 410,124 407,217
+C 404,302 300,359 232,407
 Z
-M 236,407
-C 218,376 202,332 220,301
-C 256,238 402,294 421,224
-C 448,126 312,-7 208,-6
-C 105,-6 -8,110 -6,219
-C -4,310 114,357 181,420
-C 218,454 293,468 294,518
-C 294,556 247,592 209,593
-C 172,594 126,557 126,520
-C 125,468 251,465 245,415
-C 245,411 238,410 236,407
+M 426,219
+C 423,108 316,3 210,-7
+C 104,-17 -15,113 -6,219
+C 2,313 108,354 181,420
+C 220,455 281,467 294,519
+C 304,556 246,594 210,593
+C 172,593 120,556 126,519
+C 135,467 200,454 239,420
+C 304,362 423,314 426,219
 Z
-M 209,353
-C 142,324 48,435 47,510
-C 46,585 135,667 210,667
-C 285,667 373,583 373,509
-C 372,436 269,405 216,354
-C 167,307 74,277 73,209
-C 71,144 144,67 210,67
-C 279,67 345,144 347,210
-C 349,275 230,291 210,353
-C 209,358 213,367 209,367
-C 204,366 212,356 209,353
+M 204,354
+C 151,389 53,435 47,509
+C 42,581 137,667 210,667
+C 287,667 374,581 373,509
+C 371,435 278,391 216,354
+C 157,319 80,281 73,209
+C 66,147 146,67 210,67
+C 274,67 354,147 347,209
+C 340,277 262,320 204,354
 Z
-M 209,353
-C 213,353 206,365 210,367
-C 279,392 365,281 367,210
-C 368,137 283,46 210,53
-C 138,60 49,135 53,211
-C 57,283 157,314 207,366
-C 255,415 357,442 353,511
-C 350,577 276,648 210,653
-C 144,659 70,576 67,510
-C 64,443 189,430 209,367
-C 210,362 204,354 209,353
+M 367,211
+C 360,136 285,58 210,53
+C 129,48 46,136 53,211
+C 61,287 152,314 207,366
+C 260,417 323,444 353,511
+C 382,573 279,657 210,653
+C 149,650 59,580 67,511
+C 75,438 159,414 213,366
+C 274,312 357,279 367,211
 Z
-M 191,304
-C 124,237 -11,408 -12,504
-C -13,608 105,727 209,727
-C 314,727 432,605 432,501
-C 432,409 308,364 242,300
-C 207,266 137,250 132,201
-C 129,167 173,127 208,127
-C 246,126 280,169 289,205
-C 307,274 294,416 218,416
-C 181,416 172,348 182,313
-C 183,309 192,308 191,304
+M 178,300
+C 102,359 -9,408 -12,501
+C -16,602 108,727 210,727
+C 312,727 434,597 432,501
+C 430,408 323,338 242,300
+C 197,279 138,250 132,201
+C 128,167 175,127 210,127
+C 244,127 291,166 288,201
+C 284,243 224,275 178,300
 Z
-M 182,300
-C 224,312 161,419 202,424
-C 283,435 330,276 306,198
-C 294,158 254,112 212,113
-C 168,115 112,158 113,203
-C 114,257 194,275 234,312
-C 298,372 406,417 413,503
-C 421,599 314,708 211,713
-C 114,718 13,597 7,500
-C 2,417 123,376 173,309
-C 176,306 177,298 182,300
+M 307,202
+C 309,157 255,116 210,113
+C 165,111 104,159 113,202
+C 124,259 187,279 234,313
+C 310,365 416,412 413,503
+C 410,602 309,718 210,713
+C 112,708 2,601 7,503
+C 11,420 119,373 186,313
+C 226,276 300,262 307,202
 Z
 '
 transform='translate(15285,17082) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_30389541c96dffdf)'
+clip-path='url(#clip_786822744ba80241)'
 />
 <!-- 9 -->
-<clipPath id='clip_ae4fc9e2c40bee75'>
+<clipPath id='clip_416de1b51a74089b'>
 <rect x='-120' y='-420' width='726' height='1190'/>
 </clipPath>
 <path
 d='
 M -35,127
 L 20,115
-C 45,46 147,-3 217,21
+C 45,46 152,-1 217,21
 C 339,62 366,234 394,359
-C 402,394 402,428 394,462
-C 372,559 312,690 211,700
-C 110,710 24,560 26,459
-C 28,355 107,221 208,220
-C 310,220 334,383 394,459
-L 417,488
-L 440,459
-C 521,356 330,151 203,180
-C 86,207 -24,342 -20,458
-C -16,575 94,740 213,740
-C 333,740 423,581 440,466
-C 445,430 447,393 440,357
-C 413,221 358,35 229,-18
-C 132,-58 -3,32 -35,127
+C 402,393 400,428 394,462
+C 376,561 313,688 211,700
+C 109,712 25,561 26,458
+C 27,358 101,217 205,220
+C 321,224 438,400 398,510
+C 448,393 320,176 198,181
+C 80,186 -26,342 -20,456
+C -13,577 99,740 213,740
+C 331,740 422,581 440,466
+C 445,429 447,393 440,357
+C 412,220 369,44 229,-18
+C 143,-56 -5,32 -35,127
 Z
 M 14,158
 L 69,148
-C 83,96 156,63 204,79
-C 300,112 323,259 334,361
-C 338,394 337,425 334,459
-C 327,534 284,626 209,640
-C 139,653 77,533 86,460
-C 95,386 141,280 212,280
-C 287,280 289,402 334,459
-L 357,488
-L 380,459
-C 438,385 300,230 209,240
-C 117,250 37,364 40,460
-C 43,552 118,680 211,680
-C 303,680 361,552 380,461
-C 387,427 387,393 380,359
-C 357,243 327,80 215,41
-C 142,15 35,83 14,158
+C 84,98 155,62 204,79
+C 301,113 318,259 334,361
+C 339,394 338,426 334,459
+C 325,533 283,628 209,640
+C 137,651 79,534 86,461
+C 93,387 135,278 214,280
+C 295,282 374,409 343,485
+C 387,402 298,238 207,240
+C 116,242 37,371 40,459
+C 43,550 112,680 211,680
+C 302,680 369,551 380,461
+C 384,426 387,393 380,359
+C 357,244 326,81 215,41
+C 145,16 34,77 14,158
 Z
 M 61,187
 L 117,181
-C 120,150 163,128 192,138
-C 267,163 276,279 274,362
-C 273,391 276,423 274,456
-C 271,503 257,574 208,580
-C 164,585 140,506 146,462
-C 152,416 168,339 214,340
-C 260,341 247,424 274,459
-L 297,488
-L 320,459
-C 360,407 278,295 215,300
-C 149,305 97,396 100,462
-C 103,524 141,620 208,620
-C 275,620 312,520 320,456
-C 324,424 325,394 320,362
-C 305,268 288,121 198,99
-C 146,85 70,132 61,187
+C 120,151 163,128 192,138
+C 266,163 275,282 274,362
+C 274,393 275,424 274,456
+C 273,499 255,573 208,580
+C 164,586 143,507 146,464
+C 150,413 171,338 222,339
+C 268,340 307,416 289,460
+C 325,411 276,303 216,299
+C 152,296 97,396 100,462
+C 103,523 143,620 208,620
+C 273,620 315,520 320,456
+C 323,425 325,393 320,362
+C 303,260 290,127 198,99
+C 148,83 68,129 61,187
 Z
 '
 transform='translate(15751,17082) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_ae4fc9e2c40bee75)'
+clip-path='url(#clip_416de1b51a74089b)'
 />
 <!-- A -->
 <clipPath id='clip_3a618f144ecf6bca'>
@@ -17339,78 +19853,54 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_3a618f144ecf6bca)'
 />
 <!-- B -->
-<clipPath id='clip_5bcb4001a335d178'>
-<rect x='-120' y='-420' width='728' height='1190'/>
+<clipPath id='clip_7d94e6fc936208d2'>
+<rect x='-120' y='-420' width='732' height='1190'/>
 </clipPath>
 <path
 d='
-M 0,281
-L 38,320
-L 61,320
-C 148,320 290,319 288,225
-C 286,137 7,140 61,140
-L 96,140
-L 96,580
-L 61,580
-C 51,580 250,580 288,495
-C 329,403 172,331 61,400
-L 29,420
-L 61,440
-C 136,487 288,421 318,525
-C 346,623 -16,620 61,620
-L 140,620
-L 140,100
-L 61,100
-C 27,100 310,87 318,195
-C 325,299 152,278 61,280
-L 0,281
+M 58,263
+L 63,316
+C 180,373 308,313 326,210
+C 346,96 200,15 95,77
+L 95,643
+C 217,679 333,605 326,510
+C 319,412 172,382 69,425
+C 152,397 267,419 280,510
+C 290,581 212,641 140,617
+L 140,103
+C 208,79 294,128 280,210
+C 265,297 136,306 58,263
 Z
-M 0,341
-L 38,380
-L 61,380
-C 172,380 330,318 386,210
-C 501,-15 147,-166 61,40
-L 54,58
-L 54,662
-L 61,680
-C 136,859 451,762 386,510
-C 343,343 177,268 61,340
-L 29,360
-L 61,380
-C 143,431 342,404 340,510
-C 338,615 54,541 61,640
-L 62,658
-L 62,62
-L 61,80
-C 51,220 281,117 340,210
-C 397,300 185,337 61,340
-L 0,341
+M 23,311
+L 27,364
+C 183,423 360,350 386,210
+C 415,51 187,-84 35,50
+L 35,670
+C 213,727 368,636 386,510
+C 409,352 185,264 33,377
+C 165,323 334,381 340,510
+C 345,621 204,689 80,650
+L 80,70
+C 191,32 337,93 340,210
+C 344,340 146,384 23,311
 Z
-M 0,401
-L 38,440
-L 61,440
-C 274,440 413,267 442,221
-C 638,-84 51,-195 38,-1
-L 34,59
-L 34,661
-L 38,721
-C 60,1067 569,909 442,499
-C 382,303 184,204 61,280
-L 29,300
-L 61,320
-C 133,364 334,454 404,521
-C 671,780 107,1079 84,719
-L 80,660
-L 80,60
-L 84,1
-C 98,-220 583,-127 404,199
-C 301,386 112,399 61,400
-L 0,401
+M -14,359
+L -9,412
+C 181,495 434,431 446,210
+C 459,-18 157,-82 -25,22
+L -25,698
+C 178,816 446,696 446,510
+C 446,329 173,242 -3,329
+C 179,258 395,335 400,510
+C 405,671 188,755 20,682
+L 20,38
+C 187,-17 386,53 400,210
+C 417,398 144,443 -14,359
 Z
 '
 transform='translate(466,18152) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_5bcb4001a335d178)'
+clip-path='url(#clip_7d94e6fc936208d2)'
 />
 <!-- C -->
 <clipPath id='clip_b8d6beadda863a34'>
@@ -17457,44 +19947,42 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_b8d6beadda863a34)'
 />
 <!-- D -->
-<clipPath id='clip_d998a9bd1a1a52ab'>
-<rect x='-120' y='-420' width='725' height='1190'/>
+<clipPath id='clip_6e92a070a803d1b9'>
+<rect x='-120' y='-420' width='726' height='1190'/>
 </clipPath>
 <path
 d='
 M -16,717
 L 25,680
-L 24,20
-L 61,20
-C 254,20 399,185 394,366
-C 388,560 224,700 39,725
-C 247,737 427,580 439,374
-C 451,159 279,-20 61,-20
-L -20,-20
+L 24,17
+C 224,9 391,166 394,360
+C 397,561 223,717 29,720
+C 240,739 450,583 440,360
+C 430,134 189,12 -20,-17
 L -16,717
 Z
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 44,717
+L 85,680
+L 84,80
+C 233,91 342,217 334,360
+C 326,512 187,623 29,660
+C 214,673 373,540 380,360
+C 387,174 221,33 40,40
+L 44,717
 Z
-M 110,719
-L 147,678
-L 85,41
-L 41,41
-L 38,119
-C 34,245 243,263 288,368
-C 333,472 152,546 36,575
-C 179,582 313,473 308,332
-C 303,217 205,125 84,121
-L 65,120
-L 110,719
+M 104,717
+L 145,680
+L 144,147
+C 233,174 289,266 274,360
+C 255,478 138,546 29,601
+C 182,610 312,502 320,360
+C 328,226 221,122 100,93
+L 104,717
 Z
 '
 transform='translate(1398,18152) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_d998a9bd1a1a52ab)'
+clip-path='url(#clip_6e92a070a803d1b9)'
 />
 <!-- E -->
 <clipPath id='clip_429023ce711911b6'>
@@ -17597,73 +20085,60 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_97f46cc4d7569a76)'
 />
 <!-- G -->
-<clipPath id='clip_82e71bcf7e57f68f'>
-<rect x='-120' y='-420' width='743' height='1190'/>
+<clipPath id='clip_4f847d338a67c192'>
+<rect x='-120' y='-420' width='742' height='1190'/>
 </clipPath>
 <path
 d='
-M 457,597
-L 401,606
-C 346,683 268,725 203,699
-C 79,649 164,368 26,361
-L 7,360
-L 26,359
-C 185,351 123,94 203,21
-C 272,-42 393,79 394,210
+M 456,595
+L 400,606
+C 371,679 282,723 203,699
+C 86,664 27,483 26,360
+C 25,231 67,41 203,21
+C 310,5 393,106 394,210
 L 396,400
 L 179,420
 L 440,440
 L 440,210
-C 440,96 325,-7 191,-18
-C -160,-47 -264,346 -20,359
-L -1,360
-L -20,361
-C -313,376 -112,862 193,738
-C 306,692 329,636 457,597
+C 440,78 323,-38 190,-17
+C 33,7 -29,217 -20,359
+C -11,502 43,700 192,738
+C 298,765 399,690 456,595
 Z
-M 407,563
+M 406,562
 L 351,572
-C 329,625 268,663 216,640
-C 116,597 197,367 86,361
-L 67,360
-L 86,359
-C 203,353 124,128 216,80
-C 261,56 333,97 334,210
+C 330,628 268,653 216,640
+C 115,617 76,464 86,360
+C 96,257 115,91 216,80
+C 279,72 333,145 334,210
 L 336,340
 L 179,360
 L 380,380
 L 380,210
-C 380,81 249,48 206,40
-C -160,-22 -177,348 40,359
-L 59,360
-L 40,361
-C -165,372 -100,794 206,680
-C 300,644 348,595 407,563
+C 380,120 295,35 206,40
+C 82,49 30,240 40,360
+C 50,484 106,651 206,680
+C 284,702 369,638 406,562
 Z
-M 321,508
-L 283,549
-C 281,571 264,585 241,589
-C 152,604 117,294 123,341
-L 126,360
-L 123,379
-C 117,424 168,139 235,136
-C 272,135 273,181 274,210
+M 359,532
+L 303,539
+C 288,570 255,585 227,582
+C 149,574 128,440 146,360
+C 163,283 160,144 225,138
+C 263,135 273,176 274,210
 L 276,280
 L 179,300
 L 320,320
 L 320,210
-C 320,126 262,85 214,101
-C 129,129 222,338 123,339
-L 42,340
-L 42,380
-L 123,381
-C 230,382 124,589 205,614
-C 260,631 274,530 321,508
+C 320,162 278,104 225,98
+C 133,89 86,262 100,361
+C 113,455 127,595 220,621
+C 277,637 345,587 359,532
 Z
 '
 transform='translate(2796,18152) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_82e71bcf7e57f68f)'
+clip-path='url(#clip_4f847d338a67c192)'
 />
 <!-- H -->
 <clipPath id='clip_97a268efea780cd1'>
@@ -18016,180 +20491,131 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_6f84d22444ed4192)'
 />
 <!-- O -->
-<clipPath id='clip_bf0a2d386f6184f0'>
-<rect x='-120' y='-420' width='718' height='1190'/>
+<clipPath id='clip_dc8e77f8825d94ed'>
+<rect x='-120' y='-420' width='719' height='1190'/>
 </clipPath>
 <path
 d='
-M 109,364
-C 49,412 118,606 207,606
-C 300,607 340,462 313,359
-C 291,280 299,119 215,114
-C 136,110 16,231 52,304
-C 63,325 142,360 117,367
-C 114,367 112,363 109,364
+M 107,360
+C 95,453 109,607 210,607
+C 299,607 318,438 313,360
+C 307,268 303,127 210,113
+C 115,99 83,271 107,360
 Z
-M 117,353
-C 95,340 70,321 68,296
-C 61,226 133,115 205,126
-C 288,139 293,283 293,361
-C 294,447 293,583 213,594
-C 132,604 196,396 125,356
-C 123,355 120,354 117,353
+M 210,127
+C 300,127 295,308 293,360
+C 292,418 306,578 210,593
+C 107,610 122,428 127,360
+C 132,279 92,127 210,127
 Z
-M 57,353
-C 172,324 93,665 215,665
-C 328,666 369,473 372,362
-C 375,247 320,47 204,55
-C 93,62 72,244 60,353
-C 59,358 61,365 57,367
-C 53,368 52,355 57,353
+M 47,360
+C 27,479 76,667 210,667
+C 329,667 381,475 373,360
+C 364,247 350,72 210,53
+C 80,36 19,247 47,360
 Z
-M 57,353
-C 63,353 54,366 60,367
-C 146,378 109,64 216,65
-C 315,67 355,256 354,358
-C 352,487 314,639 205,655
-C 104,669 82,432 57,367
-C 55,363 53,354 57,353
+M 210,67
+C 315,67 358,257 353,360
+C 349,461 335,645 210,653
+C 93,661 61,482 67,360
+C 71,262 69,67 210,67
 Z
-M 4,355
-C 143,358 52,724 216,725
-C 349,726 400,485 432,362
-C 470,217 331,-47 203,-5
-C 77,37 205,402 64,414
-C 37,416 3,389 -3,367
-C -4,362 -2,355 4,355
+M -13,360
+C -25,483 -2,727 210,727
+C 362,727 439,500 433,360
+C 427,232 364,16 210,-7
+C 46,-30 -59,201 -13,360
 Z
-M -3,353
-C 22,352 24,431 56,426
-C 200,403 78,14 217,5
-C 345,-4 405,229 414,358
-C 423,484 328,777 204,715
-C 130,678 26,514 -10,365
-C -11,360 -9,354 -3,353
+M 210,7
+C 344,7 420,223 413,360
+C 407,494 352,700 210,713
+C 64,727 -1,501 7,360
+C 15,210 52,7 210,7
 Z
 '
 transform='translate(6674,18152) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_bf0a2d386f6184f0)'
+clip-path='url(#clip_dc8e77f8825d94ed)'
 />
 <!-- P -->
-<clipPath id='clip_0b6e775fab5cc2d0'>
-<rect x='-120' y='-420' width='712' height='1190'/>
+<clipPath id='clip_f1055a310eac329a'>
+<rect x='-120' y='-420' width='732' height='1190'/>
 </clipPath>
 <path
 d='
 M 136,3
 L 95,40
-L 96,580
-L 61,580
-C 13,580 374,514 326,511
-L 307,510
-L 326,509
-C 457,502 420,178 61,400
-L 29,420
-L 61,440
-C 127,481 202,505 280,509
-L 299,510
-L 280,511
-C 220,514 -103,620 61,620
-L 140,620
+L 95,643
+C 217,679 333,605 326,510
+C 319,412 172,382 69,425
+C 152,397 267,419 280,510
+C 290,581 212,641 140,617
 L 136,3
 Z
 M 76,3
 L 35,40
-L 54,662
-L 61,680
-C 42847567,102371459 93849745,4939951 386,511
-L 367,510
-L 386,509
-C 568,499 511,61 61,340
-L 29,360
-L 61,380
-C 150,435 238,504 340,509
-L 359,510
-L 340,511
-C 273,515 53,515 61,640
-L 62,658
+L 35,670
+C 213,727 368,636 386,510
+C 409,352 185,264 33,377
+C 165,323 334,381 340,510
+C 345,621 204,689 80,650
 L 76,3
 Z
-M 10,1
-L -27,42
-L 34,662
-L 38,721
-C 44,820 409,390 423,491
-L 426,510
-L 423,529
-C 379,854 197,196 61,280
-L 29,300
-L 61,320
-C 145,372 685,486 423,489
-L 342,490
-L 342,530
-L 423,531
-C 5544482415,68481291 2093285869,32387164474 84,719
-L 80,659
-L 10,1
+M 16,3
+L -25,40
+L -25,698
+C 178,816 446,696 446,510
+C 446,329 173,242 -3,329
+C 179,258 395,335 400,510
+C 405,671 188,755 20,682
+L 16,3
 Z
 '
 transform='translate(7140,18152) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_0b6e775fab5cc2d0)'
+clip-path='url(#clip_f1055a310eac329a)'
 />
 <!-- Q -->
-<clipPath id='clip_22082dc685c90708'>
+<clipPath id='clip_bf3a433d0e4a21a1'>
 <rect x='-120' y='-420' width='742' height='1190'/>
 </clipPath>
 <path
 d='
-M 109,364
-C 49,412 118,606 207,606
-C 300,607 340,462 313,359
-C 291,280 299,119 215,114
-C 136,110 16,231 52,304
-C 63,325 142,360 117,367
-C 114,367 112,363 109,364
+M 107,360
+C 95,453 109,607 210,607
+C 299,607 318,438 313,360
+C 307,268 303,127 210,113
+C 115,99 83,271 107,360
 Z
-M 117,353
-C 95,340 70,321 68,296
-C 61,226 133,115 205,126
-C 288,139 293,283 293,361
-C 294,447 293,583 213,594
-C 132,604 196,396 125,356
-C 123,355 120,354 117,353
+M 210,127
+C 300,127 295,308 293,360
+C 292,418 306,578 210,593
+C 107,610 122,428 127,360
+C 132,279 92,127 210,127
 Z
-M 57,353
-C 172,324 93,665 215,665
-C 328,666 369,473 372,362
-C 375,247 320,47 204,55
-C 93,62 72,244 60,353
-C 59,358 61,365 57,367
-C 53,368 52,355 57,353
+M 47,360
+C 27,479 76,667 210,667
+C 329,667 381,475 373,360
+C 364,247 350,72 210,53
+C 80,36 19,247 47,360
 Z
-M 57,353
-C 63,353 54,366 60,367
-C 146,378 109,64 216,65
-C 315,67 355,256 354,358
-C 352,487 314,639 205,655
-C 104,669 82,432 57,367
-C 55,363 53,354 57,353
+M 210,67
+C 315,67 358,257 353,360
+C 349,461 335,645 210,653
+C 93,661 61,482 67,360
+C 71,262 69,67 210,67
 Z
-M 4,355
-C 143,358 52,724 216,725
-C 349,726 400,485 432,362
-C 470,217 331,-47 203,-5
-C 77,37 205,402 64,414
-C 37,416 3,389 -3,367
-C -4,362 -2,355 4,355
+M -13,360
+C -25,483 -2,727 210,727
+C 362,727 439,500 433,360
+C 427,232 364,16 210,-7
+C 46,-30 -59,201 -13,360
 Z
-M -3,353
-C 22,352 24,431 56,426
-C 200,403 78,14 217,5
-C 345,-4 405,229 414,358
-C 423,484 328,777 204,715
-C 130,678 26,514 -10,365
-C -11,360 -9,354 -3,353
+M 210,7
+C 344,7 420,223 413,360
+C 407,494 352,700 210,713
+C 64,727 -1,501 7,360
+C 15,210 52,7 210,7
 Z
 M 456,75
 L 400,74
@@ -18209,45 +20635,46 @@ Z
 '
 transform='translate(7606,18152) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_22082dc685c90708)'
+clip-path='url(#clip_bf3a433d0e4a21a1)'
 />
 <!-- R -->
-<clipPath id='clip_8d51bcbad516bba2'>
-<rect x='-120' y='-420' width='730' height='1190'/>
+<clipPath id='clip_03d1924eabda681d'>
+<rect x='-120' y='-420' width='731' height='1190'/>
 </clipPath>
 <path
 d='
-M 90,300
-C 90,330 120,360 150,360
-C 180,360 210,330 210,300
-C 210,270 180,240 150,240
-C 120,240 90,270 90,300
+M 136,3
+L 95,40
+L 95,645
+C 206,691 337,626 326,514
+C 318,432 228,383 135,400
+L 29,420
+L 135,440
+C 188,450 269,463 281,523
+C 296,597 189,612 140,626
+L 136,3
 Z
 M 76,3
 L 35,40
-L 54,662
-L 61,680
-C 139,866 462,759 386,511
-C 333,340 197,328 135,340
+L 34,668
+C 220,739 383,640 386,507
+C 388,382 251,318 135,340
 L 29,360
 L 135,380
-C 191,391 355,411 340,509
-C 324,612 54,536 61,640
-L 62,658
+C 219,396 324,427 340,513
+C 362,629 183,662 80,652
 L 76,3
 Z
-M 10,1
-L -27,42
-L 34,662
-L 38,721
-C 51,929 605,785 444,506
-C 433,486 293,250 135,280
+M 16,3
+L -25,40
+L -26,692
+C 186,787 438,693 445,499
+C 451,343 279,253 135,280
 L 29,300
 L 135,320
-C 283,348 383,489 402,522
-C 547,767 95,888 84,719
-L 80,659
-L 10,1
+C 246,341 371,384 400,504
+C 442,680 158,759 20,678
+L 16,3
 Z
 M 115,376
 L 169,360
@@ -18267,7 +20694,7 @@ Z
 '
 transform='translate(8072,18152) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_8d51bcbad516bba2)'
+clip-path='url(#clip_03d1924eabda681d)'
 />
 <!-- S -->
 <clipPath id='clip_59cb435a506d0088'>
@@ -18593,44 +21020,50 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_93dbad429a094ae4)'
 />
 <!-- Z -->
-<clipPath id='clip_1fdb25676e756728'>
-<rect x='-120' y='-420' width='741' height='1190'/>
+<clipPath id='clip_dc7fab742123d3ef'>
+<rect x='-120' y='-420' width='711' height='1190'/>
 </clipPath>
 <path
 d='
 M 0,581
 L 38,620
+L 302,600
 L 324,620
 L 2,20
 L 391,0
 L -57,-20
 L -57,-20
-L 265,580
+L 300,600
+L 302,600
 L 0,581
 Z
 M 0,641
 L 38,680
+L 362,660
 L 384,680
 L 97,80
 L 391,60
 L 40,40
 L 40,40
-L 327,640
+L 360,660
+L 362,660
 L 0,641
 Z
 M 0,701
 L 38,740
-L 455,740
+L 422,720
+L 425,720
 L 193,140
 L 391,120
 L 127,100
-L 389,700
+L 420,720
+L 422,720
 L 0,701
 Z
 '
 transform='translate(11950,18152) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_1fdb25676e756728)'
+clip-path='url(#clip_dc7fab742123d3ef)'
 />
 <!--   -->
 <clipPath id='clip_e3b0c44298fc1c14'>
@@ -18644,7 +21077,7 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_e3b0c44298fc1c14)'
 />
 <!-- ! -->
-<clipPath id='clip_b54bc4e47dd2e832'>
+<clipPath id='clip_fe4ec2336b4d34c4'>
 <rect x='-120' y='-420' width='431' height='1190'/>
 </clipPath>
 <path
@@ -18665,37 +21098,33 @@ L 123,182
 L 104,717
 Z
 M 60,7
-C 94,22 109,37 110,60
-C 112,88 79,116 60,113
-C 32,110 14,85 10,60
-C 6,36 35,12 60,7
-C 60,7 60,7 60,7
+C 87,7 110,29 110,60
+C 110,94 85,113 60,113
+C 33,113 10,85 10,60
+C 9,28 30,7 60,7
 Z
-M 60,-7
-C 69,25 0,29 -10,60
-C -19,89 20,127 60,127
-C 99,127 134,93 130,60
-C 126,30 33,15 60,-7
-C 60,-7 60,-7 60,-7
+M -10,60
+C -6,93 21,127 60,127
+C 94,127 128,93 130,60
+C 131,25 95,-7 60,-7
+C 25,-6 -7,23 -10,60
 Z
 M 60,37
-C 74,43 80,49 80,60
-C 81,71 68,85 60,83
-C 49,82 42,71 40,60
-C 37,50 49,39 60,37
-C 60,37 60,37 60,37
+C 70,37 81,47 80,60
+C 79,73 71,83 60,83
+C 48,84 39,72 40,60
+C 40,49 47,37 60,37
 Z
-M 60,23
-C 65,41 26,43 20,60
-C 15,76 38,97 60,97
-C 82,97 102,79 100,60
-C 98,43 45,35 60,23
-C 60,23 60,23 60,23
+M 20,60
+C 22,79 40,97 60,97
+C 78,97 99,80 100,60
+C 101,33 78,23 60,23
+C 37,24 21,41 20,60
 Z
 '
 transform='translate(12732,18152) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_b54bc4e47dd2e832)'
+clip-path='url(#clip_fe4ec2336b4d34c4)'
 />
 <!-- " -->
 <clipPath id='clip_27a2fbab6b13a6b8'>
@@ -18810,56 +21239,51 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_c8506ff7400a549e)'
 />
 <!-- £ -->
-<clipPath id='clip_14b12a2c9425ce80'>
+<clipPath id='clip_658c0237e03ffdb5'>
 <rect x='-120' y='-420' width='742' height='1190'/>
 </clipPath>
 <path
 d='
-M 456,621
-L 400,617
-C 366,680 282,710 211,700
-C 128,689 30,621 26,539
-C 23,486 59,455 78,407
-C 119,302 30,182 26,61
-L 25,20
+M 456,618
+L 400,616
+C 360,677 277,702 210,700
+C 123,697 22,623 26,541
+C 29,486 64,453 81,400
+C 120,275 49,145 2,20
 L 391,-0
-L -20,-20
-L -20,61
-C -20,177 55,289 33,399
-C 24,444 -10,483 -19,532
-C -38,630 110,726 213,740
-C 285,750 424,694 456,621
+L -99,-20
+L -99,20
+C -27,102 79,262 38,385
+C 21,436 -12,478 -20,538
+C -32,635 97,727 211,740
+C 298,750 421,699 456,618
 Z
-M 415,573
-L 358,572
-C 322,616 269,643 210,640
-C 152,637 93,591 86,540
-C 80,496 107,463 133,430
-C 216,322 174,-36 80,48
-L 66,61
+M 415,574
+L 359,572
+C 328,622 263,636 210,640
+C 152,645 87,594 86,540
+C 85,494 111,470 133,429
+C 188,325 128,195 112,80
 L 391,60
-L 40,40
-L 46,74
-C 63,178 127,312 93,410
-C 77,457 42,492 40,540
-C 37,608 133,672 210,680
-C 284,688 375,636 415,573
+L 41,40
+L 41,40
+C 85,147 145,290 92,411
+C 73,454 40,490 40,540
+C 41,612 140,673 210,680
+C 284,687 375,635 415,574
 Z
-M 373,527
-L 317,527
-C 291,559 251,582 209,580
-C 183,579 154,565 145,539
-C 134,506 161,474 186,452
-C 292,358 268,42 123,41
-L 41,41
-L 41,81
-L 391,126
-L 126,67
-L 123,81
-C 101,191 190,318 155,422
-C 140,466 95,504 101,550
-C 106,592 167,619 207,620
-C 270,622 349,581 373,527
+M 373,529
+L 317,528
+C 292,561 250,582 210,580
+C 182,579 152,564 146,538
+C 139,508 164,483 184,460
+C 257,376 240,244 235,140
+L 391,120
+L 169,100
+C 181,205 194,342 147,436
+C 130,471 97,501 100,544
+C 103,588 166,618 209,620
+C 274,623 348,584 373,529
 Z
 M 0,341
 L 38,380
@@ -18879,7 +21303,7 @@ Z
 '
 transform='translate(13730,18152) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_14b12a2c9425ce80)'
+clip-path='url(#clip_658c0237e03ffdb5)'
 />
 <!-- $ -->
 <clipPath id='clip_cccdea9d25c5314c'>
@@ -18953,94 +21377,70 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_cccdea9d25c5314c)'
 />
 <!-- % -->
-<clipPath id='clip_b1dca66194517a9d'>
+<clipPath id='clip_89acf37487412ada'>
 <rect x='-120' y='-420' width='733' height='1190'/>
 </clipPath>
 <path
 d='
-M 87,715
-C 70,650 51,554 100,508
-C 110,498 134,495 142,507
-C 162,534 109,564 101,597
-C 92,637 136,735 96,725
-C 92,724 88,720 87,715
+M 98,712
+C 50,645 40,540 98,508
+C 118,498 131,500 147,508
+C 207,538 169,673 98,712
 Z
-M 96,712
-C 89,675 107,637 119,603
-C 130,568 173,529 155,497
-C 145,478 105,478 93,496
-C 49,557 175,729 105,721
-C 100,720 97,716 96,712
+M 151,495
+C 133,493 114,490 94,495
+C 24,514 11,714 94,725
+C 177,735 182,568 151,495
 Z
-M 111,667
-C 135,641 94,585 117,565
-C 120,563 125,562 128,565
-C 153,592 84,641 110,667
-C 110,667 110,667 111,667
-C 111,667 111,667 111,667
+M 113,654
+C 105,618 89,578 113,566
+C 121,562 126,563 132,566
+C 157,580 139,631 113,654
 Z
-M 111,653
-C 111,653 110,653 110,653
-C 86,675 167,579 141,555
-C 132,546 114,546 104,555
-C 80,578 85,631 110,653
-C 111,653 111,653 111,653
+M 136,554
+C 128,550 118,550 109,554
+C 74,567 68,661 109,666
+C 146,671 170,570 136,554
 Z
-M 119,607
-C 118,609 124,611 122,612
-C 122,612 122,612 121,612
-C 90,606 101,720 120,720
-C 163,722 144,632 125,608
-C 124,607 120,605 119,607
+M 122,608
+C 121,610 121,611 122,612
+C 122,612 123,612 123,612
+C 124,611 123,609 122,608
 Z
-M 125,595
-C 97,622 140,731 100,720
-C 59,708 84,616 118,625
-C 124,626 124,626 128,625
-C 137,621 140,604 132,597
-C 130,595 128,595 125,595
+M 117,625
+C 122,626 123,626 128,625
+C 139,622 139,599 128,595
+C 115,591 110,614 117,625
 Z
 M 322,8
-C 359,61 410,202 322,212
-C 305,214 288,216 273,212
-C 217,196 267,32 309,7
-C 314,4 328,7 324,8
-C 323,9 323,9 322,8
+C 392,16 384,191 322,212
+C 307,216 290,217 273,212
+C 212,191 249,0 322,8
 Z
-M 324,-5
-C 320,-7 314,-10 311,-7
-C 251,45 211,164 269,225
-C 282,239 313,238 326,225
-C 379,172 397,11 326,-5
-C 325,-5 324,-5 324,-5
+M 269,225
+C 294,231 296,232 326,225
+C 416,204 441,-2 326,-5
+C 209,-7 210,180 269,225
 Z
-M 309,53
-C 283,45 328,135 303,155
-C 300,157 296,157 292,155
-C 258,139 277,50 310,53
-C 315,54 313,68 309,67
-C 305,64 311,57 309,53
+M 307,66
+C 336,70 331,145 307,154
+C 301,156 294,156 288,154
+C 263,145 280,64 307,66
 Z
-M 309,53
-C 314,53 312,64 310,67
-C 293,93 255,134 279,165
-C 286,174 308,175 316,165
-C 333,142 326,89 310,67
-C 307,63 304,53 309,53
+M 284,166
+C 297,169 298,169 311,166
+C 357,159 370,55 311,54
+C 253,52 253,143 284,166
 Z
-M 301,113
-C 302,111 296,109 298,108
-C 298,108 298,108 298,108
-C 299,112 305,113 303,115
-C 301,118 299,124 295,125
-C 293,125 302,117 301,113
+M 298,112
+C 299,112 299,108 298,108
+C 298,108 297,108 297,108
+C 296,108 297,112 298,112
 Z
-M 295,112
-C 302,109 307,130 317,125
-C 330,117 314,96 302,95
-C 301,95 296,95 292,96
-C 283,96 279,123 288,123
-C 294,123 289,114 295,112
+M 303,95
+C 300,94 295,94 292,95
+C 283,100 282,123 292,125
+C 301,126 312,102 303,95
 Z
 M 312,803
 L 336,754
@@ -19060,69 +21460,63 @@ Z
 '
 transform='translate(14662,18152) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_b1dca66194517a9d)'
+clip-path='url(#clip_89acf37487412ada)'
 />
 <!-- & -->
-<clipPath id='clip_b5ced07e9251d74c'>
-<rect x='-120' y='-420' width='732' height='1190'/>
+<clipPath id='clip_fb8bb949ec2afc89'>
+<rect x='-120' y='-420' width='734' height='1190'/>
 </clipPath>
 <path
 d='
-M 284,267
-L 325,230
-L 326,209
-C 328,154 268,101 214,100
-C 160,98 103,149 94,202
-C 73,330 269,390 320,511
-C 351,585 255,702 169,699
-C 80,695 -14,562 32,488
+M 283,270
+L 325,233
+C 325,175 266,102 206,100
+C 154,98 102,148 94,199
+C 72,329 281,384 320,511
+C 343,586 253,696 169,699
+C 80,701 -14,562 32,488
 L 330,3
 L -7,466
-C -74,558 82,735 180,737
-C 274,740 394,608 364,500
-C 331,381 125,322 139,209
-C 145,169 183,137 218,140
-C 252,141 278,175 280,209
-L 284,267
+C -73,557 72,734 181,737
+C 271,740 393,596 364,501
+C 327,376 133,324 139,205
+C 141,167 175,135 208,140
+C 259,148 247,235 283,270
 Z
-M 344,267
-L 385,230
-L 386,209
-C 389,127 292,40 207,40
-C 125,40 31,129 34,211
-C 39,334 226,391 259,512
-C 274,567 211,646 154,641
-C 104,636 54,567 82,521
+M 348,268
+L 387,228
+C 391,141 297,43 212,40
+C 128,38 33,132 34,213
+C 36,339 235,387 259,512
+C 270,568 211,645 154,641
+C 104,636 56,563 82,521
 L 380,36
 L 43,499
-C -12,574 98,677 165,679
-C 243,682 323,582 305,508
-C 281,407 91,333 80,209
-C 74,143 153,79 212,80
-C 276,80 337,153 340,209
-L 344,267
+C -4,564 84,676 165,679
+C 252,683 319,571 305,508
+C 287,426 96,333 80,207
+C 72,145 136,75 209,80
+C 290,85 344,193 348,268
 Z
-M 404,267
-L 445,230
-L 446,209
-C 450,103 320,-41 200,-20
-C 96,-1 -18,112 -25,219
-C -33,333 188,392 199,514
-C 202,542 169,594 142,582
-C 132,578 126,564 132,554
+M 412,266
+L 448,224
+C 456,123 325,-20 216,-20
+C 105,-19 -26,107 -24,225
+C -22,352 193,393 199,513
+C 201,543 168,596 142,582
+C 133,577 125,564 132,554
 L 430,70
 L 93,532
-C 67,568 105,618 146,622
-C 203,628 246,562 245,516
-C 243,419 55,333 19,210
-C -2,135 117,21 206,20
-C 291,19 396,138 400,209
-L 404,267
+C 69,566 107,618 146,622
+C 197,627 241,561 245,515
+C 256,385 56,337 19,212
+C -8,118 134,17 210,20
+C 307,24 412,165 412,266
 Z
 '
 transform='translate(15128,18152) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_b5ced07e9251d74c)'
+clip-path='url(#clip_fb8bb949ec2afc89)'
 />
 <!-- ' -->
 <clipPath id='clip_f9db624fe705e5ec'>
@@ -19364,43 +21758,39 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_79faf63d06e383a0)'
 />
 <!-- . -->
-<clipPath id='clip_c46df7924a01c06c'>
+<clipPath id='clip_7d6b94651d4e74f1'>
 <rect x='-120' y='-420' width='416' height='1190'/>
 </clipPath>
 <path
 d='
 M 60,7
-C 94,22 109,37 110,60
-C 112,88 79,116 60,113
-C 32,110 14,85 10,60
-C 6,36 35,12 60,7
-C 60,7 60,7 60,7
+C 87,7 110,29 110,60
+C 110,94 85,113 60,113
+C 33,113 10,85 10,60
+C 9,28 30,7 60,7
 Z
-M 60,-7
-C 69,25 0,29 -10,60
-C -19,89 20,127 60,127
-C 99,127 134,93 130,60
-C 126,30 33,15 60,-7
-C 60,-7 60,-7 60,-7
+M -10,60
+C -6,93 21,127 60,127
+C 94,127 128,93 130,60
+C 131,25 95,-7 60,-7
+C 25,-6 -7,23 -10,60
 Z
 M 60,37
-C 74,43 80,49 80,60
-C 81,71 68,85 60,83
-C 49,82 42,71 40,60
-C 37,50 49,39 60,37
-C 60,37 60,37 60,37
+C 70,37 81,47 80,60
+C 79,73 71,83 60,83
+C 48,84 39,72 40,60
+C 40,49 47,37 60,37
 Z
-M 60,23
-C 65,41 26,43 20,60
-C 15,76 38,97 60,97
-C 82,97 102,79 100,60
-C 98,43 45,35 60,23
-C 60,23 60,23 60,23
+M 20,60
+C 22,79 40,97 60,97
+C 78,97 99,80 100,60
+C 101,33 78,23 60,23
+C 37,24 21,41 20,60
 Z
 '
 transform='translate(17881,18152) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_c46df7924a01c06c)'
+clip-path='url(#clip_7d6b94651d4e74f1)'
 />
 <!-- / -->
 <clipPath id='clip_9281a0f9e90c674d'>
@@ -19598,7 +21988,7 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_001e0aa474134ff5)'
 />
 <!-- e -->
-<clipPath id='clip_2ffbfd44063da0d0'>
+<clipPath id='clip_140141a5065f1316'>
 <rect x='-60' y='-360' width='554' height='1070'/>
 </clipPath>
 <path
@@ -19610,25 +22000,25 @@ L -1,270
 L 61,270
 L 61,240
 L 299,240
-C 299,310 235,360 180,360
-C 97,360 61,271 62,210
-C 62,116 141,64 183,60
-C 231,55 268,94 299,120
+C 299,316 237,360 180,360
+C 87,360 62,263 62,210
+C 62,127 123,60 180,60
+C 229,60 256,102 299,120
 L 299,150
 L 361,150
 L 361,30
 L 299,30
 L 299,60
-C 255,22 225,-4 177,0
-C 123,5 -2,88 -2,210
-C -1,311 92,420 180,420
-C 275,420 361,290 361,180
+C 247,39 227,-0 180,0
+C 125,0 -2,108 -2,210
+C -1,310 84,420 180,420
+C 286,420 361,279 361,180
 L 61,180
 Z
 '
 transform='translate(1732,19362) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_2ffbfd44063da0d0)'
+clip-path='url(#clip_140141a5065f1316)'
 />
 <!-- f -->
 <clipPath id='clip_f1ad91880ce84e42'>
@@ -19883,7 +22273,7 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_10de78d35a0d3e03)'
 />
 <!-- l -->
-<clipPath id='clip_8251ce5326b11f0b'>
+<clipPath id='clip_7669be9c3d101251'>
 <rect x='-60' y='-360' width='404' height='1070'/>
 </clipPath>
 <path
@@ -19895,19 +22285,19 @@ L 91,660
 L 91,600
 L 61,600
 L 62,210
-C 62,146 96,89 149,60
+C 62,84 117,60 149,60
 L 149,90
 L 211,90
 L 211,-30
 L 149,-30
 L 149,-0
-C 41,58 -2,140 -2,210
+C 78,0 -2,64 -2,210
 L -1,600
 Z
 '
 transform='translate(4238,19362) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_8251ce5326b11f0b)'
+clip-path='url(#clip_7669be9c3d101251)'
 />
 <!-- m -->
 <clipPath id='clip_6dddcaa6de82b2c7'>
@@ -22379,694 +24769,1600 @@ clip-path='url(#clip_607b45ea872a6a55)'
 <g id='Dactyl Smooth9'>
 <text x='0' y='20672' font-size='200'>Dactyl Smooth</text>
 <!-- a -->
-<clipPath id='clip_dad0d571344f86e4'>
+<clipPath id='clip_25752a4b8fedeba3'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 299,420
-C 320,420 340,420 361,420
-C 361,279 361,141 361,-0
-C 340,-0 320,-0 299,-0
-C 299,141 299,279 299,420
+C 306,423 313,425 318,427
+C 324,428 329,429 333,428
+C 338,428 343,427 347,426
+C 352,424 356,422 361,420
+C 385,409 397,391 399,367
+C 402,342 396,311 388,275
+C 381,239 372,197 367,151
+C 362,105 361,54 361,-0
+C 354,-3 347,-5 342,-7
+C 336,-8 331,-9 327,-8
+C 322,-8 317,-7 313,-6
+C 308,-4 304,-2 299,-0
+C 275,11 263,29 261,53
+C 258,78 264,109 272,145
+C 279,181 288,223 293,269
+C 298,315 299,366 299,420
 Z
 M 361,300
-C 341,300 319,302 299,300
-C 275,338 232,369 186,361
-C 126,349 60,277 61,211
-C 63,148 127,72 186,59
-C 231,50 277,81 299,120
-C 319,120 341,120 361,120
-C 324,54 249,-15 174,1
-C 90,18 0,115 -1,209
-C -3,300 82,402 174,419
-C 249,434 321,363 361,300
+C 355,298 349,296 344,295
+C 338,294 333,293 328,294
+C 323,294 318,294 314,295
+C 309,297 304,298 299,300
+C 288,304 279,311 271,318
+C 262,325 254,334 246,341
+C 237,348 229,355 219,358
+C 209,362 199,363 186,361
+C 171,358 156,351 142,342
+C 127,333 113,321 101,307
+C 88,294 78,278 71,262
+C 65,246 61,228 61,211
+C 62,193 66,176 72,160
+C 79,144 89,128 101,114
+C 112,101 126,89 141,79
+C 155,70 171,63 186,59
+C 199,57 210,57 221,57
+C 232,58 242,61 251,65
+C 260,69 268,75 276,84
+C 284,93 291,105 299,120
+C 306,123 313,126 319,128
+C 325,131 331,132 337,132
+C 342,132 347,132 351,130
+C 355,128 359,125 361,120
+C 367,110 363,96 354,81
+C 344,66 328,50 309,37
+C 289,23 267,11 243,4
+C 220,-2 196,-4 174,1
+C 153,5 132,14 112,27
+C 92,40 72,57 55,76
+C 38,95 24,116 14,139
+C 4,161 -1,185 -1,209
+C -2,234 3,259 12,281
+C 21,304 35,326 52,345
+C 69,364 88,380 109,393
+C 130,406 152,415 174,419
+C 195,424 215,422 234,416
+C 253,410 271,399 287,386
+C 303,373 317,357 330,342
+C 343,327 353,312 361,300
 Z
 '
 transform='translate(0,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_dad0d571344f86e4)'
+clip-path='url(#clip_25752a4b8fedeba3)'
 />
 <!-- b -->
-<clipPath id='clip_5371c4c961820bad'>
+<clipPath id='clip_434d787331efd44e'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,660
-C 20,660 40,660 61,660
-C 61,439 61,221 61,-0
-C 40,-0 20,0 -1,-0
-C -1,221 -1,439 -1,660
+C 6,663 13,665 18,666
+C 24,667 29,668 34,667
+C 38,667 43,666 47,665
+C 52,664 56,662 61,660
+C 95,647 112,620 115,583
+C 119,545 110,496 100,438
+C 89,380 77,313 69,239
+C 62,165 61,85 61,-0
+C 54,-3 47,-5 42,-6
+C 36,-7 31,-8 26,-7
+C 22,-7 17,-6 13,-5
+C 8,-4 4,-2 -1,-0
+C -35,13 -52,40 -55,77
+C -59,115 -50,164 -40,222
+C -29,280 -17,347 -9,421
+C -2,495 -1,575 -1,660
 Z
 M -1,120
-C 19,120 41,120 61,120
-C 85,77 127,50 174,59
-C 235,72 298,144 299,210
-C 299,276 235,350 174,360
-C 129,369 86,338 61,300
-C 42,300 17,299 -1,300
-C 41,362 107,433 186,420
-C 276,404 362,302 361,210
-C 361,112 270,17 186,1
-C 109,-15 30,64 -1,120
+C 5,122 11,124 16,125
+C 21,126 27,126 32,126
+C 37,126 42,126 46,125
+C 51,123 56,122 61,120
+C 72,116 81,109 89,102
+C 98,94 106,86 114,79
+C 122,71 131,65 141,61
+C 150,58 161,57 174,59
+C 188,62 203,69 218,79
+C 232,88 246,100 259,114
+C 271,127 281,143 288,159
+C 295,175 298,193 299,210
+C 299,227 295,245 289,261
+C 282,278 273,293 261,307
+C 249,320 236,332 221,342
+C 206,351 190,358 174,360
+C 162,363 151,363 141,361
+C 130,360 121,358 112,353
+C 103,349 95,343 86,334
+C 78,325 70,314 61,300
+C 54,297 47,294 41,292
+C 35,290 29,288 23,288
+C 18,288 13,288 9,290
+C 5,292 1,295 -1,300
+C -7,310 -3,323 6,338
+C 16,353 32,368 51,382
+C 70,396 93,407 116,414
+C 139,421 163,423 186,420
+C 206,416 228,407 249,394
+C 269,381 289,364 306,345
+C 323,326 337,305 347,282
+C 357,259 362,234 361,210
+C 361,186 356,161 347,139
+C 337,116 324,95 307,76
+C 291,57 271,40 251,27
+C 230,14 208,5 186,1
+C 165,-4 145,-3 126,3
+C 107,8 90,18 74,31
+C 58,43 43,58 31,74
+C 18,89 7,105 -1,120
 Z
 '
 transform='translate(403,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_5371c4c961820bad)'
+clip-path='url(#clip_434d787331efd44e)'
 />
 <!-- c -->
-<clipPath id='clip_03f30a8528999790'>
+<clipPath id='clip_6bfaf9d4ca0f9321'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 361,300
-C 341,300 319,302 299,300
-C 275,338 232,369 186,361
-C 126,349 60,277 61,211
-C 63,148 127,72 186,59
-C 231,50 277,81 299,120
-C 319,120 341,120 361,120
-C 324,54 249,-15 174,1
-C 90,18 0,115 -1,209
-C -3,300 82,402 174,419
-C 249,434 321,363 361,300
+C 355,298 349,296 344,295
+C 338,294 333,293 328,294
+C 323,294 318,294 314,295
+C 309,297 304,298 299,300
+C 288,304 279,311 271,318
+C 262,325 254,334 246,341
+C 237,348 229,355 219,358
+C 209,362 199,363 186,361
+C 171,358 156,351 142,342
+C 127,333 113,321 101,307
+C 88,294 78,278 71,262
+C 65,246 61,228 61,211
+C 62,193 66,176 72,160
+C 79,144 89,128 101,114
+C 112,101 126,89 141,79
+C 155,70 171,63 186,59
+C 199,57 210,57 221,57
+C 232,58 242,61 251,65
+C 260,69 268,75 276,84
+C 284,93 291,105 299,120
+C 306,123 313,126 319,128
+C 325,131 331,132 337,132
+C 342,132 347,132 351,130
+C 355,128 359,125 361,120
+C 367,110 363,96 354,81
+C 344,66 328,50 309,37
+C 289,23 267,11 243,4
+C 220,-2 196,-4 174,1
+C 153,5 132,14 112,27
+C 92,40 72,57 55,76
+C 38,95 24,116 14,139
+C 4,161 -1,185 -1,209
+C -2,234 3,259 12,281
+C 21,304 35,326 52,345
+C 69,364 88,380 109,393
+C 130,406 152,415 174,419
+C 195,424 215,422 234,416
+C 253,410 271,399 287,386
+C 303,373 317,357 330,342
+C 343,327 353,312 361,300
 Z
 '
 transform='translate(806,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_03f30a8528999790)'
+clip-path='url(#clip_6bfaf9d4ca0f9321)'
 />
 <!-- d -->
-<clipPath id='clip_a7852d908343c6e3'>
+<clipPath id='clip_ccf8f707cc7f4a58'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 299,660
-C 320,660 340,660 361,660
-C 361,439 361,221 361,-0
-C 340,-0 320,0 299,-0
-C 299,221 299,439 299,660
+C 306,663 313,665 318,666
+C 324,667 329,668 334,667
+C 338,667 343,666 347,665
+C 352,664 356,662 361,660
+C 395,647 412,620 415,583
+C 419,545 410,496 400,438
+C 389,380 377,313 369,239
+C 362,165 361,85 361,-0
+C 354,-3 347,-5 342,-6
+C 336,-7 331,-8 326,-7
+C 322,-7 317,-6 313,-5
+C 308,-4 304,-2 299,-0
+C 265,13 248,40 245,77
+C 241,115 250,164 260,222
+C 271,280 283,347 291,421
+C 298,495 299,575 299,660
 Z
 M 361,300
-C 341,300 319,302 299,300
-C 275,338 232,369 186,361
-C 126,349 60,277 61,211
-C 63,148 127,72 186,59
-C 231,50 277,81 299,120
-C 319,120 341,120 361,120
-C 324,54 249,-15 174,1
-C 90,18 0,115 -1,209
-C -3,300 82,402 174,419
-C 249,434 321,363 361,300
+C 355,298 349,296 344,295
+C 338,294 333,293 328,294
+C 323,294 318,294 314,295
+C 309,297 304,298 299,300
+C 288,304 279,311 271,318
+C 262,325 254,334 246,341
+C 237,348 229,355 219,358
+C 209,362 199,363 186,361
+C 171,358 156,351 142,342
+C 127,333 113,321 101,307
+C 88,294 78,278 71,262
+C 65,246 61,228 61,211
+C 62,193 66,176 72,160
+C 79,144 89,128 101,114
+C 112,101 126,89 141,79
+C 155,70 171,63 186,59
+C 199,57 210,57 221,57
+C 232,58 242,61 251,65
+C 260,69 268,75 276,84
+C 284,93 291,105 299,120
+C 306,123 313,126 319,128
+C 325,131 331,132 337,132
+C 342,132 347,132 351,130
+C 355,128 359,125 361,120
+C 367,110 363,96 354,81
+C 344,66 328,50 309,37
+C 289,23 267,11 243,4
+C 220,-2 196,-4 174,1
+C 153,5 132,14 112,27
+C 92,40 72,57 55,76
+C 38,95 24,116 14,139
+C 4,161 -1,185 -1,209
+C -2,234 3,259 12,281
+C 21,304 35,326 52,345
+C 69,364 88,380 109,393
+C 130,406 152,415 174,419
+C 195,424 215,422 234,416
+C 253,410 271,399 287,386
+C 303,373 317,357 330,342
+C 343,327 353,312 361,300
 Z
 '
 transform='translate(1209,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_a7852d908343c6e3)'
+clip-path='url(#clip_ccf8f707cc7f4a58)'
 />
 <!-- e -->
-<clipPath id='clip_d1b297c25c29f800'>
+<clipPath id='clip_851eebb56a4a8ef4'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,180
-C -1,200 -6,220 -1,240
-C 71,308 298,107 298,210
-C 298,273 245,360 180,360
-C 116,360 61,274 62,210
-C 62,144 123,74 187,59
-C 229,50 281,81 299,120
-C 320,120 340,120 361,120
-C 329,51 247,-16 173,1
-C 85,21 -2,118 -2,210
-C -1,303 86,420 180,420
-C 273,420 362,301 362,210
-C 362,86 89,264 -1,180
+C -4,187 -7,193 -9,198
+C -10,204 -11,209 -11,213
+C -10,218 -9,222 -8,227
+C -6,231 -4,235 -1,240
+C 10,259 37,274 76,284
+C 115,293 165,298 206,297
+C 247,296 279,289 292,275
+C 305,261 298,239 298,210
+C 298,226 295,243 290,260
+C 284,277 275,294 265,309
+C 255,324 242,337 228,346
+C 213,355 197,360 180,360
+C 163,360 147,355 132,346
+C 118,337 105,325 95,310
+C 84,296 76,279 70,262
+C 65,245 61,227 62,210
+C 62,193 65,175 70,158
+C 75,141 83,124 93,109
+C 103,94 115,82 130,73
+C 144,65 161,60 180,60
+C 192,60 202,62 212,64
+C 222,66 231,68 240,72
+C 249,76 258,82 268,90
+C 277,98 287,108 299,120
+C 306,123 313,126 319,128
+C 326,130 332,132 337,132
+C 342,132 347,131 351,129
+C 355,128 359,124 361,120
+C 366,111 362,98 353,85
+C 343,72 327,58 308,46
+C 290,33 268,21 245,13
+C 223,5 200,-0 180,0
+C 156,-0 132,7 110,19
+C 89,31 69,48 52,68
+C 36,88 22,111 13,136
+C 4,160 -2,185 -2,210
+C -2,235 4,260 13,284
+C 22,309 35,332 51,352
+C 68,372 87,389 109,401
+C 131,413 155,420 180,420
+C 205,420 229,413 251,400
+C 272,387 291,369 308,348
+C 324,327 337,303 347,279
+C 356,255 362,231 362,210
+C 362,219 358,229 340,239
+C 322,249 291,258 252,261
+C 213,263 167,259 124,245
+C 80,231 40,207 -1,180
 Z
 '
 transform='translate(1612,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_d1b297c25c29f800)'
+clip-path='url(#clip_851eebb56a4a8ef4)'
 />
 <!-- f -->
-<clipPath id='clip_9540c31cd313c5f3'>
+<clipPath id='clip_6d63dd0b7fe9bb68'>
 <rect x='-60' y='-360' width='449' height='1070'/>
 </clipPath>
 <path
 d='
 M 111,-0
-C 91,-0 70,0 49,-0
-C 12,168 -28,373 52,524
-C 96,605 193,660 286,660
-C 286,640 285,620 286,600
-C 212,600 141,559 108,496
-C 33,355 75,165 111,-0
+C 104,-2 98,-4 92,-5
+C 87,-6 82,-6 77,-6
+C 72,-6 68,-5 63,-4
+C 59,-3 54,-2 49,-0
+C 15,11 -7,40 -19,80
+C -31,120 -33,171 -28,225
+C -24,279 -13,336 1,389
+C 16,441 33,489 52,524
+C 65,548 79,568 96,585
+C 113,602 132,616 153,627
+C 173,638 196,646 218,651
+C 240,657 263,660 286,660
+C 288,654 290,649 291,643
+C 292,638 293,633 293,628
+C 293,623 292,619 291,614
+C 290,609 288,605 286,600
+C 279,584 267,574 251,568
+C 236,561 217,558 199,555
+C 180,551 162,547 147,538
+C 131,529 118,516 108,496
+C 93,469 83,429 78,383
+C 72,337 72,284 75,233
+C 79,181 85,131 93,89
+C 100,48 108,16 111,-0
 Z
 M -1,360
-C -1,380 -1,400 -1,420
-C 70,420 140,420 211,420
-C 211,400 211,380 211,360
-C 140,360 70,360 -1,360
+C -4,367 -7,373 -9,378
+C -10,384 -11,389 -11,393
+C -10,398 -9,402 -8,407
+C -6,411 -4,415 -1,420
+C 7,433 17,440 30,441
+C 43,443 58,439 76,435
+C 93,431 113,426 136,423
+C 159,421 184,420 211,420
+C 214,413 217,407 219,402
+C 220,396 221,391 221,387
+C 220,382 219,378 218,373
+C 216,369 214,365 211,360
+C 203,347 193,340 180,339
+C 167,337 152,341 134,345
+C 117,349 97,354 74,357
+C 51,359 26,360 -1,360
 Z
 '
 transform='translate(2015,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_9540c31cd313c5f3)'
+clip-path='url(#clip_6d63dd0b7fe9bb68)'
 />
 <!-- g -->
-<clipPath id='clip_2ff6f79af42dc706'>
+<clipPath id='clip_999965993cb91f31'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 299,420
-C 319,420 341,420 361,420
-C 459,278 430,39 359,-131
-C 329,-204 268,-300 180,-300
-C 116,-300 61,-259 -1,-240
-C -1,-220 -2,-200 -1,-180
-C 57,-198 122,-240 180,-240
-C 250,-240 277,-165 301,-109
-C 370,58 404,269 299,420
+C 306,422 313,424 318,425
+C 324,426 329,427 334,426
+C 338,426 343,425 347,424
+C 352,423 356,422 361,420
+C 396,409 417,379 429,339
+C 441,299 443,247 439,192
+C 434,136 423,77 409,21
+C 394,-36 377,-89 359,-131
+C 350,-153 340,-174 329,-194
+C 318,-213 306,-232 291,-247
+C 277,-263 261,-276 243,-285
+C 224,-295 204,-300 180,-300
+C 164,-300 150,-297 137,-293
+C 124,-289 113,-284 100,-278
+C 87,-272 74,-266 57,-260
+C 41,-253 22,-247 -1,-240
+C -5,-233 -8,-227 -10,-222
+C -12,-216 -13,-211 -13,-206
+C -13,-201 -12,-196 -10,-192
+C -8,-187 -5,-184 -1,-180
+C 8,-172 19,-172 32,-176
+C 46,-180 61,-189 77,-198
+C 93,-208 110,-218 127,-226
+C 145,-234 163,-240 180,-240
+C 196,-240 210,-235 222,-228
+C 235,-220 245,-209 255,-197
+C 264,-185 273,-170 280,-155
+C 288,-140 294,-124 301,-109
+C 324,-53 343,-6 360,38
+C 377,81 391,120 398,158
+C 404,197 401,234 385,275
+C 369,317 339,362 299,420
 Z
 M 361,360
-C 361,338 361,320 361,300
-C 309,329 239,360 180,360
-C 108,360 60,278 61,211
-C 63,150 105,60 180,60
-C 239,60 307,92 361,120
-C 361,101 361,79 361,60
-C 305,31 238,-0 180,0
-C 81,0 1,116 -1,209
-C -4,305 81,420 180,420
-C 241,420 307,391 361,360
+C 364,354 367,348 369,343
+C 371,337 372,332 372,327
+C 373,321 372,317 370,312
+C 368,308 365,304 361,300
+C 352,292 341,292 328,296
+C 315,301 300,309 284,319
+C 268,328 251,338 233,346
+C 216,354 198,360 180,360
+C 163,360 147,355 132,346
+C 118,337 105,325 94,311
+C 84,297 75,280 69,263
+C 64,246 61,228 61,211
+C 62,194 65,177 70,159
+C 76,142 83,124 92,109
+C 102,94 114,81 128,73
+C 143,64 160,60 180,60
+C 194,60 212,62 230,67
+C 248,71 266,77 284,84
+C 302,91 318,99 332,105
+C 345,112 356,117 361,120
+C 363,113 365,107 367,102
+C 368,96 368,91 368,87
+C 368,82 367,78 366,74
+C 364,69 363,65 361,60
+C 355,44 347,33 336,24
+C 326,15 313,10 297,7
+C 282,3 265,1 245,1
+C 226,-0 204,-0 180,0
+C 142,0 113,1 90,10
+C 67,19 51,36 38,58
+C 26,80 18,107 11,133
+C 4,159 -1,185 -1,209
+C -2,234 2,260 11,285
+C 19,310 31,334 47,354
+C 62,374 81,391 103,403
+C 126,414 151,420 180,420
+C 196,420 213,418 231,414
+C 249,410 267,404 284,398
+C 301,391 316,383 330,377
+C 343,370 354,364 361,360
 Z
 '
 transform='translate(2343,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_2ff6f79af42dc706)'
+clip-path='url(#clip_999965993cb91f31)'
 />
 <!-- h -->
-<clipPath id='clip_16242134a332bc28'>
+<clipPath id='clip_3d431bf0c2d559eb'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,660
-C 20,660 40,660 61,660
-C 61,439 61,221 61,-0
-C 40,-0 20,0 -1,-0
-C -1,221 -1,439 -1,660
+C 6,663 13,665 18,666
+C 24,667 29,668 34,667
+C 38,667 43,666 47,665
+C 52,664 56,662 61,660
+C 95,647 112,620 115,583
+C 119,545 110,496 100,438
+C 89,380 77,313 69,239
+C 62,165 61,85 61,-0
+C 54,-3 47,-5 42,-6
+C 36,-7 31,-8 26,-7
+C 22,-7 17,-6 13,-5
+C 8,-4 4,-2 -1,-0
+C -35,13 -52,40 -55,77
+C -59,115 -50,164 -40,222
+C -29,280 -17,347 -9,421
+C -2,495 -1,575 -1,660
 Z
 M 61,300
-C 41,300 19,299 -1,300
-C 43,365 107,437 187,419
-C 271,401 340,302 361,217
-C 378,146 382,63 361,-0
-C 341,-0 318,1 299,-0
-C 320,65 316,137 299,203
-C 283,268 236,347 173,361
-C 126,371 86,337 61,300
+C 54,297 47,294 41,292
+C 35,289 29,288 23,288
+C 18,288 13,288 9,290
+C 5,292 1,295 -1,300
+C -7,310 -3,324 7,339
+C 16,354 32,370 52,384
+C 71,398 94,409 117,416
+C 141,423 165,424 187,419
+C 207,415 226,405 245,393
+C 263,381 281,365 296,348
+C 311,330 325,310 336,288
+C 346,266 354,242 361,217
+C 365,201 368,182 371,164
+C 373,145 374,125 375,106
+C 375,87 374,68 372,50
+C 369,32 366,15 361,-0
+C 355,-3 350,-5 344,-7
+C 339,-9 333,-9 328,-9
+C 323,-9 318,-9 313,-7
+C 308,-5 303,-3 299,-0
+C 287,8 282,20 283,34
+C 283,47 287,64 292,81
+C 297,99 302,119 304,139
+C 306,159 305,181 299,203
+C 296,217 291,233 283,249
+C 276,266 267,282 256,298
+C 245,313 233,327 219,338
+C 205,349 190,357 173,361
+C 161,363 150,364 140,362
+C 129,361 120,358 111,354
+C 103,349 94,343 86,334
+C 78,325 70,313 61,300
 Z
 '
 transform='translate(2746,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_16242134a332bc28)'
+clip-path='url(#clip_3d431bf0c2d559eb)'
 />
 <!-- i -->
-<clipPath id='clip_0f21b35df5032d83'>
+<clipPath id='clip_e89a7fcba29dfbbe'>
 <rect x='-60' y='-360' width='228' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,420
-C 20,420 40,420 61,420
-C 61,279 61,141 61,-0
-C 40,-0 20,-0 -1,-0
-C -1,141 -1,279 -1,420
+C 6,423 13,425 18,427
+C 24,428 29,429 33,428
+C 38,428 43,427 47,426
+C 52,424 56,422 61,420
+C 85,409 97,391 99,367
+C 102,342 96,311 88,275
+C 81,239 72,197 67,151
+C 62,105 61,54 61,-0
+C 54,-3 47,-5 42,-7
+C 36,-8 31,-9 27,-8
+C 22,-8 17,-7 13,-6
+C 8,-4 4,-2 -1,-0
+C -25,11 -37,29 -39,53
+C -42,78 -36,109 -28,145
+C -21,181 -12,223 -7,269
+C -2,315 -1,366 -1,420
 Z
 M 30,515
-C 52,515 65,534 65,550
-C 65,569 51,585 30,585
-C 12,585 -5,570 -5,550
-C -5,533 8,515 30,515
+C 48,515 65,532 65,550
+C 65,568 48,585 30,585
+C 12,585 -5,568 -5,550
+C -5,532 12,515 30,515
 Z
 '
 transform='translate(3149,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_0f21b35df5032d83)'
+clip-path='url(#clip_e89a7fcba29dfbbe)'
 />
 <!-- j -->
-<clipPath id='clip_769075e1b2ea4017'>
+<clipPath id='clip_7f580bbf44a6ba2f'>
 <rect x='-60' y='-360' width='453' height='1070'/>
 </clipPath>
 <path
 d='
 M 224,420
-C 243,420 265,420 286,420
-C 345,236 312,45 286,-125
-C 277,-187 247,-271 194,-297
-C 107,-340 28,-225 -1,-180
-C 24,-180 42,-180 61,-180
-C 88,-221 119,-267 166,-243
-C 200,-226 218,-155 224,-115
-C 250,58 281,242 224,420
+C 231,423 238,425 243,426
+C 249,427 254,427 259,427
+C 263,427 268,426 272,425
+C 277,423 281,422 286,420
+C 317,408 335,385 343,353
+C 352,321 350,280 344,232
+C 338,184 328,129 317,69
+C 307,8 296,-57 286,-125
+C 282,-149 279,-170 274,-188
+C 270,-206 264,-221 257,-234
+C 249,-247 241,-258 231,-269
+C 221,-280 209,-289 194,-297
+C 175,-306 156,-308 137,-304
+C 118,-299 99,-288 82,-274
+C 64,-259 48,-242 33,-225
+C 19,-209 7,-193 -1,-180
+C 5,-178 11,-176 16,-175
+C 22,-173 27,-173 32,-173
+C 37,-173 42,-174 47,-175
+C 51,-176 56,-178 61,-180
+C 71,-184 80,-192 89,-200
+C 98,-209 107,-218 115,-227
+C 123,-235 132,-241 140,-245
+C 148,-248 157,-248 166,-243
+C 176,-238 183,-231 189,-223
+C 195,-215 201,-206 205,-195
+C 209,-185 213,-173 216,-160
+C 219,-147 221,-132 224,-115
+C 226,-100 231,-74 240,-40
+C 249,-7 260,35 267,82
+C 275,129 277,182 270,238
+C 263,294 245,354 224,420
 Z
 M 255,515
-C 276,515 289,535 290,550
-C 291,567 274,585 255,585
-C 235,585 220,572 220,550
-C 220,531 236,515 255,515
+C 273,515 290,532 290,550
+C 290,568 273,585 255,585
+C 237,585 220,568 220,550
+C 220,532 237,515 255,515
 Z
 '
 transform='translate(3252,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_769075e1b2ea4017)'
+clip-path='url(#clip_7f580bbf44a6ba2f)'
 />
 <!-- k -->
-<clipPath id='clip_a6ec0d4c85e2779c'>
+<clipPath id='clip_82bc7150600fe9c8'>
 <rect x='-60' y='-360' width='449' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,660
-C 20,660 40,660 61,660
-C 61,439 61,221 61,-0
-C 40,-0 20,0 -1,-0
-C -1,221 -1,439 -1,660
+C 6,663 13,665 18,666
+C 24,667 29,668 34,667
+C 38,667 43,666 47,665
+C 52,664 56,662 61,660
+C 95,647 112,620 115,583
+C 119,545 110,496 100,438
+C 89,380 77,313 69,239
+C 62,165 61,85 61,-0
+C 54,-3 47,-5 42,-6
+C 36,-7 31,-8 26,-7
+C 22,-7 17,-6 13,-5
+C 8,-4 4,-2 -1,-0
+C -35,13 -52,40 -55,77
+C -59,115 -50,164 -40,222
+C -29,280 -17,347 -9,421
+C -2,495 -1,575 -1,660
 Z
 M 286,420
-C 286,400 287,380 286,360
-C 195,287 89,252 -1,180
-C -1,200 -2,220 -1,240
-C 89,312 196,348 286,420
+C 288,413 289,406 290,401
+C 291,396 291,391 291,386
+C 290,382 290,378 289,374
+C 288,369 287,365 286,360
+C 279,331 266,313 248,301
+C 229,290 205,284 178,277
+C 152,270 123,262 94,246
+C 64,231 34,208 -1,180
+C -3,187 -4,194 -5,199
+C -6,204 -6,209 -6,214
+C -5,218 -5,222 -4,226
+C -3,231 -2,235 -1,240
+C 6,269 19,287 37,299
+C 56,310 80,316 107,323
+C 133,330 162,338 191,354
+C 221,369 251,392 286,420
 Z
 M -1,180
-C -1,198 -1,220 -1,240
-C 89,168 193,135 286,60
-C 286,40 285,20 286,-0
-C 196,72 91,106 -1,180
+C -5,187 -8,193 -10,198
+C -12,204 -13,209 -13,214
+C -13,219 -12,224 -10,228
+C -8,232 -5,236 -1,240
+C 11,251 26,252 45,245
+C 63,238 85,223 109,205
+C 133,186 161,162 191,138
+C 220,113 253,87 286,60
+C 290,53 293,47 295,42
+C 297,36 298,31 298,26
+C 298,21 297,16 295,12
+C 293,8 290,4 286,-0
+C 274,-11 259,-12 240,-5
+C 222,2 200,17 176,35
+C 152,54 124,78 94,102
+C 65,127 32,153 -1,180
 Z
 '
 transform='translate(3580,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_a6ec0d4c85e2779c)'
+clip-path='url(#clip_82bc7150600fe9c8)'
 />
 <!-- l -->
-<clipPath id='clip_63201953b3591967'>
+<clipPath id='clip_cb0a905d49324315'>
 <rect x='-60' y='-360' width='374' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,660
-C 19,660 39,660 61,660
-C 23,523 6,355 59,221
-C 89,145 143,100 211,60
-C 211,39 211,20 211,-0
-C 116,55 42,93 1,199
-C -31,280 -42,513 -1,660
+C 6,663 12,665 18,667
+C 24,668 29,669 33,669
+C 38,668 43,667 47,666
+C 52,664 56,662 61,660
+C 85,649 96,624 99,592
+C 102,560 98,520 91,476
+C 84,433 74,386 67,341
+C 61,295 57,251 61,214
+C 64,193 69,173 75,153
+C 81,133 89,115 99,99
+C 110,84 123,73 141,67
+C 159,61 182,60 211,60
+C 215,53 218,47 220,42
+C 222,36 223,31 223,26
+C 223,21 222,16 220,12
+C 218,7 215,4 211,-0
+C 199,-10 181,-10 159,-3
+C 138,4 113,19 90,39
+C 67,60 45,85 29,114
+C 13,142 3,174 -1,206
+C -5,236 -3,264 2,295
+C 7,326 15,358 20,393
+C 25,429 28,467 25,511
+C 21,554 11,603 -1,660
 Z
 '
 transform='translate(3908,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_63201953b3591967)'
+clip-path='url(#clip_cb0a905d49324315)'
 />
 <!-- m -->
-<clipPath id='clip_347df3dec813f7ca'>
+<clipPath id='clip_9f5d0b9239e94a3e'>
 <rect x='-60' y='-360' width='674' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,420
-C 20,420 40,420 61,420
-C 61,279 61,141 61,-0
-C 40,-0 20,-0 -1,-0
-C -1,141 -1,279 -1,420
+C 6,423 13,425 18,427
+C 24,428 29,429 33,428
+C 38,428 43,427 47,426
+C 52,424 56,422 61,420
+C 85,409 97,391 99,367
+C 102,342 96,311 88,275
+C 81,239 72,197 67,151
+C 62,105 61,54 61,-0
+C 54,-3 47,-5 42,-7
+C 36,-8 31,-9 27,-8
+C 22,-8 17,-7 13,-6
+C 8,-4 4,-2 -1,-0
+C -25,11 -37,29 -39,53
+C -42,78 -36,109 -28,145
+C -21,181 -12,223 -7,269
+C -2,315 -1,366 -1,420
 Z
 M 61,300
-C 41,300 19,300 -1,300
-C 43,365 116,448 192,418
-C 257,392 284,286 286,211
-C 289,146 301,68 286,-0
-C 265,-0 244,1 224,-0
-C 239,67 226,140 224,209
-C 222,264 219,342 168,362
-C 125,379 85,335 61,300
+C 54,297 47,294 41,292
+C 35,290 29,288 23,288
+C 18,288 13,288 9,290
+C 5,292 1,295 -1,300
+C -7,310 -3,325 8,341
+C 19,357 37,374 58,389
+C 78,403 102,415 125,421
+C 149,426 172,426 192,418
+C 209,411 222,400 234,387
+C 246,374 256,360 264,344
+C 272,327 277,309 281,287
+C 284,265 286,240 286,211
+C 287,185 288,162 289,142
+C 290,122 290,104 291,88
+C 291,72 291,58 291,43
+C 291,29 289,15 286,-0
+C 280,-3 275,-5 269,-7
+C 264,-8 258,-9 253,-9
+C 248,-9 243,-8 238,-6
+C 233,-5 229,-3 224,-0
+C 211,8 205,18 204,31
+C 203,44 206,59 211,76
+C 215,93 220,113 222,135
+C 225,157 224,182 224,209
+C 223,229 222,248 221,264
+C 219,280 217,294 213,306
+C 210,318 205,329 197,339
+C 190,349 181,357 168,362
+C 157,366 147,367 138,366
+C 128,365 119,361 110,356
+C 102,351 94,343 86,334
+C 78,325 70,313 61,300
 Z
 M 286,240
-C 266,240 244,240 224,240
-C 245,321 312,434 395,420
-C 472,407 506,291 511,212
-C 516,141 538,67 511,-0
-C 491,-0 469,2 449,-0
-C 475,65 453,138 449,208
-C 445,263 441,351 385,360
-C 334,369 299,291 286,240
+C 279,236 273,233 267,231
+C 261,229 255,227 250,227
+C 245,227 240,228 236,230
+C 232,233 228,236 224,240
+C 214,251 214,270 222,290
+C 229,311 243,333 262,354
+C 280,375 302,394 325,406
+C 349,418 373,423 395,420
+C 415,416 431,407 445,395
+C 460,383 472,369 481,352
+C 491,335 498,315 503,292
+C 507,269 509,242 511,212
+C 513,185 515,163 516,144
+C 518,124 520,108 521,92
+C 522,77 523,62 522,47
+C 521,32 518,17 511,-0
+C 505,-3 500,-5 494,-6
+C 489,-8 484,-9 478,-9
+C 473,-9 468,-8 463,-7
+C 458,-5 454,-3 449,-0
+C 436,8 430,18 430,31
+C 429,44 433,58 438,76
+C 442,93 447,112 449,134
+C 451,156 450,181 449,208
+C 447,229 446,248 444,265
+C 442,282 439,296 435,309
+C 430,322 424,333 416,342
+C 409,351 398,358 385,360
+C 372,363 360,360 349,354
+C 339,349 330,340 322,330
+C 314,320 307,307 301,292
+C 296,277 291,259 286,240
 Z
 '
 transform='translate(4161,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_347df3dec813f7ca)'
+clip-path='url(#clip_9f5d0b9239e94a3e)'
 />
 <!-- n -->
-<clipPath id='clip_785a1a96397d4f85'>
+<clipPath id='clip_2c7ac2a3658990b2'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,420
-C 20,420 40,420 61,420
-C 61,279 61,141 61,-0
-C 40,-0 20,-0 -1,-0
-C -1,141 -1,279 -1,420
+C 6,423 13,425 18,427
+C 24,428 29,429 33,428
+C 38,428 43,427 47,426
+C 52,424 56,422 61,420
+C 85,409 97,391 99,367
+C 102,342 96,311 88,275
+C 81,239 72,197 67,151
+C 62,105 61,54 61,-0
+C 54,-3 47,-5 42,-7
+C 36,-8 31,-9 27,-8
+C 22,-8 17,-7 13,-6
+C 8,-4 4,-2 -1,-0
+C -25,11 -37,29 -39,53
+C -42,78 -36,109 -28,145
+C -21,181 -12,223 -7,269
+C -2,315 -1,366 -1,420
 Z
 M -1,300
-C -1,320 -2,340 -1,360
-C 51,395 117,420 180,420
-C 273,420 341,306 361,217
-C 376,149 394,66 361,-0
-C 341,-0 320,2 299,-0
-C 330,62 314,137 299,203
-C 285,269 249,360 180,360
-C 118,360 51,335 -1,300
+C -4,307 -6,313 -7,319
+C -8,324 -8,329 -8,333
+C -8,338 -7,342 -6,347
+C -4,351 -3,355 -1,360
+C 5,376 13,387 24,396
+C 34,405 47,410 63,413
+C 78,417 95,419 115,419
+C 134,420 156,420 180,420
+C 217,420 245,419 266,413
+C 287,406 302,393 313,375
+C 325,357 332,334 340,307
+C 347,280 353,250 361,217
+C 367,190 372,168 375,148
+C 378,128 380,111 380,95
+C 381,79 380,64 377,48
+C 374,33 369,17 361,-0
+C 355,-3 350,-5 344,-7
+C 339,-8 334,-9 328,-9
+C 323,-9 318,-8 313,-7
+C 308,-5 303,-3 299,-0
+C 287,8 282,20 282,33
+C 282,47 287,63 292,80
+C 297,98 302,117 304,138
+C 306,159 304,180 299,203
+C 296,217 292,233 286,251
+C 281,269 274,288 266,305
+C 257,322 247,337 233,346
+C 219,356 201,360 180,360
+C 166,360 153,359 139,357
+C 126,355 112,354 98,350
+C 83,346 68,341 52,333
+C 36,325 19,314 -1,300
 Z
 '
 transform='translate(4714,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_785a1a96397d4f85)'
+clip-path='url(#clip_2c7ac2a3658990b2)'
 />
 <!-- o -->
-<clipPath id='clip_e06503d440c86663'>
+<clipPath id='clip_0d70c8ece17d55cf'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,211
-C 1,295 53,420 180,420
-C 273,420 366,329 361,209
-C 357,94 271,8 183,0
-C 63,-11 -5,113 -1,211
+C -1,235 5,260 14,284
+C 23,308 37,331 53,352
+C 69,372 88,389 110,401
+C 131,413 155,420 180,420
+C 205,420 229,413 252,401
+C 274,389 294,372 310,352
+C 327,332 340,309 349,285
+C 358,260 362,234 361,209
+C 361,185 355,161 346,138
+C 336,114 323,92 307,72
+C 290,53 271,36 250,23
+C 229,10 207,2 183,0
+C 156,-2 132,3 109,14
+C 87,26 67,43 50,63
+C 34,84 20,108 11,133
+C 2,159 -2,185 -1,211
 Z
 M 177,60
-C 236,65 296,137 299,211
-C 302,295 244,360 180,360
-C 102,360 63,272 61,209
-C 60,147 88,52 177,60
+C 194,61 209,68 224,77
+C 238,86 251,99 262,113
+C 273,128 282,144 288,161
+C 294,177 298,195 299,211
+C 299,229 296,247 291,264
+C 285,281 277,297 266,311
+C 255,326 243,338 228,346
+C 213,355 197,360 180,360
+C 163,360 147,355 132,346
+C 118,337 106,324 95,309
+C 85,294 77,277 71,260
+C 65,243 62,225 61,209
+C 61,192 64,174 69,156
+C 74,138 82,121 92,106
+C 102,91 115,79 129,71
+C 143,62 159,58 177,60
 Z
 '
 transform='translate(5117,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_e06503d440c86663)'
+clip-path='url(#clip_0d70c8ece17d55cf)'
 />
 <!-- p -->
-<clipPath id='clip_b64ced70ddbc7679'>
+<clipPath id='clip_9091268201e8d6c9'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,420
-C 20,420 40,420 61,420
-C 61,179 61,-59 61,-300
-C 40,-300 20,-300 -1,-300
-C -1,-59 -1,179 -1,420
+C 6,423 13,425 18,426
+C 24,427 29,427 34,427
+C 38,427 43,426 47,425
+C 52,423 56,422 61,420
+C 98,407 115,378 119,337
+C 123,296 114,242 102,179
+C 91,115 78,42 70,-39
+C 62,-120 61,-208 61,-300
+C 54,-303 47,-305 42,-306
+C 36,-307 31,-307 26,-307
+C 22,-307 17,-306 13,-305
+C 8,-303 4,-302 -1,-300
+C -38,-287 -55,-258 -59,-217
+C -63,-176 -54,-122 -42,-59
+C -31,5 -18,78 -10,159
+C -2,240 -1,328 -1,420
 Z
 M -1,120
-C 19,120 41,120 61,120
-C 85,77 127,50 174,59
-C 235,72 298,144 299,210
-C 299,276 235,350 174,360
-C 129,369 86,338 61,300
-C 42,300 17,299 -1,300
-C 41,362 107,433 186,420
-C 276,404 362,302 361,210
-C 361,112 270,17 186,1
-C 109,-15 30,64 -1,120
+C 5,122 11,124 16,125
+C 21,126 27,126 32,126
+C 37,126 42,126 46,125
+C 51,123 56,122 61,120
+C 72,116 81,109 89,102
+C 98,94 106,86 114,79
+C 122,71 131,65 141,61
+C 150,58 161,57 174,59
+C 188,62 203,69 218,79
+C 232,88 246,100 259,114
+C 271,127 281,143 288,159
+C 295,175 298,193 299,210
+C 299,227 295,245 289,261
+C 282,278 273,293 261,307
+C 249,320 236,332 221,342
+C 206,351 190,358 174,360
+C 162,363 151,363 141,361
+C 130,360 121,358 112,353
+C 103,349 95,343 86,334
+C 78,325 70,314 61,300
+C 54,297 47,294 41,292
+C 35,290 29,288 23,288
+C 18,288 13,288 9,290
+C 5,292 1,295 -1,300
+C -7,310 -3,323 6,338
+C 16,353 32,368 51,382
+C 70,396 93,407 116,414
+C 139,421 163,423 186,420
+C 206,416 228,407 249,394
+C 269,381 289,364 306,345
+C 323,326 337,305 347,282
+C 357,259 362,234 361,210
+C 361,186 356,161 347,139
+C 337,116 324,95 307,76
+C 291,57 271,40 251,27
+C 230,14 208,5 186,1
+C 165,-4 145,-3 126,3
+C 107,8 90,18 74,31
+C 58,43 43,58 31,74
+C 18,89 7,105 -1,120
 Z
 '
 transform='translate(5520,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_b64ced70ddbc7679)'
+clip-path='url(#clip_9091268201e8d6c9)'
 />
 <!-- q -->
-<clipPath id='clip_ced8858da5396451'>
+<clipPath id='clip_cf2bfd755be5618c'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 299,420
-C 320,420 340,420 361,420
-C 361,179 361,-59 361,-300
-C 340,-300 320,-300 299,-300
-C 299,-59 299,179 299,420
+C 306,423 313,425 318,426
+C 324,427 329,427 334,427
+C 338,427 343,426 347,425
+C 352,423 356,422 361,420
+C 398,407 415,378 419,337
+C 423,296 414,242 402,179
+C 391,115 378,42 370,-39
+C 362,-120 361,-208 361,-300
+C 354,-303 347,-305 342,-306
+C 336,-307 331,-307 326,-307
+C 322,-307 317,-306 313,-305
+C 308,-303 304,-302 299,-300
+C 262,-287 245,-258 241,-217
+C 237,-176 246,-122 258,-59
+C 269,5 282,78 290,159
+C 298,240 299,328 299,420
 Z
 M 361,300
-C 341,300 319,302 299,300
-C 275,338 232,369 186,361
-C 126,349 60,277 61,211
-C 63,148 127,72 186,59
-C 231,50 277,81 299,120
-C 319,120 341,120 361,120
-C 324,54 249,-15 174,1
-C 90,18 0,115 -1,209
-C -3,300 82,402 174,419
-C 249,434 321,363 361,300
+C 355,298 349,296 344,295
+C 338,294 333,293 328,294
+C 323,294 318,294 314,295
+C 309,297 304,298 299,300
+C 288,304 279,311 271,318
+C 262,325 254,334 246,341
+C 237,348 229,355 219,358
+C 209,362 199,363 186,361
+C 171,358 156,351 142,342
+C 127,333 113,321 101,307
+C 88,294 78,278 71,262
+C 65,246 61,228 61,211
+C 62,193 66,176 72,160
+C 79,144 89,128 101,114
+C 112,101 126,89 141,79
+C 155,70 171,63 186,59
+C 199,57 210,57 221,57
+C 232,58 242,61 251,65
+C 260,69 268,75 276,84
+C 284,93 291,105 299,120
+C 306,123 313,126 319,128
+C 325,131 331,132 337,132
+C 342,132 347,132 351,130
+C 355,128 359,125 361,120
+C 367,110 363,96 354,81
+C 344,66 328,50 309,37
+C 289,23 267,11 243,4
+C 220,-2 196,-4 174,1
+C 153,5 132,14 112,27
+C 92,40 72,57 55,76
+C 38,95 24,116 14,139
+C 4,161 -1,185 -1,209
+C -2,234 3,259 12,281
+C 21,304 35,326 52,345
+C 69,364 88,380 109,393
+C 130,406 152,415 174,419
+C 195,424 215,422 234,416
+C 253,410 271,399 287,386
+C 303,373 317,357 330,342
+C 343,327 353,312 361,300
 Z
 '
 transform='translate(5923,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_ced8858da5396451)'
+clip-path='url(#clip_cf2bfd755be5618c)'
 />
 <!-- r -->
-<clipPath id='clip_d5d72d7db6c458df'>
+<clipPath id='clip_bf8f925109e2e011'>
 <rect x='-60' y='-360' width='424' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,420
-C 20,420 40,420 61,420
-C 61,279 61,141 61,-0
-C 40,-0 20,-0 -1,-0
-C -1,141 -1,279 -1,420
+C 6,423 13,425 18,427
+C 24,428 29,429 33,428
+C 38,428 43,427 47,426
+C 52,424 56,422 61,420
+C 85,409 97,391 99,367
+C 102,342 96,311 88,275
+C 81,239 72,197 67,151
+C 62,105 61,54 61,-0
+C 54,-3 47,-5 42,-7
+C 36,-8 31,-9 27,-8
+C 22,-8 17,-7 13,-6
+C 8,-4 4,-2 -1,-0
+C -25,11 -37,29 -39,53
+C -42,78 -36,109 -28,145
+C -21,181 -12,223 -7,269
+C -2,315 -1,366 -1,420
 Z
 M 61,300
-C 42,300 20,301 -1,300
-C 33,359 66,420 130,420
-C 190,420 234,344 261,300
-C 238,300 219,300 199,300
-C 182,327 167,360 130,360
-C 99,360 74,322 61,300
+C 54,296 48,293 41,291
+C 35,289 30,288 24,287
+C 19,287 14,288 10,290
+C 6,292 2,295 -1,300
+C -7,309 -6,321 -0,334
+C 6,347 17,361 30,374
+C 44,387 61,398 78,407
+C 95,415 113,420 130,420
+C 146,420 159,416 170,410
+C 182,404 192,396 201,386
+C 211,376 220,364 230,350
+C 239,336 249,319 261,300
+C 254,297 248,294 242,292
+C 237,290 231,290 227,290
+C 222,290 217,291 213,293
+C 208,295 204,297 199,300
+C 192,304 186,310 181,317
+C 176,323 172,330 167,337
+C 162,343 157,349 151,353
+C 145,357 139,360 130,360
+C 122,360 115,358 109,355
+C 103,352 97,348 92,344
+C 87,339 82,333 77,326
+C 72,319 67,310 61,300
 Z
 '
 transform='translate(6326,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_d5d72d7db6c458df)'
+clip-path='url(#clip_bf8f925109e2e011)'
 />
 <!-- s -->
-<clipPath id='clip_e32ec9773746501c'>
+<clipPath id='clip_f33fcd185a9f40c3'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 361,300
-C 341,300 319,301 299,300
-C 270,331 226,360 180,360
-C 132,360 48,326 60,278
-C 71,236 139,240 180,240
-C 245,240 337,222 360,160
-C 388,84 259,-0 180,0
-C 107,0 39,60 -1,120
-C 19,120 41,120 61,120
-C 86,82 134,60 180,60
-C 229,60 318,91 300,140
-C 286,178 221,180 180,180
-C 114,180 16,197 -0,262
-C -21,343 103,420 180,420
-C 253,420 312,352 361,300
+C 354,298 347,296 342,295
+C 336,294 331,293 326,294
+C 322,294 317,295 313,296
+C 308,297 304,298 299,300
+C 288,304 278,309 269,316
+C 260,322 251,329 242,336
+C 233,342 224,348 214,353
+C 203,357 193,360 180,360
+C 168,360 154,357 139,353
+C 125,349 110,343 97,335
+C 85,328 74,319 67,309
+C 60,299 58,289 60,278
+C 63,268 69,260 78,255
+C 86,249 97,246 109,244
+C 120,242 133,241 145,240
+C 158,240 170,240 180,240
+C 199,240 218,239 237,237
+C 255,234 272,230 288,224
+C 304,218 319,210 331,200
+C 344,189 354,176 360,160
+C 367,140 366,121 357,102
+C 349,83 334,66 315,51
+C 297,36 274,23 250,14
+C 227,5 202,0 180,0
+C 161,0 142,4 125,11
+C 107,18 90,28 74,40
+C 58,52 44,66 31,80
+C 18,93 7,107 -1,120
+C 5,122 11,123 16,124
+C 22,125 27,126 32,125
+C 37,125 42,125 46,124
+C 51,123 56,122 61,120
+C 72,116 82,111 91,105
+C 101,98 110,91 119,84
+C 128,78 137,72 147,67
+C 157,63 168,60 180,60
+C 192,60 207,63 222,67
+C 238,72 253,78 266,86
+C 280,93 290,102 297,111
+C 303,120 304,129 300,140
+C 297,149 290,156 281,162
+C 272,168 262,172 250,174
+C 238,177 226,179 214,179
+C 202,180 190,180 180,180
+C 159,180 138,181 119,183
+C 100,185 82,189 66,195
+C 51,202 36,210 25,221
+C 13,232 4,245 -0,262
+C -6,283 -3,303 7,321
+C 16,340 31,357 50,372
+C 68,386 90,398 113,407
+C 136,415 159,420 180,420
+C 200,420 216,416 231,410
+C 246,404 259,396 272,387
+C 285,377 298,365 312,351
+C 326,337 342,320 361,300
 Z
 '
 transform='translate(6629,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_e32ec9773746501c)'
+clip-path='url(#clip_f33fcd185a9f40c3)'
 />
 <!-- t -->
-<clipPath id='clip_96b00fe491ca20d1'>
+<clipPath id='clip_027e47dbc1c98f5c'>
 <rect x='-60' y='-360' width='424' height='1070'/>
 </clipPath>
 <path
 d='
 M 74,660
-C 94,660 116,660 136,660
-C 89,503 92,316 135,158
-C 145,121 156,74 193,57
-C 214,48 241,48 261,60
-C 261,41 265,19 261,-0
-C 234,-16 195,-10 167,3
-C 116,26 89,89 75,142
-C 30,307 22,490 74,660
+C 81,663 86,665 92,666
+C 97,668 103,668 108,668
+C 112,668 117,667 122,666
+C 127,664 131,662 136,660
+C 161,647 168,626 163,596
+C 157,566 141,528 127,483
+C 113,439 102,390 103,336
+C 104,282 118,224 135,158
+C 139,144 142,132 146,122
+C 149,111 152,102 156,95
+C 159,87 164,80 170,74
+C 175,68 183,62 193,57
+C 199,55 204,53 209,51
+C 214,50 219,49 225,48
+C 230,48 235,48 241,50
+C 247,52 253,56 261,60
+C 265,53 268,47 270,42
+C 272,36 272,31 272,26
+C 272,22 271,17 269,13
+C 267,8 264,4 261,-0
+C 256,-7 249,-10 242,-12
+C 234,-14 226,-14 217,-13
+C 208,-12 199,-10 191,-7
+C 182,-4 174,-1 167,3
+C 149,11 136,19 125,28
+C 115,37 107,48 101,60
+C 96,71 91,84 87,98
+C 83,112 79,126 75,142
+C 63,186 53,233 47,279
+C 42,326 40,373 41,419
+C 42,464 46,509 51,550
+C 57,591 64,628 74,660
 Z
 M -1,360
-C -1,380 -1,400 -1,420
-C 87,420 173,420 261,420
-C 261,400 261,380 261,360
-C 173,360 87,360 -1,360
+C -4,367 -7,373 -8,378
+C -10,384 -10,389 -10,393
+C -10,398 -9,402 -7,407
+C -6,411 -4,415 -1,420
+C 8,436 20,444 36,446
+C 51,447 70,443 92,438
+C 114,433 139,427 168,424
+C 196,421 227,420 261,420
+C 264,413 267,407 268,402
+C 270,396 270,391 270,387
+C 270,382 269,378 267,373
+C 266,369 264,365 261,360
+C 252,344 240,336 224,334
+C 209,333 190,337 168,342
+C 146,347 121,353 92,356
+C 64,359 33,360 -1,360
 Z
 '
 transform='translate(7032,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_96b00fe491ca20d1)'
+clip-path='url(#clip_027e47dbc1c98f5c)'
 />
 <!-- u -->
-<clipPath id='clip_60e61371de5fbc2e'>
+<clipPath id='clip_c8826ec3a6cc5352'>
 <rect x='-60' y='-360' width='449' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,420
-C 19,420 41,420 61,420
-C 34,356 41,285 60,218
-C 78,157 109,50 175,60
-C 236,69 225,164 224,209
-C 221,277 237,349 224,420
-C 244,420 266,420 286,420
-C 299,347 284,283 286,211
-C 289,127 273,14 185,0
-C 102,-12 26,108 -0,202
-C -23,281 -31,348 -1,420
+C 5,423 10,425 16,427
+C 21,429 27,429 32,429
+C 37,430 42,429 47,427
+C 52,426 57,423 61,420
+C 73,412 77,401 75,388
+C 74,374 68,359 62,342
+C 56,325 51,306 50,285
+C 49,265 53,243 60,218
+C 64,206 69,189 76,171
+C 83,153 91,133 101,116
+C 111,99 122,83 134,73
+C 147,63 161,57 175,60
+C 188,62 197,68 204,77
+C 211,86 216,97 219,110
+C 222,123 224,138 224,154
+C 225,171 224,189 224,209
+C 223,236 222,255 224,272
+C 225,288 228,302 230,315
+C 232,328 234,341 233,358
+C 232,374 229,394 224,420
+C 231,423 237,426 243,428
+C 248,430 254,430 258,430
+C 263,430 268,429 272,427
+C 277,425 281,423 286,420
+C 299,412 305,402 307,389
+C 308,376 304,361 300,344
+C 295,327 290,307 288,285
+C 285,263 286,238 286,211
+C 287,181 288,154 286,131
+C 283,107 278,87 270,69
+C 262,52 251,37 237,25
+C 222,13 206,4 185,0
+C 162,-3 140,2 120,13
+C 101,24 83,41 67,60
+C 51,80 38,103 27,128
+C 16,152 7,178 -0,202
+C -5,219 -9,237 -13,255
+C -16,274 -18,293 -18,312
+C -19,331 -18,350 -15,369
+C -12,387 -8,404 -1,420
 Z
 M 224,420
-C 245,420 265,420 286,420
-C 286,279 286,141 286,-0
-C 265,-0 245,-0 224,-0
-C 224,141 224,279 224,420
+C 231,423 238,425 243,427
+C 249,428 254,429 258,428
+C 263,428 268,427 272,426
+C 277,424 281,422 286,420
+C 310,409 322,391 324,367
+C 327,342 321,311 313,275
+C 306,239 297,197 292,151
+C 287,105 286,54 286,-0
+C 279,-3 272,-5 267,-7
+C 261,-8 256,-9 252,-8
+C 247,-8 242,-7 238,-6
+C 233,-4 229,-2 224,-0
+C 200,11 188,29 186,53
+C 183,78 189,109 197,145
+C 204,181 213,223 218,269
+C 223,315 224,366 224,420
 Z
 '
 transform='translate(7335,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_60e61371de5fbc2e)'
+clip-path='url(#clip_c8826ec3a6cc5352)'
 />
 <!-- v -->
-<clipPath id='clip_b8de03b0d0b6090f'>
+<clipPath id='clip_591fa4ba2dbfaa99'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,420
-C 15,420 44,420 61,420
-C -48,259 60,60 180,60
-C 320,60 348,283 299,420
-C 305,420 333,420 361,420
-C 412,276 354,-0 180,0
-C 71,0 -137,220 -1,420
+C 5,423 11,425 17,426
+C 22,427 27,428 32,428
+C 37,427 42,427 47,425
+C 51,424 56,422 61,420
+C 86,408 105,378 120,336
+C 135,294 145,241 153,194
+C 161,147 166,107 170,85
+C 174,63 177,60 180,60
+C 202,60 225,76 249,98
+C 272,120 295,150 311,182
+C 327,214 335,250 333,290
+C 330,329 316,372 299,420
+C 306,423 312,426 318,428
+C 323,430 329,430 333,430
+C 338,430 343,429 347,427
+C 352,425 356,423 361,420
+C 385,405 395,372 394,329
+C 393,285 381,233 361,184
+C 342,134 315,88 284,54
+C 252,20 217,-0 180,0
+C 144,0 107,19 73,48
+C 39,76 8,115 -13,157
+C -35,200 -48,245 -46,290
+C -45,335 -29,379 -1,420
 Z
 '
 transform='translate(7663,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_b8de03b0d0b6090f)'
+clip-path='url(#clip_591fa4ba2dbfaa99)'
 />
 <!-- w -->
-<clipPath id='clip_2305f3e1b608eb48'>
+<clipPath id='clip_c8993f51e7327db8'>
 <rect x='-60' y='-360' width='674' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,420
-C 20,420 40,420 61,420
-C 29,301 20,60 142,60
-C 270,60 127,420 255,420
-C 380,420 238,60 367,60
-C 500,60 379,429 511,420
-C 511,400 506,380 511,360
-C 379,369 499,0 368,0
-C 242,-0 382,360 255,360
-C 128,360 271,0 143,0
-C -3,-0 -40,277 -1,420
+C 5,423 11,425 17,426
+C 22,428 27,428 32,428
+C 37,428 42,427 47,426
+C 52,424 56,422 61,420
+C 85,408 103,380 116,344
+C 130,308 139,264 144,222
+C 150,180 151,139 151,109
+C 150,79 147,60 142,60
+C 147,60 156,83 166,117
+C 176,151 187,196 199,241
+C 210,286 222,330 232,364
+C 242,398 250,420 255,420
+C 260,420 268,397 278,360
+C 287,324 298,275 310,228
+C 321,181 332,136 342,106
+C 352,76 361,60 367,60
+C 376,60 388,87 402,129
+C 416,172 432,228 447,279
+C 462,329 476,371 487,394
+C 498,418 506,420 511,420
+C 511,414 511,408 511,402
+C 512,397 512,392 512,388
+C 512,383 511,379 511,374
+C 511,370 511,365 511,360
+C 510,328 506,289 499,250
+C 492,211 482,171 469,134
+C 457,98 442,65 424,40
+C 407,16 388,0 368,0
+C 360,-0 351,5 340,30
+C 330,55 319,99 308,149
+C 297,199 286,255 277,295
+C 268,336 260,360 255,360
+C 250,360 242,336 233,295
+C 224,255 213,199 202,149
+C 192,99 180,55 170,30
+C 160,5 150,0 143,0
+C 119,-0 96,19 74,47
+C 52,76 32,114 16,157
+C 1,199 -9,245 -13,291
+C -16,337 -11,381 -1,420
 Z
 '
 transform='translate(8066,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_2305f3e1b608eb48)'
+clip-path='url(#clip_c8993f51e7327db8)'
 />
 <!-- x -->
-<clipPath id='clip_385b2e5b839184df'>
+<clipPath id='clip_ab55528a903fe1d7'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,420
-C 21,420 50,420 61,420
-C 188,268 208,184 361,-0
-C 342,-0 320,-0 299,-0
-C 169,155 111,286 -1,420
+C 7,421 13,422 19,423
+C 24,423 29,423 34,423
+C 38,423 43,423 47,422
+C 51,422 56,421 61,420
+C 106,413 135,396 155,369
+C 176,343 188,307 201,268
+C 215,229 231,186 256,142
+C 282,97 318,52 361,-0
+C 353,-1 347,-2 341,-3
+C 336,-3 331,-3 326,-3
+C 322,-3 317,-3 313,-2
+C 309,-2 304,-1 299,-0
+C 254,7 225,24 205,51
+C 184,77 172,113 159,152
+C 145,191 129,234 104,278
+C 78,323 42,368 -1,420
 Z
 M 299,420
-C 319,420 340,420 361,420
-C 246,282 185,148 61,-0
-C 50,-0 20,0 -1,-0
-C 114,139 173,269 299,420
+C 306,424 312,427 318,429
+C 324,431 329,433 334,433
+C 340,433 344,431 349,429
+C 353,427 357,424 361,420
+C 375,405 373,384 360,358
+C 346,332 322,300 291,265
+C 260,229 222,188 183,143
+C 144,99 103,50 61,-0
+C 54,-4 48,-7 42,-9
+C 36,-11 31,-13 26,-13
+C 20,-13 16,-11 11,-9
+C 7,-7 3,-4 -1,-0
+C -15,15 -13,36 0,62
+C 14,88 38,120 69,155
+C 100,191 138,232 177,277
+C 216,321 257,370 299,420
 Z
 '
 transform='translate(8619,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_385b2e5b839184df)'
+clip-path='url(#clip_ab55528a903fe1d7)'
 />
 <!-- y -->
-<clipPath id='clip_78f1d5a60fdd87b5'>
+<clipPath id='clip_900d202e0af7d3b7'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,420
-C 18,420 44,420 61,420
-C 38,353 42,291 61,217
-C 74,162 101,60 180,60
-C 245,60 287,162 299,217
-C 316,290 329,350 299,420
-C 319,420 341,420 361,420
-C 391,350 377,277 361,203
-C 338,101 275,-0 180,0
-C 88,0 21,117 -1,203
-C -21,283 -26,348 -1,420
+C 5,423 10,425 16,427
+C 21,429 27,429 32,429
+C 37,429 42,429 47,427
+C 52,426 57,423 61,420
+C 73,412 77,401 77,387
+C 76,374 71,358 65,341
+C 60,323 55,304 53,284
+C 52,263 55,241 61,217
+C 64,204 69,188 75,171
+C 81,153 89,135 99,118
+C 109,101 120,87 134,76
+C 147,66 162,60 180,60
+C 197,60 213,66 226,74
+C 239,83 250,95 260,109
+C 269,124 277,140 283,158
+C 290,177 295,196 299,217
+C 302,230 306,244 310,259
+C 314,273 319,288 322,304
+C 325,321 325,338 321,356
+C 318,375 309,396 299,420
+C 306,423 312,426 318,427
+C 324,429 329,430 333,429
+C 338,429 343,428 347,426
+C 352,425 356,423 361,420
+C 376,412 385,401 389,388
+C 393,374 393,358 390,340
+C 388,321 383,301 378,278
+C 373,255 367,230 361,203
+C 353,169 346,140 336,115
+C 326,90 314,71 299,54
+C 284,38 266,26 246,16
+C 227,7 205,-0 180,0
+C 155,0 133,7 114,18
+C 94,30 77,46 62,65
+C 47,84 34,105 24,129
+C 14,153 6,178 -1,203
+C -5,219 -8,238 -11,256
+C -14,275 -15,294 -15,314
+C -16,333 -15,352 -12,370
+C -10,388 -6,405 -1,420
 Z
 M 299,420
-C 318,420 341,420 361,420
-C 396,289 380,160 361,26
-C 345,-90 281,-269 190,-299
-C 98,-329 45,-259 -1,-180
-C 20,-180 38,-180 61,-180
-C 85,-221 118,-259 170,-241
-C 235,-220 287,-47 299,34
-C 318,171 338,273 299,420
+C 306,423 313,425 318,426
+C 324,428 329,428 334,428
+C 338,428 343,427 347,425
+C 352,424 356,422 361,420
+C 385,410 399,392 404,369
+C 410,345 409,316 404,282
+C 399,247 391,208 383,165
+C 375,122 368,75 361,26
+C 355,-20 349,-60 340,-95
+C 332,-130 321,-159 308,-185
+C 295,-211 279,-233 260,-253
+C 241,-272 218,-289 190,-299
+C 169,-305 149,-306 130,-301
+C 111,-296 93,-286 76,-272
+C 60,-259 45,-242 31,-226
+C 18,-210 7,-194 -1,-180
+C 5,-178 11,-176 16,-175
+C 21,-174 27,-173 32,-173
+C 37,-173 42,-174 46,-175
+C 51,-176 56,-178 61,-180
+C 71,-184 80,-191 89,-200
+C 97,-208 105,-217 113,-225
+C 122,-232 130,-239 139,-242
+C 148,-245 158,-245 170,-241
+C 191,-235 208,-220 222,-203
+C 236,-187 247,-167 257,-144
+C 267,-122 275,-97 282,-67
+C 288,-37 293,-3 299,34
+C 306,82 311,118 316,149
+C 321,179 326,204 328,228
+C 330,253 330,277 325,307
+C 321,337 312,372 299,420
 Z
 '
 transform='translate(9022,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_78f1d5a60fdd87b5)'
+clip-path='url(#clip_900d202e0af7d3b7)'
 />
 <!-- z -->
-<clipPath id='clip_2abd30a5940d39c6'>
+<clipPath id='clip_ef7a130d189b01ff'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,360
-C -1,378 -2,401 -1,420
-C 90,499 324,515 360,399
-C 409,242 41,178 61,34
-C 78,-87 286,8 361,60
-C 361,41 362,19 361,-0
-C 252,-76 18,-113 -1,26
-C -22,181 349,224 300,381
-C 273,467 75,426 -1,360
+C -4,367 -6,373 -7,379
+C -8,384 -9,389 -9,393
+C -8,398 -7,402 -6,407
+C -5,411 -3,415 -1,420
+C 10,446 35,464 69,475
+C 102,485 142,489 182,486
+C 222,483 263,474 295,459
+C 327,445 352,424 360,399
+C 368,374 358,346 334,316
+C 310,285 272,252 231,218
+C 190,184 146,149 113,118
+C 80,86 58,57 61,34
+C 63,20 74,8 93,-1
+C 112,-10 139,-16 169,-17
+C 198,-17 231,-11 264,2
+C 296,16 328,37 361,60
+C 364,53 366,47 368,41
+C 369,36 370,31 369,27
+C 369,22 368,18 367,13
+C 365,9 363,5 361,-0
+C 350,-24 322,-41 287,-51
+C 251,-61 208,-64 167,-61
+C 125,-58 84,-49 54,-34
+C 23,-19 2,1 -1,26
+C -5,54 14,85 46,117
+C 78,150 122,183 163,215
+C 205,247 244,277 270,305
+C 296,333 307,358 300,381
+C 294,400 277,415 254,426
+C 231,437 204,444 175,445
+C 146,446 116,440 87,425
+C 58,410 29,387 -1,360
 Z
 '
 transform='translate(9425,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_2abd30a5940d39c6)'
+clip-path='url(#clip_ef7a130d189b01ff)'
 />
 <!--   -->
 <clipPath id='clip_e3b0c44298fc1c14'>
@@ -23080,904 +26376,2074 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_e3b0c44298fc1c14)'
 />
 <!-- 0 -->
-<clipPath id='clip_5002ba674c5f3ed1'>
+<clipPath id='clip_ea509eced99d1a36'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,326
-C -25,508 47,660 180,660
-C 314,660 374,489 361,328
-C 351,191 305,17 184,0
-C 46,-19 1,311 -1,326
+C -6,365 -7,405 -2,443
+C 3,481 14,517 30,549
+C 47,580 68,608 93,628
+C 118,648 147,660 180,660
+C 213,660 241,648 266,628
+C 290,608 310,581 326,550
+C 342,519 352,483 358,445
+C 364,407 364,367 361,328
+C 359,301 355,268 348,234
+C 340,199 330,163 315,130
+C 301,96 283,66 261,43
+C 240,20 214,4 184,0
+C 154,-4 129,5 108,25
+C 86,46 69,76 54,112
+C 39,148 28,188 18,226
+C 9,264 2,299 -1,326
 Z
 M 176,60
-C 269,73 295,288 299,332
-C 306,434 310,600 180,600
-C 91,600 44,460 61,334
-C 74,237 47,42 176,60
+C 197,63 215,76 231,96
+C 246,116 259,142 269,171
+C 278,200 285,231 290,259
+C 295,287 297,313 299,332
+C 301,367 303,401 300,432
+C 298,463 292,491 282,515
+C 271,539 257,559 240,575
+C 223,590 203,600 180,600
+C 157,600 136,590 119,574
+C 102,558 87,536 77,511
+C 66,486 60,458 58,428
+C 55,398 57,366 61,334
+C 64,314 68,286 74,254
+C 80,222 87,187 96,156
+C 105,125 115,98 128,81
+C 141,64 157,57 176,60
 Z
 M 299,660
-C 307,660 345,660 361,660
-C 267,473 184,247 61,-0
-C 39,-0 17,0 -1,-0
-C 137,275 168,399 299,660
+C 306,664 312,667 318,669
+C 323,671 329,672 334,671
+C 339,671 343,670 348,668
+C 352,666 357,663 361,660
+C 383,643 385,614 373,575
+C 360,536 333,488 299,431
+C 265,373 224,307 184,235
+C 143,162 102,82 61,-0
+C 54,-4 48,-7 42,-9
+C 37,-11 31,-12 26,-11
+C 21,-11 17,-10 12,-8
+C 8,-6 3,-3 -1,-0
+C -23,17 -25,46 -13,85
+C -0,124 27,172 61,229
+C 95,287 136,353 176,425
+C 217,498 258,578 299,660
 Z
 '
 transform='translate(10081,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_5002ba674c5f3ed1)'
+clip-path='url(#clip_ea509eced99d1a36)'
 />
 <!-- 1 -->
-<clipPath id='clip_2b816de863d34e34'>
+<clipPath id='clip_ffb132dd123672c9'>
 <rect x='-60' y='-360' width='269' height='1070'/>
 </clipPath>
 <path
 d='
 M 61,540
-C 41,540 23,536 -1,540
-C -7,586 38,663 106,660
-C 273,653 268,130 74,0
-C 74,16 75,42 74,60
-C 233,167 191,596 104,600
-C 69,602 57,575 61,540
+C 54,536 48,533 42,531
+C 36,529 30,527 25,527
+C 20,527 15,528 11,530
+C 6,532 2,536 -1,540
+C -8,549 -9,561 -5,575
+C -2,589 6,604 16,617
+C 27,630 41,642 56,650
+C 72,657 89,661 106,660
+C 162,658 208,682 242,656
+C 276,630 297,558 298,466
+C 300,373 281,264 241,180
+C 202,97 141,45 74,0
+C 74,7 74,13 74,18
+C 74,24 74,28 74,33
+C 74,37 74,42 74,46
+C 74,50 74,55 74,60
+C 74,105 76,164 78,230
+C 80,297 82,370 85,432
+C 88,494 91,543 94,570
+C 97,597 100,600 104,600
+C 95,600 88,600 81,597
+C 75,595 70,591 66,586
+C 62,580 60,574 60,566
+C 59,558 60,550 61,540
 Z
 '
 transform='translate(10484,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_2b816de863d34e34)'
+clip-path='url(#clip_ffb132dd123672c9)'
 />
 <!-- 2 -->
-<clipPath id='clip_89178002c29a53ca'>
+<clipPath id='clip_42814591fe6cf8cc'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 61,540
-C 40,540 20,539 -1,540
-C 36,597 110,673 186,660
-C 264,645 346,567 361,485
-C 382,366 308,205 193,153
-C 144,131 58,93 61,32
-C 66,-49 251,-17 299,60
-C 319,60 341,60 361,60
-C 294,-48 5,-98 -1,28
-C -6,108 92,173 167,207
-C 259,249 316,380 299,475
-C 288,534 230,591 174,600
-C 130,608 85,577 61,540
+C 54,537 47,534 41,532
+C 35,530 29,528 23,528
+C 18,528 13,528 9,530
+C 5,532 1,535 -1,540
+C -7,550 -3,563 6,578
+C 16,593 31,609 51,623
+C 70,636 92,648 116,655
+C 139,662 163,664 186,660
+C 204,656 223,649 242,639
+C 261,629 280,616 296,601
+C 313,586 327,569 338,549
+C 349,530 357,508 361,485
+C 367,455 367,422 365,389
+C 362,357 358,324 347,293
+C 337,263 321,236 296,213
+C 271,190 236,172 193,153
+C 179,146 164,140 148,132
+C 133,124 119,115 106,104
+C 93,94 82,83 74,71
+C 65,59 61,46 61,32
+C 62,17 60,4 73,-6
+C 87,-15 113,-22 145,-22
+C 177,-22 213,-15 240,-1
+C 267,13 284,35 299,60
+C 307,60 314,61 322,61
+C 329,61 336,61 342,61
+C 347,61 352,61 356,61
+C 359,61 361,60 361,60
+C 361,59 336,55 295,52
+C 254,48 197,43 146,39
+C 95,35 51,31 27,29
+C 2,28 -1,27 -1,28
+C -3,48 3,66 11,83
+C 19,100 29,116 43,131
+C 56,145 72,158 93,171
+C 114,183 139,195 167,207
+C 204,224 233,238 253,256
+C 274,274 286,296 293,320
+C 300,345 302,372 303,398
+C 304,425 303,451 299,475
+C 296,491 291,507 283,521
+C 275,535 266,547 254,558
+C 243,569 230,578 216,585
+C 203,593 189,598 174,600
+C 162,603 151,603 141,601
+C 130,600 120,598 111,594
+C 102,589 94,583 86,574
+C 78,565 70,554 61,540
 Z
 '
 transform='translate(10662,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_89178002c29a53ca)'
+clip-path='url(#clip_42814591fe6cf8cc)'
 />
 <!-- 3 -->
-<clipPath id='clip_fa830c3c9a89e2a0'>
+<clipPath id='clip_b320c0d038344645'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 61,540
-C 41,540 19,540 -1,540
-C 36,602 115,673 186,659
-C 266,644 359,564 361,481
-C 364,398 276,325 188,301
-C 157,292 124,283 99,300
-C 99,318 105,341 99,360
-C 119,347 148,352 172,359
-C 226,374 300,422 299,479
-C 297,535 229,590 174,601
-C 131,609 82,575 61,540
+C 54,537 47,534 41,532
+C 35,530 29,528 23,528
+C 18,528 13,528 9,530
+C 5,532 1,535 -1,540
+C -7,550 -3,564 6,578
+C 16,593 31,609 50,623
+C 69,637 92,649 115,656
+C 139,662 163,664 186,659
+C 204,656 224,648 244,638
+C 264,627 284,614 301,598
+C 319,582 334,564 344,544
+C 355,524 361,503 361,481
+C 362,458 357,437 350,418
+C 343,398 333,381 319,366
+C 306,351 289,338 268,328
+C 246,317 219,310 188,301
+C 178,298 168,296 160,294
+C 152,292 146,290 139,289
+C 133,289 126,289 120,291
+C 113,292 106,295 99,300
+C 97,304 94,310 93,315
+C 91,320 90,326 89,331
+C 89,337 89,342 91,347
+C 92,352 95,357 99,360
+C 104,364 109,365 114,365
+C 119,365 125,363 131,361
+C 137,359 143,357 150,357
+C 156,356 164,357 172,359
+C 181,361 193,366 207,373
+C 222,380 237,389 251,399
+C 265,409 278,421 286,435
+C 295,448 299,463 299,479
+C 298,495 294,509 286,523
+C 279,536 268,548 256,559
+C 244,570 230,579 216,586
+C 202,593 187,598 174,601
+C 162,603 150,603 140,602
+C 129,601 119,599 110,595
+C 101,590 93,584 85,575
+C 77,566 70,554 61,540
 Z
 M 99,300
-C 99,320 95,340 99,360
-C 127,373 160,367 189,359
-C 268,336 356,264 361,182
-C 367,97 266,8 183,0
-C 109,-7 41,58 -1,120
-C 20,120 40,120 61,120
-C 86,83 133,56 177,60
-C 233,65 303,120 299,178
-C 295,236 227,285 171,301
-C 147,308 122,310 99,300
+C 95,307 92,313 90,318
+C 88,324 87,329 88,334
+C 88,338 89,343 91,347
+C 93,352 95,356 99,360
+C 104,366 110,370 115,372
+C 121,374 128,374 135,373
+C 142,372 150,370 159,367
+C 168,365 178,362 189,359
+C 219,350 245,342 266,332
+C 287,321 303,308 316,293
+C 329,278 338,261 346,242
+C 354,224 360,204 361,182
+C 363,158 358,136 349,115
+C 339,94 325,75 307,59
+C 290,43 270,29 248,19
+C 227,9 204,2 183,0
+C 162,-2 143,1 124,8
+C 106,14 88,25 72,38
+C 57,51 42,66 30,80
+C 17,95 7,108 -1,120
+C 5,122 11,124 16,125
+C 22,126 27,126 32,126
+C 37,126 42,125 46,124
+C 51,123 56,122 61,120
+C 72,116 81,110 90,103
+C 99,96 107,89 116,82
+C 124,75 133,69 143,65
+C 153,60 164,59 177,60
+C 190,61 205,65 219,72
+C 234,79 248,87 260,98
+C 272,108 283,120 290,134
+C 296,147 300,162 299,178
+C 298,193 293,208 285,221
+C 278,234 268,246 256,256
+C 244,267 231,276 217,283
+C 202,291 187,297 171,301
+C 165,303 159,305 153,306
+C 148,308 143,309 137,310
+C 132,310 127,310 121,309
+C 114,307 107,304 99,300
 Z
 '
 transform='translate(11065,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_fa830c3c9a89e2a0)'
+clip-path='url(#clip_b320c0d038344645)'
 />
 <!-- 4 -->
-<clipPath id='clip_e5feacee21671831'>
+<clipPath id='clip_bb3c258b1ad93fda'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 224,0
-C 224,20 225,40 224,60
-C 403,99 422,553 247,601
-C 100,641 -94,279 45,207
-C 137,159 256,206 361,210
-C 361,190 360,170 361,150
-C 251,146 117,100 15,153
-C -150,240 78,710 263,659
-C 474,601 445,48 224,0
+C 224,7 223,13 223,18
+C 223,24 223,28 223,33
+C 223,37 223,42 223,46
+C 224,50 224,55 224,60
+C 226,106 233,161 240,218
+C 248,275 256,335 263,389
+C 269,444 273,494 272,532
+C 270,570 263,596 247,601
+C 230,606 205,586 175,547
+C 145,508 111,451 82,397
+C 54,343 33,292 27,260
+C 20,228 29,215 45,207
+C 67,195 92,189 118,187
+C 144,185 171,186 199,189
+C 227,192 255,197 282,201
+C 310,205 336,209 361,210
+C 363,204 365,198 366,193
+C 367,188 367,183 367,178
+C 367,173 367,169 365,164
+C 364,159 363,155 361,150
+C 352,126 332,111 305,103
+C 279,95 246,94 211,97
+C 176,100 140,108 106,118
+C 71,128 40,141 15,153
+C -6,164 -18,181 -11,224
+C -4,268 22,336 57,408
+C 92,480 135,553 172,600
+C 210,647 241,665 263,659
+C 294,650 322,600 345,527
+C 368,454 386,360 391,277
+C 396,193 387,121 360,75
+C 332,30 285,13 224,0
 Z
 '
 transform='translate(11468,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_e5feacee21671831)'
+clip-path='url(#clip_bb3c258b1ad93fda)'
 />
 <!-- 5 -->
-<clipPath id='clip_7e3f1d2d501e38d2'>
+<clipPath id='clip_fb7dc94d8eb74be4'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 361,660
-C 361,640 360,620 361,600
-C 283,667 128,678 51,608
-C -12,550 -9,423 61,360
-C 61,342 62,320 61,300
-C -13,366 -86,565 9,652
-C 90,726 264,742 361,660
+C 364,654 367,649 369,643
+C 370,638 371,633 371,628
+C 371,623 370,618 369,613
+C 367,609 365,604 361,600
+C 349,586 328,584 302,588
+C 276,593 245,603 214,613
+C 182,622 150,631 122,632
+C 95,632 71,626 51,608
+C 36,594 24,575 14,553
+C 4,532 -4,509 -7,486
+C -10,464 -7,442 5,422
+C 16,401 36,382 61,360
+C 63,353 65,346 66,339
+C 68,332 69,326 69,321
+C 69,315 69,310 68,307
+C 66,303 64,301 61,300
+C 52,297 37,313 22,341
+C 7,368 -10,407 -21,448
+C -32,489 -37,531 -33,566
+C -29,602 -14,631 9,652
+C 28,670 54,684 84,695
+C 113,705 146,713 179,715
+C 212,717 245,715 276,706
+C 307,697 336,681 361,660
 Z
 M 61,300
-C 41,300 19,299 -1,300
-C 16,382 100,472 184,460
-C 276,447 367,325 361,228
-C 356,133 273,19 187,1
-C 111,-15 38,56 -1,120
-C 19,120 41,120 61,120
-C 85,82 129,50 173,59
-C 238,73 295,165 299,232
-C 303,303 246,390 176,400
-C 122,408 72,353 61,300
+C 54,296 48,293 42,291
+C 36,289 30,287 25,287
+C 19,287 15,288 10,290
+C 6,292 2,296 -1,300
+C -9,311 -8,328 1,346
+C 9,365 24,385 44,404
+C 63,422 86,438 111,448
+C 135,459 160,463 184,460
+C 207,457 230,446 252,432
+C 273,418 294,400 311,378
+C 328,357 342,333 350,308
+C 359,282 363,255 361,228
+C 360,204 355,179 345,155
+C 336,131 323,107 307,86
+C 292,65 273,46 253,31
+C 232,16 210,6 187,1
+C 165,-4 145,-3 127,3
+C 108,9 90,19 74,33
+C 58,46 43,61 30,77
+C 18,92 7,107 -1,120
+C 5,122 11,124 16,125
+C 22,126 27,127 32,126
+C 37,126 42,126 46,125
+C 51,124 56,122 61,120
+C 71,116 81,109 89,102
+C 98,94 106,86 114,79
+C 122,71 131,65 141,61
+C 150,58 161,57 173,59
+C 189,63 205,71 220,82
+C 234,94 248,108 259,125
+C 271,141 280,159 287,177
+C 294,196 298,214 299,232
+C 300,251 297,271 292,289
+C 286,308 277,325 266,341
+C 254,356 240,370 225,380
+C 210,391 193,398 176,400
+C 161,402 147,401 134,398
+C 121,394 109,389 99,381
+C 89,374 81,363 75,350
+C 69,336 65,320 61,300
 Z
 '
 transform='translate(11871,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_7e3f1d2d501e38d2)'
+clip-path='url(#clip_fb7dc94d8eb74be4)'
 />
 <!-- 6 -->
-<clipPath id='clip_0e6a29845a8ee496'>
+<clipPath id='clip_2e68629518f9ed8c'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 361,540
-C 341,540 319,543 299,540
-C 282,580 230,614 190,601
-C 94,571 77,424 61,325
-C 56,295 58,264 61,233
-C 68,163 110,60 180,60
-C 248,60 299,161 299,230
-C 298,300 246,394 177,400
-C 99,407 61,277 61,200
-C 41,200 20,200 -1,200
-C -1,307 76,470 183,460
-C 278,451 361,327 361,230
-C 363,133 278,0 180,0
-C 83,-0 8,130 -1,227
-C -5,263 -7,299 -1,335
-C 18,454 55,622 170,659
-C 242,682 332,610 361,540
+C 355,538 349,536 344,535
+C 339,534 334,533 328,533
+C 323,533 318,534 314,535
+C 309,536 304,538 299,540
+C 289,544 280,551 271,559
+C 263,568 255,577 247,584
+C 238,592 230,599 221,602
+C 212,605 202,605 190,601
+C 168,595 152,580 138,563
+C 125,546 114,527 104,504
+C 94,482 87,456 80,426
+C 73,397 67,363 61,325
+C 59,314 58,304 57,296
+C 56,288 57,281 57,274
+C 58,267 58,261 59,254
+C 60,248 61,241 61,233
+C 64,207 67,184 72,164
+C 77,143 84,126 94,111
+C 104,96 116,84 131,75
+C 145,66 161,60 180,60
+C 198,60 215,66 230,76
+C 244,87 257,101 267,118
+C 278,134 285,153 291,173
+C 296,192 299,212 299,230
+C 298,248 295,267 290,286
+C 284,304 275,323 265,339
+C 254,355 241,370 226,381
+C 211,391 195,398 177,400
+C 157,402 139,396 124,387
+C 108,377 95,363 85,345
+C 75,327 69,306 65,282
+C 61,257 61,230 61,200
+C 54,196 48,193 42,191
+C 36,189 31,188 26,188
+C 21,188 16,189 12,191
+C 7,193 3,196 -1,200
+C -16,213 -19,237 -13,265
+C -8,294 6,327 26,358
+C 45,388 70,416 97,435
+C 124,453 154,463 183,460
+C 207,458 230,448 251,434
+C 272,420 292,401 308,379
+C 325,357 338,333 347,307
+C 356,282 361,256 361,230
+C 362,204 357,177 349,150
+C 340,124 327,98 311,76
+C 295,54 275,35 253,21
+C 231,8 206,0 180,0
+C 154,-0 130,7 108,19
+C 86,30 67,45 51,64
+C 35,83 23,106 15,133
+C 6,160 2,192 -1,227
+C -2,237 -3,245 -4,253
+C -5,261 -6,268 -6,276
+C -7,283 -7,292 -6,301
+C -5,311 -3,321 -1,335
+C 6,380 13,420 22,455
+C 30,490 40,519 53,545
+C 66,571 81,593 100,613
+C 119,632 141,649 170,659
+C 192,665 212,666 231,662
+C 250,658 269,650 285,637
+C 302,625 317,610 330,593
+C 343,576 353,558 361,540
 Z
 '
 transform='translate(12274,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_0e6a29845a8ee496)'
+clip-path='url(#clip_2e68629518f9ed8c)'
 />
 <!-- 7 -->
-<clipPath id='clip_ab8b187f1c39cb21'>
+<clipPath id='clip_81691fbf36f2879e'>
 <rect x='-60' y='-360' width='515' height='1070'/>
 </clipPath>
 <path
 d='
 M 61,600
-C 43,600 18,599 -1,600
-C 60,663 242,759 352,651
-C 510,497 241,132 74,0
-C 74,19 74,42 74,60
-C 238,189 457,463 308,609
-C 235,680 135,677 61,600
+C 54,598 46,596 39,595
+C 32,593 26,592 20,592
+C 15,591 10,592 6,593
+C 2,594 -0,597 -1,600
+C -4,609 12,623 38,637
+C 65,651 102,665 142,675
+C 182,685 224,691 261,688
+C 298,685 330,673 352,651
+C 384,620 394,571 392,515
+C 390,460 374,397 348,336
+C 322,274 285,213 238,156
+C 191,99 133,47 74,0
+C 73,7 73,13 72,18
+C 72,24 72,28 72,33
+C 72,37 72,42 73,46
+C 73,50 73,55 74,60
+C 80,114 104,170 138,227
+C 172,285 214,343 250,395
+C 287,447 316,492 328,526
+C 339,561 332,585 308,609
+C 291,625 271,638 250,648
+C 229,658 207,666 186,668
+C 165,670 144,666 124,655
+C 104,643 84,624 61,600
 Z
 '
 transform='translate(12677,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_ab8b187f1c39cb21)'
+clip-path='url(#clip_81691fbf36f2879e)'
 />
 <!-- 8 -->
-<clipPath id='clip_4d3b2a50af5e07cc'>
+<clipPath id='clip_6d529812f10001fc'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 162,306
-C 95,353 12,399 -1,475
-C -19,577 98,660 180,660
-C 277,660 367,564 361,478
-C 357,399 247,330 194,303
-C 123,267 66,251 61,178
-C 59,131 104,60 180,60
-C 250,60 302,125 299,178
-C 294,246 225,260 162,306
+C 138,323 117,338 99,351
+C 82,364 67,376 53,387
+C 40,399 29,411 20,425
+C 10,439 3,455 -1,475
+C -5,499 -2,523 6,544
+C 15,566 30,586 47,603
+C 65,620 87,634 110,644
+C 133,654 157,660 180,660
+C 203,660 226,654 248,645
+C 270,635 290,621 307,604
+C 325,587 339,567 348,546
+C 358,525 363,502 361,478
+C 360,456 353,436 342,418
+C 331,400 316,384 299,369
+C 282,355 264,342 245,331
+C 227,320 209,311 194,303
+C 179,295 163,288 148,279
+C 133,271 119,263 107,253
+C 94,244 84,233 76,221
+C 68,208 62,195 61,178
+C 61,163 64,148 70,134
+C 76,120 85,107 97,96
+C 108,85 121,76 136,70
+C 150,64 165,60 180,60
+C 195,60 210,64 224,70
+C 239,76 252,85 263,96
+C 275,107 284,120 290,134
+C 296,148 300,163 299,178
+C 298,195 292,208 284,218
+C 276,228 265,236 253,244
+C 242,252 228,260 213,270
+C 198,280 181,292 162,306
 Z
 M 361,182
-C 365,119 268,-0 180,0
-C 95,0 -6,102 -1,182
-C 3,257 103,325 166,357
-C 223,386 294,414 299,482
-C 301,524 251,600 180,600
-C 117,600 49,552 61,485
-C 72,424 153,387 198,354
-C 272,301 356,270 361,182
+C 363,159 358,136 348,115
+C 339,93 325,73 307,56
+C 290,39 270,25 248,15
+C 226,6 203,-0 180,0
+C 157,0 134,6 112,15
+C 90,25 70,39 52,56
+C 35,73 21,93 12,114
+C 2,135 -3,158 -1,182
+C -0,204 7,224 18,242
+C 28,260 44,276 61,291
+C 77,305 96,318 115,329
+C 133,340 151,349 166,357
+C 181,365 197,372 212,381
+C 227,389 241,397 253,407
+C 266,416 276,427 284,439
+C 292,452 298,465 299,482
+C 299,497 296,512 290,526
+C 284,540 275,553 263,564
+C 252,575 239,584 224,590
+C 210,596 195,600 180,600
+C 165,600 150,597 135,591
+C 120,585 106,576 94,566
+C 82,555 72,543 66,529
+C 60,516 58,501 61,485
+C 64,470 70,457 79,447
+C 87,436 97,428 108,419
+C 120,410 133,401 147,391
+C 162,380 179,368 198,354
+C 223,337 244,322 262,309
+C 280,296 296,284 310,273
+C 324,261 336,249 345,235
+C 354,221 360,204 361,182
 Z
 '
 transform='translate(13080,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_4d3b2a50af5e07cc)'
+clip-path='url(#clip_6d529812f10001fc)'
 />
 <!-- 9 -->
-<clipPath id='clip_c8fda2c4b92e3cf5'>
+<clipPath id='clip_e876b3c67b52c400'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,120
-C 19,120 40,120 61,120
-C 79,80 127,42 169,58
-C 261,93 284,236 299,334
-C 303,365 302,396 299,426
-C 290,496 247,593 177,600
-C 107,608 60,501 61,431
-C 63,361 109,260 180,260
-C 257,260 299,382 299,460
-C 320,460 341,460 361,460
-C 361,354 286,200 180,200
-C 83,200 1,333 -1,429
-C -4,528 83,671 183,660
-C 277,650 350,528 361,434
-C 366,398 366,361 361,326
-C 343,207 303,45 191,2
-C 119,-25 29,54 -1,120
+C 5,122 11,124 16,125
+C 21,126 26,127 32,127
+C 37,127 42,126 46,125
+C 51,124 56,122 61,120
+C 71,116 80,108 89,100
+C 97,92 105,82 113,74
+C 122,66 130,60 139,56
+C 148,53 157,54 169,58
+C 189,66 204,80 218,97
+C 232,114 244,134 254,156
+C 265,178 273,203 281,233
+C 288,263 293,297 299,334
+C 301,346 302,355 303,363
+C 303,372 303,378 303,385
+C 303,392 302,398 301,404
+C 301,411 300,418 299,426
+C 296,448 292,469 286,488
+C 280,508 272,526 262,541
+C 251,557 239,570 225,580
+C 210,591 195,598 177,600
+C 158,602 141,598 127,588
+C 113,578 100,564 91,547
+C 81,530 73,510 68,490
+C 63,470 61,449 61,431
+C 62,414 65,394 71,375
+C 76,356 84,336 94,319
+C 104,302 116,287 131,277
+C 145,266 161,260 180,260
+C 200,260 218,267 234,278
+C 250,288 263,302 273,319
+C 284,336 291,356 295,379
+C 299,403 299,430 299,460
+C 306,464 312,467 318,469
+C 323,471 329,472 334,472
+C 339,472 344,471 348,469
+C 353,467 357,464 361,460
+C 376,447 379,425 374,398
+C 369,370 355,339 336,309
+C 317,279 293,252 266,232
+C 239,212 209,200 180,200
+C 155,200 132,208 110,222
+C 89,236 69,255 53,278
+C 36,300 23,326 14,352
+C 4,378 -1,404 -1,429
+C -2,456 2,485 11,512
+C 19,540 32,567 49,590
+C 65,613 85,632 108,644
+C 130,657 156,663 183,660
+C 208,657 231,648 251,635
+C 272,622 290,606 306,586
+C 321,567 334,544 343,519
+C 352,493 357,464 361,434
+C 362,424 363,415 364,407
+C 365,398 365,391 366,382
+C 366,374 366,366 365,357
+C 364,348 363,337 361,326
+C 359,310 355,284 348,254
+C 340,223 330,187 316,153
+C 303,118 285,85 264,58
+C 243,32 219,12 191,2
+C 170,-6 150,-8 131,-4
+C 111,-0 93,9 77,21
+C 60,34 45,50 31,67
+C 18,84 7,102 -1,120
 Z
 '
 transform='translate(13483,21582) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_c8fda2c4b92e3cf5)'
+clip-path='url(#clip_e876b3c67b52c400)'
 />
 <!-- A -->
-<clipPath id='clip_a513979a8da875c1'>
+<clipPath id='clip_f3279bda7a6d1cff'>
 <rect x='-60' y='-360' width='462' height='1070'/>
 </clipPath>
 <path
 d='
 M 61,60
-C 61,41 62,18 61,-0
-C -115,126 -51,661 180,660
-C 386,659 474,175 299,0
-C 299,20 300,40 299,60
-C 430,191 376,599 180,600
-C 3,601 -97,173 61,60
+C 61,53 61,46 61,39
+C 60,32 60,26 60,20
+C 60,14 60,9 60,6
+C 60,2 61,0 61,-0
+C 63,-0 69,45 78,120
+C 87,195 98,297 111,389
+C 124,482 137,562 149,607
+C 161,652 172,660 180,660
+C 215,660 257,624 301,571
+C 345,519 389,449 415,379
+C 442,309 450,240 430,178
+C 410,116 361,62 299,0
+C 299,7 299,14 299,19
+C 299,25 299,29 299,34
+C 299,38 299,42 299,46
+C 299,51 299,55 299,60
+C 299,106 298,163 296,223
+C 294,283 289,346 282,403
+C 274,459 263,509 246,544
+C 230,580 208,600 180,600
+C 145,600 106,570 67,522
+C 28,473 -10,409 -32,346
+C -55,284 -63,224 -47,178
+C -31,131 9,97 61,60
 Z
 M 74,150
-C 74,170 74,190 74,210
-C 145,210 215,210 286,210
-C 286,190 286,170 286,150
-C 215,150 145,150 74,150
+C 71,157 68,163 66,168
+C 65,174 64,179 64,183
+C 65,188 66,192 67,197
+C 69,201 71,205 74,210
+C 82,223 92,230 105,231
+C 118,233 133,229 151,225
+C 168,221 188,216 211,213
+C 234,211 259,210 286,210
+C 289,203 292,197 294,192
+C 295,186 296,181 296,177
+C 295,172 294,168 293,163
+C 291,159 289,155 286,150
+C 278,137 268,130 255,129
+C 242,127 227,131 209,135
+C 192,139 172,144 149,147
+C 126,149 101,150 74,150
 Z
 '
 transform='translate(0,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_a513979a8da875c1)'
+clip-path='url(#clip_f3279bda7a6d1cff)'
 />
 <!-- B -->
-<clipPath id='clip_2485768e6c6fe2a4'>
+<clipPath id='clip_d3f1b8d8860510ff'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,300
-C -1,319 -1,341 -1,360
-C 130,360 352,316 361,182
-C 371,54 -2,-112 -2,30
-C -1,240 -184,660 30,660
-C 152,660 351,605 361,483
-C 374,341 130,300 -1,300
-C -1,320 -2,341 -1,360
-C 104,360 308,364 299,477
-C 290,573 132,600 30,600
-C -166,600 61,219 62,30
-C 62,-75 306,84 299,178
-C 290,287 101,300 -1,300
+C -4,307 -7,313 -9,318
+C -11,324 -11,329 -11,333
+C -11,338 -10,343 -8,347
+C -6,351 -4,356 -1,360
+C 12,381 41,386 76,381
+C 111,376 153,360 194,338
+C 235,317 275,290 306,262
+C 338,235 360,206 361,182
+C 362,177 356,170 323,160
+C 291,150 236,138 179,124
+C 122,110 67,94 36,78
+C 4,62 -2,46 -2,30
+C -1,60 -1,118 -1,193
+C -1,268 -1,359 -0,438
+C 1,517 3,582 7,618
+C 12,655 19,660 30,660
+C 60,660 95,657 131,650
+C 167,643 203,633 236,618
+C 270,604 300,585 322,563
+C 344,540 359,514 361,483
+C 364,450 353,422 330,399
+C 307,377 272,358 233,344
+C 194,329 151,319 109,311
+C 68,304 29,300 -1,300
+C -4,306 -5,312 -7,317
+C -8,323 -8,327 -8,332
+C -8,337 -7,342 -6,346
+C -5,351 -3,355 -1,360
+C 9,383 34,401 70,417
+C 105,432 149,444 188,454
+C 227,463 260,469 278,472
+C 296,476 299,476 299,477
+C 297,497 284,514 266,529
+C 248,545 224,559 197,569
+C 170,580 141,588 112,593
+C 83,598 55,600 30,600
+C 41,600 48,597 53,574
+C 57,550 60,507 61,449
+C 62,391 62,320 62,247
+C 62,174 61,101 62,30
+C 62,48 65,63 84,77
+C 104,91 138,103 174,114
+C 210,126 247,136 270,146
+C 292,156 299,166 299,178
+C 297,197 284,214 266,229
+C 249,245 226,260 200,271
+C 175,282 145,291 112,295
+C 78,300 40,300 -1,300
 Z
 '
 transform='translate(403,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_2485768e6c6fe2a4)'
+clip-path='url(#clip_d3f1b8d8860510ff)'
 />
 <!-- C -->
-<clipPath id='clip_baceb121cbe83888'>
+<clipPath id='clip_e451181fec3a5903'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 361,540
-C 341,540 319,543 299,540
-C 280,579 229,610 187,601
-C 93,579 54,430 61,332
-C 68,233 94,90 190,59
-C 230,45 281,80 299,120
-C 320,120 340,120 361,120
-C 330,50 243,-22 170,1
-C 55,39 7,207 -1,328
-C -10,449 53,632 173,659
-C 246,676 328,608 361,540
+C 355,538 349,536 344,535
+C 339,534 333,533 328,534
+C 323,534 318,534 314,535
+C 309,536 304,538 299,540
+C 289,544 280,551 271,558
+C 263,566 255,575 246,582
+C 238,590 230,596 220,599
+C 210,603 200,604 187,601
+C 164,596 145,582 128,565
+C 110,548 96,527 84,504
+C 73,480 66,454 62,425
+C 58,396 59,365 61,332
+C 63,312 65,286 70,259
+C 75,232 82,203 91,175
+C 101,148 114,122 130,102
+C 147,82 166,66 190,59
+C 202,55 214,53 225,54
+C 236,54 246,56 255,61
+C 265,65 272,72 279,82
+C 286,92 292,105 299,120
+C 306,123 313,126 319,128
+C 325,131 331,132 337,132
+C 342,132 347,132 351,130
+C 355,128 359,125 361,120
+C 367,110 363,95 353,80
+C 343,64 326,47 306,32
+C 286,18 262,6 239,0
+C 215,-6 192,-5 170,1
+C 144,10 121,28 100,51
+C 80,75 62,105 47,136
+C 32,168 20,203 13,236
+C 5,269 1,301 -1,328
+C -4,365 -3,403 2,438
+C 8,473 18,506 33,536
+C 48,566 68,593 91,614
+C 115,636 142,652 173,659
+C 194,664 214,664 233,659
+C 252,654 270,645 286,632
+C 302,620 317,605 329,589
+C 342,573 353,557 361,540
 Z
 '
 transform='translate(806,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_baceb121cbe83888)'
+clip-path='url(#clip_e451181fec3a5903)'
 />
 <!-- D -->
-<clipPath id='clip_f522bbe30c25f9fb'>
+<clipPath id='clip_acb27713885317de'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 61,660
-C 61,640 60,620 61,600
-C -81,486 -164,60 30,60
-C 145,60 300,202 299,330
-C 297,467 136,604 -1,600
-C -1,619 -2,639 -1,660
-C 165,665 360,491 361,330
-C 363,174 187,-0 30,0
-C -205,0 -115,519 61,660
+C 61,653 61,647 61,642
+C 61,636 61,632 61,627
+C 61,623 61,618 61,614
+C 61,610 61,605 61,600
+C 61,555 62,496 62,430
+C 62,363 63,289 61,227
+C 60,165 58,116 53,89
+C 48,63 41,60 30,60
+C 60,60 92,69 124,84
+C 155,99 185,120 212,145
+C 238,170 260,199 275,230
+C 291,262 299,295 299,330
+C 298,366 289,403 276,438
+C 263,474 245,508 223,535
+C 200,562 171,582 135,592
+C 98,602 53,602 -1,600
+C -5,607 -8,613 -10,618
+C -12,624 -13,629 -13,634
+C -13,639 -12,643 -10,648
+C -8,652 -5,656 -1,660
+C 14,677 45,676 82,663
+C 120,650 164,625 206,591
+C 248,557 288,516 316,471
+C 344,426 361,377 361,330
+C 362,291 351,251 332,213
+C 313,175 286,138 254,107
+C 221,75 184,49 146,30
+C 108,11 68,-0 30,0
+C -12,0 -48,-5 -79,29
+C -109,64 -132,134 -138,218
+C -143,303 -131,398 -96,476
+C -62,553 -4,608 61,660
 Z
 '
 transform='translate(1209,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_f522bbe30c25f9fb)'
+clip-path='url(#clip_acb27713885317de)'
 />
 <!-- E -->
-<clipPath id='clip_8ccb13331bc577d6'>
+<clipPath id='clip_bb038a59ed5d3959'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 361,600
-C 341,600 320,602 299,600
-C 244,663 117,657 49,606
-C -98,496 -102,162 48,54
-C 132,-6 283,-14 361,60
-C 361,41 362,20 361,-0
-C 275,-81 107,-63 12,6
-C -159,128 -159,526 11,654
-C 107,726 281,691 361,600
+C 354,599 349,599 343,598
+C 338,598 333,598 328,598
+C 323,598 318,598 314,599
+C 309,599 304,599 299,600
+C 278,602 257,608 236,614
+C 215,620 193,627 172,631
+C 151,635 131,637 110,633
+C 90,630 69,621 49,606
+C 12,578 -17,536 -37,488
+C -57,439 -69,385 -71,330
+C -73,276 -65,222 -45,174
+C -26,127 6,85 48,54
+C 72,37 97,24 124,12
+C 150,-0 177,-10 203,-14
+C 229,-18 254,-16 280,-4
+C 305,9 330,31 361,60
+C 363,53 365,47 367,41
+C 368,36 368,31 368,27
+C 368,22 367,18 366,13
+C 364,9 363,5 361,-0
+C 352,-25 332,-42 306,-52
+C 280,-62 247,-66 212,-64
+C 177,-62 141,-54 106,-42
+C 71,-30 38,-14 12,6
+C -37,41 -73,89 -96,146
+C -120,202 -130,265 -129,329
+C -128,393 -116,457 -92,514
+C -69,571 -34,620 11,654
+C 39,675 69,689 99,697
+C 130,706 161,709 191,705
+C 222,702 251,691 279,674
+C 307,656 334,631 361,600
 Z
 M -1,300
-C -1,320 -1,340 -1,360
-C 120,360 240,360 361,360
-C 361,340 361,320 361,300
-C 240,300 120,300 -1,300
+C -4,307 -6,313 -8,319
+C -9,324 -10,329 -9,333
+C -9,338 -8,342 -7,347
+C -5,351 -3,355 -1,360
+C 9,381 25,391 46,393
+C 67,396 94,390 125,384
+C 156,377 192,370 231,365
+C 271,361 314,360 361,360
+C 364,353 366,347 368,341
+C 369,336 370,331 369,327
+C 369,322 368,318 367,313
+C 365,309 363,305 361,300
+C 351,279 335,269 314,267
+C 293,264 266,270 235,276
+C 204,283 168,290 129,295
+C 89,299 46,300 -1,300
 Z
 '
 transform='translate(1612,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_8ccb13331bc577d6)'
+clip-path='url(#clip_bb038a59ed5d3959)'
 />
 <!-- F -->
-<clipPath id='clip_8beec9afbb3a9121'>
+<clipPath id='clip_caccc612019ffb0c'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 61,-0
-C 41,-0 19,-0 -1,-0
-C -123,185 -165,518 11,654
-C 105,727 267,741 361,660
-C 361,641 360,620 361,600
-C 279,670 134,671 49,606
-C -111,482 -50,167 61,-0
+C 53,-2 47,-3 41,-4
+C 36,-5 31,-5 26,-5
+C 22,-5 17,-4 13,-3
+C 9,-2 4,-1 -1,-0
+C -47,12 -83,49 -107,101
+C -130,152 -143,219 -143,288
+C -143,358 -131,430 -105,494
+C -79,558 -40,614 11,654
+C 36,674 65,689 95,700
+C 125,711 156,717 187,718
+C 218,719 249,716 279,706
+C 308,696 336,681 361,660
+C 364,654 367,649 368,643
+C 370,638 371,633 371,628
+C 371,623 370,618 369,613
+C 367,609 364,604 361,600
+C 349,585 330,583 305,587
+C 280,592 250,602 219,612
+C 188,622 157,630 128,631
+C 99,631 72,624 49,606
+C 16,581 -6,540 -25,494
+C -44,448 -59,397 -63,344
+C -68,291 -62,237 -40,181
+C -19,124 18,65 61,-0
 Z
 M -1,300
-C -1,320 -1,340 -1,360
-C 95,360 190,360 286,360
-C 286,340 286,320 286,300
-C 190,300 95,300 -1,300
+C -4,307 -7,313 -8,318
+C -10,324 -10,329 -10,333
+C -10,338 -9,342 -7,347
+C -5,351 -3,355 -1,360
+C 8,377 21,386 38,388
+C 55,390 76,385 100,380
+C 125,374 152,368 184,364
+C 215,361 249,360 286,360
+C 289,353 292,347 293,342
+C 295,336 295,331 295,327
+C 295,322 294,318 292,313
+C 290,309 288,305 286,300
+C 277,283 264,274 247,272
+C 230,270 209,275 185,280
+C 160,286 133,292 101,296
+C 70,299 36,300 -1,300
 Z
 '
 transform='translate(2015,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_8beec9afbb3a9121)'
+clip-path='url(#clip_caccc612019ffb0c)'
 />
 <!-- G -->
-<clipPath id='clip_ac340b3eedaae8c0'>
+<clipPath id='clip_03264adf4bc1a51c'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 361,540
-C 340,540 320,542 299,540
-C 281,579 230,612 188,601
-C 93,576 61,429 62,330
-C 62,231 88,74 185,60
-C 243,51 284,133 300,188
-C 310,224 330,278 305,312
-C 274,354 191,332 149,300
-C 149,320 148,340 149,360
-C 203,401 313,405 355,348
-C 390,301 376,228 360,172
-C 336,90 260,-13 175,0
-C 53,19 -2,206 -2,330
-C -1,456 52,628 172,659
-C 244,678 329,609 361,540
+C 355,538 349,536 344,535
+C 339,534 333,533 328,533
+C 323,534 318,534 314,535
+C 309,536 304,538 299,540
+C 289,544 280,551 271,559
+C 263,567 255,575 247,583
+C 238,590 230,597 220,600
+C 211,604 200,604 188,601
+C 166,595 147,581 130,562
+C 114,543 101,519 90,493
+C 80,468 72,439 68,411
+C 63,383 62,355 62,330
+C 62,305 63,277 67,248
+C 71,219 78,190 87,164
+C 97,137 110,113 126,95
+C 142,76 161,63 185,60
+C 201,57 215,60 227,65
+C 239,71 250,79 259,90
+C 268,102 275,115 281,132
+C 288,148 294,167 300,188
+C 304,203 308,216 311,228
+C 314,239 316,249 317,258
+C 318,268 318,276 316,285
+C 315,294 311,303 305,312
+C 296,324 285,331 273,336
+C 261,341 248,343 235,342
+C 222,342 208,338 194,330
+C 180,323 165,312 149,300
+C 146,307 144,313 142,318
+C 141,324 140,329 140,333
+C 141,338 142,342 143,347
+C 145,351 147,355 149,360
+C 157,376 170,387 188,394
+C 205,400 225,403 246,402
+C 268,400 289,395 308,386
+C 327,377 344,364 355,348
+C 364,335 370,322 374,307
+C 377,292 378,276 377,261
+C 377,245 374,229 371,214
+C 368,199 364,185 360,172
+C 352,144 343,118 333,96
+C 322,74 309,55 293,40
+C 278,25 260,14 241,7
+C 221,-0 199,-3 175,0
+C 144,5 117,21 94,43
+C 72,65 53,93 39,125
+C 25,157 14,192 8,228
+C 1,263 -2,298 -2,330
+C -1,361 1,396 8,430
+C 14,464 25,498 39,529
+C 53,560 71,589 93,611
+C 115,634 142,651 172,659
+C 193,665 214,665 233,660
+C 252,656 269,646 286,634
+C 302,622 317,607 330,591
+C 342,575 353,557 361,540
 Z
 '
 transform='translate(2418,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_ac340b3eedaae8c0)'
+clip-path='url(#clip_03264adf4bc1a51c)'
 />
 <!-- H -->
-<clipPath id='clip_ce38d78386f7c468'>
+<clipPath id='clip_7227560448c49b55'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,660
-C 20,660 40,660 61,660
-C 61,439 61,221 61,-0
-C 40,-0 20,0 -1,-0
-C -1,221 -1,439 -1,660
+C 6,663 13,665 18,666
+C 24,667 29,668 34,667
+C 38,667 43,666 47,665
+C 52,664 56,662 61,660
+C 95,647 112,620 115,583
+C 119,545 110,496 100,438
+C 89,380 77,313 69,239
+C 62,165 61,85 61,-0
+C 54,-3 47,-5 42,-6
+C 36,-7 31,-8 26,-7
+C 22,-7 17,-6 13,-5
+C 8,-4 4,-2 -1,-0
+C -35,13 -52,40 -55,77
+C -59,115 -50,164 -40,222
+C -29,280 -17,347 -9,421
+C -2,495 -1,575 -1,660
 Z
 M -1,300
-C -1,320 -1,340 -1,360
-C 120,360 240,360 361,360
-C 361,340 361,320 361,300
-C 240,300 120,300 -1,300
+C -4,307 -6,313 -8,319
+C -9,324 -10,329 -9,333
+C -9,338 -8,342 -7,347
+C -5,351 -3,355 -1,360
+C 9,381 25,391 46,393
+C 67,396 94,390 125,384
+C 156,377 192,370 231,365
+C 271,361 314,360 361,360
+C 364,353 366,347 368,341
+C 369,336 370,331 369,327
+C 369,322 368,318 367,313
+C 365,309 363,305 361,300
+C 351,279 335,269 314,267
+C 293,264 266,270 235,276
+C 204,283 168,290 129,295
+C 89,299 46,300 -1,300
 Z
 M 299,660
-C 320,660 340,660 361,660
-C 361,439 361,221 361,-0
-C 340,-0 320,0 299,-0
-C 299,221 299,439 299,660
+C 306,663 313,665 318,666
+C 324,667 329,668 334,667
+C 338,667 343,666 347,665
+C 352,664 356,662 361,660
+C 395,647 412,620 415,583
+C 419,545 410,496 400,438
+C 389,380 377,313 369,239
+C 362,165 361,85 361,-0
+C 354,-3 347,-5 342,-6
+C 336,-7 331,-8 326,-7
+C 322,-7 317,-6 313,-5
+C 308,-4 304,-2 299,-0
+C 265,13 248,40 245,77
+C 241,115 250,164 260,222
+C 271,280 283,347 291,421
+C 298,495 299,575 299,660
 Z
 '
 transform='translate(2821,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_ce38d78386f7c468)'
+clip-path='url(#clip_7227560448c49b55)'
 />
 <!-- I -->
-<clipPath id='clip_84d6bbd47759ca05'>
+<clipPath id='clip_9f57f18b5f0dad09'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,600
-C -1,620 -1,640 -1,660
-C 120,660 240,660 361,660
-C 361,640 361,620 361,600
-C 240,600 120,600 -1,600
+C -4,607 -6,613 -8,619
+C -9,624 -10,629 -9,633
+C -9,638 -8,642 -7,647
+C -5,651 -3,655 -1,660
+C 9,681 25,691 46,693
+C 67,696 94,690 125,684
+C 156,677 192,670 231,665
+C 271,661 314,660 361,660
+C 364,653 366,647 368,641
+C 369,636 370,631 369,627
+C 369,622 368,618 367,613
+C 365,609 363,605 361,600
+C 351,579 335,569 314,567
+C 293,564 266,570 235,576
+C 204,583 168,590 129,595
+C 89,599 46,600 -1,600
 Z
 M 149,660
-C 170,660 190,660 211,660
-C 211,439 211,221 211,-0
-C 190,-0 170,0 149,-0
-C 149,221 149,439 149,660
+C 156,663 163,665 168,666
+C 174,667 179,668 184,667
+C 188,667 193,666 197,665
+C 202,664 206,662 211,660
+C 245,647 262,620 265,583
+C 269,545 260,496 250,438
+C 239,380 227,313 219,239
+C 212,165 211,85 211,-0
+C 204,-3 197,-5 192,-6
+C 186,-7 181,-8 176,-7
+C 172,-7 167,-6 163,-5
+C 158,-4 154,-2 149,-0
+C 115,13 98,40 95,77
+C 91,115 100,164 110,222
+C 121,280 133,347 141,421
+C 148,495 149,575 149,660
 Z
 M -1,0
-C -1,20 -1,40 -1,60
-C 120,60 240,60 361,60
-C 361,40 361,20 361,-0
-C 240,0 120,0 -1,0
+C -4,7 -6,13 -8,19
+C -9,24 -10,29 -9,33
+C -9,38 -8,42 -7,47
+C -5,51 -3,55 -1,60
+C 9,81 25,91 46,93
+C 67,96 94,90 125,84
+C 156,77 192,70 231,65
+C 271,61 314,60 361,60
+C 364,53 366,47 368,41
+C 369,36 370,31 369,27
+C 369,22 368,18 367,13
+C 365,9 363,5 361,-0
+C 351,-21 335,-31 314,-33
+C 293,-36 266,-30 235,-24
+C 204,-17 168,-10 129,-5
+C 89,-1 46,0 -1,0
 Z
 '
 transform='translate(3224,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_84d6bbd47759ca05)'
+clip-path='url(#clip_9f57f18b5f0dad09)'
 />
 <!-- J -->
-<clipPath id='clip_b0ddb22b0036daea'>
+<clipPath id='clip_ceb398fe57215a91'>
 <rect x='-60' y='-360' width='523' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,600
-C -1,620 -2,640 -1,660
-C 89,739 277,742 354,649
-C 426,563 389,419 360,322
-C 326,205 303,35 189,1
-C 116,-20 47,62 -1,120
-C 19,120 41,120 61,120
-C 89,86 125,45 171,59
-C 266,86 272,242 300,338
-C 325,427 362,544 306,611
-C 238,692 77,669 -1,600
+C -3,607 -5,613 -6,619
+C -8,624 -8,629 -8,633
+C -7,638 -7,642 -5,647
+C -4,651 -3,655 -1,660
+C 8,686 30,705 58,717
+C 87,730 122,735 159,733
+C 195,732 234,724 268,710
+C 302,695 333,675 354,649
+C 373,627 384,602 391,574
+C 397,545 398,515 395,485
+C 393,455 387,424 381,396
+C 374,368 366,343 360,322
+C 348,280 337,241 327,207
+C 317,173 307,143 296,117
+C 285,90 273,66 256,46
+C 239,26 218,10 189,1
+C 168,-5 150,-5 133,-1
+C 117,3 103,11 89,22
+C 75,33 62,46 47,63
+C 33,79 17,98 -1,120
+C 6,123 13,125 18,126
+C 24,128 29,128 34,128
+C 38,128 43,127 47,125
+C 52,124 56,122 61,120
+C 71,116 80,109 89,101
+C 97,93 105,84 113,76
+C 122,69 130,62 139,59
+C 149,55 159,55 171,59
+C 194,65 210,80 223,99
+C 237,118 246,141 255,166
+C 263,192 270,219 277,248
+C 284,278 291,308 300,338
+C 305,358 313,380 319,403
+C 326,426 332,451 336,476
+C 339,500 340,525 335,547
+C 331,570 322,592 306,611
+C 288,632 265,647 240,659
+C 215,671 189,679 162,680
+C 136,682 110,676 83,663
+C 56,649 30,627 -1,600
 Z
 '
 transform='translate(3627,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_b0ddb22b0036daea)'
+clip-path='url(#clip_ceb398fe57215a91)'
 />
 <!-- K -->
-<clipPath id='clip_8fbdf1f86e6b62ce'>
+<clipPath id='clip_55394fdc09854429'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,660
-C 20,660 40,660 61,660
-C 61,439 61,221 61,-0
-C 40,-0 20,0 -1,-0
-C -1,221 -1,439 -1,660
+C 6,663 13,665 18,666
+C 24,667 29,668 34,667
+C 38,667 43,666 47,665
+C 52,664 56,662 61,660
+C 95,647 112,620 115,583
+C 119,545 110,496 100,438
+C 89,380 77,313 69,239
+C 62,165 61,85 61,-0
+C 54,-3 47,-5 42,-6
+C 36,-7 31,-8 26,-7
+C 22,-7 17,-6 13,-5
+C 8,-4 4,-2 -1,-0
+C -35,13 -52,40 -55,77
+C -59,115 -50,164 -40,222
+C -29,280 -17,347 -9,421
+C -2,495 -1,575 -1,660
 Z
 M 361,660
-C 361,640 361,620 361,600
-C 260,499 163,402 61,300
-C 40,300 19,300 -1,300
-C 124,425 237,535 361,660
+C 362,653 363,646 363,641
+C 364,635 364,631 364,626
+C 364,622 363,618 363,614
+C 362,609 362,605 361,600
+C 356,562 343,534 325,512
+C 307,490 282,474 255,457
+C 227,439 197,421 165,396
+C 133,370 100,338 61,300
+C 54,297 47,293 41,291
+C 35,289 29,288 24,288
+C 19,287 14,288 10,290
+C 5,292 2,295 -1,300
+C -10,315 -4,333 15,354
+C 34,375 65,400 102,429
+C 139,458 182,492 226,531
+C 270,570 315,614 361,660
 Z
 M -1,300
-C -1,320 -1,340 -1,360
-C 124,235 237,124 361,-0
-C 340,-0 320,0 299,-0
-C 202,97 99,200 -1,300
+C -4,307 -7,313 -10,319
+C -12,325 -13,331 -13,336
+C -13,341 -12,345 -10,350
+C -8,354 -5,357 -1,360
+C 13,369 32,363 53,344
+C 74,326 99,295 129,258
+C 158,222 193,179 232,135
+C 271,91 315,46 361,-0
+C 353,-1 347,-2 341,-3
+C 336,-3 331,-3 326,-3
+C 322,-3 317,-3 313,-2
+C 309,-1 304,-1 299,-0
+C 261,6 233,18 211,36
+C 189,55 173,79 156,107
+C 138,134 120,165 94,197
+C 69,228 37,262 -1,300
 Z
 '
 transform='translate(4030,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_8fbdf1f86e6b62ce)'
+clip-path='url(#clip_55394fdc09854429)'
 />
 <!-- L -->
-<clipPath id='clip_ac1a483cda035716'>
+<clipPath id='clip_b0c9f6181b06f14e'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,660
-C 20,660 40,660 61,660
-C -49,494 -107,175 49,54
-C 134,-11 266,-21 361,60
-C 361,41 362,19 361,-0
-C 274,-75 104,-66 11,6
-C -157,136 -120,480 -1,660
+C 5,663 11,666 17,668
+C 22,670 28,671 33,670
+C 38,670 43,669 47,668
+C 52,666 57,663 61,660
+C 85,643 87,601 76,545
+C 65,488 42,417 23,349
+C 5,280 -9,215 -7,165
+C -4,114 15,80 49,54
+C 71,37 96,23 122,12
+C 147,1 173,-8 199,-12
+C 225,-15 251,-12 277,-1
+C 303,11 329,33 361,60
+C 363,53 365,47 367,41
+C 368,36 368,31 368,27
+C 368,22 367,18 366,13
+C 364,9 363,5 361,-0
+C 352,-25 332,-43 306,-53
+C 279,-64 246,-68 212,-66
+C 177,-64 140,-57 105,-44
+C 70,-32 37,-14 11,6
+C -35,42 -66,89 -85,143
+C -104,197 -110,258 -107,320
+C -104,383 -92,446 -73,505
+C -54,563 -30,617 -1,660
 Z
 '
 transform='translate(4433,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_ac1a483cda035716)'
+clip-path='url(#clip_b0c9f6181b06f14e)'
 />
 <!-- M -->
-<clipPath id='clip_9da6582bfe32a2eb'>
+<clipPath id='clip_01a71518eb25e881'>
 <rect x='-60' y='-360' width='674' height='1070'/>
 </clipPath>
 <path
 d='
 M 61,60
-C 61,41 62,20 61,-0
-C -133,105 -188,622 24,660
-C 238,697 42,60 255,60
-C 464,60 279,705 487,659
-C 683,616 330,151 511,60
-C 511,40 514,20 511,-0
-C 331,90 676,556 473,601
-C 265,646 465,-0 255,0
-C 46,0 248,638 36,600
-C -137,570 -98,146 61,60
+C 62,53 63,45 63,38
+C 64,31 64,25 64,19
+C 64,13 64,9 64,5
+C 63,2 62,0 61,-0
+C 55,-1 48,40 42,100
+C 35,161 28,241 23,323
+C 18,404 15,487 14,550
+C 14,614 17,658 24,660
+C 17,658 22,623 35,568
+C 47,513 68,438 93,361
+C 118,285 147,209 175,153
+C 204,96 232,60 255,60
+C 279,60 308,98 336,152
+C 365,207 393,279 418,352
+C 442,425 463,499 476,557
+C 490,615 495,658 487,659
+C 482,660 473,641 460,589
+C 446,537 428,457 418,375
+C 408,293 407,212 423,158
+C 438,104 472,79 511,60
+C 510,53 510,46 509,39
+C 509,32 508,26 508,20
+C 508,14 508,9 509,6
+C 509,2 510,0 511,-0
+C 516,-0 519,36 521,90
+C 522,145 522,218 519,292
+C 516,366 511,441 504,499
+C 497,557 487,598 473,601
+C 486,598 485,563 475,508
+C 465,454 445,380 420,305
+C 395,230 365,153 336,96
+C 307,38 279,-0 255,0
+C 232,0 204,39 174,105
+C 144,171 112,262 86,345
+C 60,428 40,502 31,545
+C 22,588 25,599 36,600
+C 8,596 -19,560 -44,508
+C -68,457 -89,391 -97,328
+C -105,266 -98,209 -72,165
+C -45,121 2,92 61,60
 Z
 '
 transform='translate(4836,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_9da6582bfe32a2eb)'
+clip-path='url(#clip_01a71518eb25e881)'
 />
 <!-- N -->
-<clipPath id='clip_89059d7da978efc9'>
+<clipPath id='clip_6b9f41366d453d78'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 61,-0
-C 40,-0 20,0 -1,-0
-C -130,179 -188,613 23,659
-C 246,708 100,11 323,59
-C 525,103 170,579 361,660
-C 361,640 358,620 361,600
-C 171,520 537,44 337,1
-C 115,-47 258,649 37,601
-C -155,559 -55,160 61,-0
+C 54,-2 47,-4 42,-5
+C 36,-6 31,-7 26,-7
+C 22,-6 17,-5 13,-4
+C 8,-3 4,-2 -1,-0
+C -44,14 -72,61 -88,121
+C -104,182 -107,258 -101,334
+C -96,410 -81,487 -59,547
+C -38,607 -10,652 23,659
+C 33,661 48,656 73,617
+C 97,578 131,507 166,423
+C 202,340 240,245 269,174
+C 298,103 319,58 323,59
+C 322,59 319,70 311,120
+C 302,169 288,252 279,339
+C 271,426 270,513 283,568
+C 297,624 327,646 361,660
+C 361,653 361,646 361,641
+C 360,635 360,631 360,626
+C 360,622 361,618 361,614
+C 361,609 361,605 361,600
+C 363,550 367,488 371,425
+C 375,362 380,296 381,236
+C 383,175 382,120 376,77
+C 369,35 357,5 337,1
+C 327,-1 311,10 285,64
+C 258,119 222,211 185,304
+C 148,398 113,489 87,541
+C 61,593 46,603 37,601
+C 9,595 -14,562 -35,519
+C -55,475 -72,420 -77,363
+C -83,306 -75,246 -51,186
+C -28,126 14,65 61,-0
 Z
 '
 transform='translate(5389,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_89059d7da978efc9)'
+clip-path='url(#clip_6b9f41366d453d78)'
 />
 <!-- O -->
-<clipPath id='clip_57afd6c741c909a4'>
+<clipPath id='clip_bb69e3c4e3a7b204'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,326
-C -25,508 47,660 180,660
-C 314,660 374,489 361,328
-C 351,191 305,17 184,0
-C 46,-19 1,311 -1,326
+C -6,365 -7,405 -2,443
+C 3,481 14,517 30,549
+C 47,580 68,608 93,628
+C 118,648 147,660 180,660
+C 213,660 241,648 266,628
+C 290,608 310,581 326,550
+C 342,519 352,483 358,445
+C 364,407 364,367 361,328
+C 359,301 355,268 348,234
+C 340,199 330,163 315,130
+C 301,96 283,66 261,43
+C 240,20 214,4 184,0
+C 154,-4 129,5 108,25
+C 86,46 69,76 54,112
+C 39,148 28,188 18,226
+C 9,264 2,299 -1,326
 Z
 M 176,60
-C 269,73 295,288 299,332
-C 306,434 310,600 180,600
-C 91,600 44,460 61,334
-C 74,237 47,42 176,60
+C 197,63 215,76 231,96
+C 246,116 259,142 269,171
+C 278,200 285,231 290,259
+C 295,287 297,313 299,332
+C 301,367 303,401 300,432
+C 298,463 292,491 282,515
+C 271,539 257,559 240,575
+C 223,590 203,600 180,600
+C 157,600 136,590 119,574
+C 102,558 87,536 77,511
+C 66,486 60,458 58,428
+C 55,398 57,366 61,334
+C 64,314 68,286 74,254
+C 80,222 87,187 96,156
+C 105,125 115,98 128,81
+C 141,64 157,57 176,60
 Z
 '
 transform='translate(5792,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_57afd6c741c909a4)'
+clip-path='url(#clip_bb69e3c4e3a7b204)'
 />
 <!-- P -->
-<clipPath id='clip_3b61107efc83da40'>
+<clipPath id='clip_45bb05e86680d48e'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 61,-0
-C 42,-0 20,-0 -1,-0
-C -123,192 -227,660 30,660
-C 151,660 362,595 362,480
-C 362,348 156,300 -1,300
-C -1,320 -2,337 -1,360
-C 109,360 298,352 298,480
-C 298,583 67,600 30,600
-C -210,600 -39,158 61,-0
+C 54,-3 47,-5 42,-7
+C 36,-8 31,-8 26,-8
+C 22,-8 17,-7 13,-5
+C 8,-4 4,-2 -1,-0
+C -38,16 -65,68 -83,143
+C -101,218 -109,313 -108,399
+C -106,485 -94,560 -71,604
+C -48,648 -15,660 30,660
+C 61,660 97,657 134,650
+C 171,643 209,632 242,617
+C 276,603 306,584 327,561
+C 349,539 362,512 362,480
+C 362,447 347,419 323,396
+C 298,373 263,355 224,341
+C 185,327 143,317 103,310
+C 63,303 26,300 -1,300
+C -4,306 -6,312 -7,317
+C -8,323 -9,327 -8,332
+C -8,337 -8,342 -6,346
+C -5,351 -3,355 -1,360
+C 9,382 34,399 69,411
+C 103,424 146,433 184,440
+C 223,448 255,453 275,459
+C 294,465 298,471 298,480
+C 298,498 287,515 269,530
+C 251,545 227,558 200,569
+C 173,580 143,588 114,593
+C 84,598 55,600 30,600
+C 9,600 -11,597 -30,569
+C -48,541 -64,489 -69,424
+C -74,359 -67,283 -44,209
+C -22,136 17,69 61,-0
 Z
 '
 transform='translate(6195,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_3b61107efc83da40)'
+clip-path='url(#clip_45bb05e86680d48e)'
 />
 <!-- Q -->
-<clipPath id='clip_276aa6b3676e3e45'>
+<clipPath id='clip_39b124d56e18f7e2'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,326
-C -25,508 47,660 180,660
-C 314,660 374,489 361,328
-C 351,191 305,17 184,0
-C 46,-19 1,311 -1,326
+C -6,365 -7,405 -2,443
+C 3,481 14,517 30,549
+C 47,580 68,608 93,628
+C 118,648 147,660 180,660
+C 213,660 241,648 266,628
+C 290,608 310,581 326,550
+C 342,519 352,483 358,445
+C 364,407 364,367 361,328
+C 359,301 355,268 348,234
+C 340,199 330,163 315,130
+C 301,96 283,66 261,43
+C 240,20 214,4 184,0
+C 154,-4 129,5 108,25
+C 86,46 69,76 54,112
+C 39,148 28,188 18,226
+C 9,264 2,299 -1,326
 Z
 M 176,60
-C 269,73 295,288 299,332
-C 306,434 310,600 180,600
-C 91,600 44,460 61,334
-C 74,237 47,42 176,60
+C 197,63 215,76 231,96
+C 246,116 259,142 269,171
+C 278,200 285,231 290,259
+C 295,287 297,313 299,332
+C 301,367 303,401 300,432
+C 298,463 292,491 282,515
+C 271,539 257,559 240,575
+C 223,590 203,600 180,600
+C 157,600 136,590 119,574
+C 102,558 87,536 77,511
+C 66,486 60,458 58,428
+C 55,398 57,366 61,334
+C 64,314 68,286 74,254
+C 80,222 87,187 96,156
+C 105,125 115,98 128,81
+C 141,64 157,57 176,60
 Z
 M 361,60
-C 361,41 361,20 361,-0
-C 278,83 226,133 149,210
-C 169,210 194,210 211,210
-C 259,163 308,113 361,60
+C 364,53 367,47 369,41
+C 371,35 373,29 373,24
+C 373,19 372,14 370,10
+C 368,6 365,3 361,-0
+C 350,-6 339,-3 326,8
+C 313,19 299,37 282,58
+C 266,80 246,105 224,131
+C 202,157 176,183 149,210
+C 157,212 163,213 169,214
+C 174,215 179,215 184,215
+C 188,215 193,214 197,213
+C 201,212 206,211 211,210
+C 230,205 243,198 254,189
+C 265,179 274,167 283,154
+C 292,141 301,126 314,111
+C 326,95 342,79 361,60
 Z
 '
 transform='translate(6598,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_276aa6b3676e3e45)'
+clip-path='url(#clip_39b124d56e18f7e2)'
 />
 <!-- R -->
-<clipPath id='clip_6438af60aa84ced0'>
+<clipPath id='clip_08733d33e87b257c'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 61,-0
-C 41,-0 19,0 -1,-0
-C -111,193 -189,660 30,660
-C 153,660 359,615 361,481
-C 363,378 209,316 110,300
-C 73,295 33,283 -1,300
-C -1,320 3,341 -1,360
-C 30,345 67,354 100,360
-C 175,371 300,402 299,479
-C 297,575 125,600 30,600
-C -172,600 -37,172 61,-0
+C 54,-3 47,-5 42,-7
+C 36,-8 31,-8 26,-8
+C 22,-8 17,-7 13,-5
+C 8,-4 4,-2 -1,-0
+C -38,16 -65,68 -83,143
+C -101,218 -110,314 -108,400
+C -106,486 -94,560 -71,604
+C -48,648 -15,660 30,660
+C 61,660 97,657 134,650
+C 170,643 208,633 242,618
+C 275,604 305,585 326,563
+C 348,540 361,513 361,481
+C 362,453 354,429 341,408
+C 328,388 311,370 290,355
+C 269,341 244,330 214,321
+C 184,312 149,306 110,300
+C 96,298 85,296 75,295
+C 65,293 56,292 48,292
+C 40,291 32,291 24,292
+C 16,293 8,296 -1,300
+C -4,305 -6,310 -8,315
+C -9,320 -10,326 -11,331
+C -11,336 -10,342 -9,347
+C -7,351 -5,356 -1,360
+C 5,366 11,369 18,369
+C 25,369 32,367 40,364
+C 49,362 58,359 68,358
+C 77,357 88,358 100,360
+C 111,361 129,365 150,370
+C 172,376 196,383 219,393
+C 242,402 263,414 277,429
+C 291,443 299,460 299,479
+C 298,503 287,522 270,537
+C 252,553 228,565 201,574
+C 174,584 143,590 114,594
+C 84,598 55,600 30,600
+C 12,600 -6,597 -23,569
+C -40,542 -54,491 -59,427
+C -63,363 -57,287 -36,213
+C -15,140 21,71 61,-0
 Z
 M 149,360
-C 166,360 190,360 211,360
-C 292,197 295,132 361,-0
-C 345,-0 318,-0 299,-0
-C 238,122 218,222 149,360
+C 157,362 163,363 169,364
+C 174,365 179,366 184,365
+C 188,365 193,364 197,363
+C 201,363 206,361 211,360
+C 242,352 260,337 270,315
+C 281,293 284,264 287,232
+C 291,199 296,163 307,125
+C 319,87 338,46 361,-0
+C 353,-2 347,-3 341,-4
+C 336,-5 331,-6 326,-5
+C 322,-5 317,-4 313,-3
+C 309,-3 304,-1 299,-0
+C 268,8 250,23 240,45
+C 229,67 226,96 223,128
+C 219,161 214,197 203,235
+C 191,273 172,314 149,360
 Z
 '
 transform='translate(7001,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_6438af60aa84ced0)'
+clip-path='url(#clip_08733d33e87b257c)'
 />
 <!-- S -->
-<clipPath id='clip_1cc04f4d3d6dc6c1'>
+<clipPath id='clip_e2cebe2eda3b0e6e'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 361,450
-C 341,450 319,451 299,450
-C 303,514 247,604 182,600
-C 116,596 40,501 60,439
-C 77,387 151,383 196,356
-C 253,322 327,301 358,244
-C 406,156 280,1 180,0
-C 88,-1 -12,117 -1,210
-C 19,210 40,210 61,210
-C 53,145 114,59 180,60
-C 246,61 335,156 302,216
-C 276,264 211,276 164,304
-C 105,339 21,356 0,421
-C -31,515 80,654 178,660
-C 271,666 367,543 361,450
+C 355,448 349,446 344,444
+C 338,443 333,442 328,443
+C 323,443 318,443 313,445
+C 309,446 304,448 299,450
+C 284,457 272,471 263,487
+C 254,504 246,523 239,541
+C 232,559 225,575 216,585
+C 207,596 197,601 182,600
+C 167,599 150,592 134,582
+C 118,572 102,558 89,543
+C 76,527 66,510 60,492
+C 55,474 54,456 60,439
+C 65,425 72,416 81,410
+C 90,403 100,400 112,396
+C 123,392 136,388 150,381
+C 163,375 179,366 196,356
+C 217,343 235,333 251,324
+C 267,315 281,308 294,302
+C 306,295 318,288 329,279
+C 339,271 349,260 358,244
+C 372,219 376,191 371,164
+C 366,137 353,110 334,86
+C 315,62 290,41 264,25
+C 237,10 208,0 180,0
+C 156,-0 131,6 108,18
+C 85,29 63,45 46,64
+C 28,83 15,106 6,130
+C -2,155 -4,182 -1,210
+C 5,212 11,214 16,216
+C 22,217 27,217 32,217
+C 37,217 42,217 47,215
+C 51,214 56,212 61,210
+C 76,203 88,190 97,174
+C 106,158 113,139 121,122
+C 128,104 135,88 144,77
+C 153,66 164,60 180,60
+C 195,60 213,67 231,77
+C 249,87 266,101 280,116
+C 295,131 305,148 309,165
+C 314,182 311,199 302,216
+C 296,228 287,236 278,243
+C 269,249 259,254 247,260
+C 236,265 224,270 211,277
+C 197,285 182,294 164,304
+C 142,317 123,328 107,337
+C 90,345 75,352 61,358
+C 48,365 36,371 25,381
+C 15,390 6,403 0,421
+C -8,446 -8,473 -1,500
+C 6,526 19,552 37,576
+C 55,599 77,619 101,634
+C 125,649 152,658 178,660
+C 204,662 229,656 251,645
+C 274,634 295,618 312,598
+C 329,578 342,555 350,530
+C 359,505 363,477 361,450
 Z
 '
 transform='translate(7404,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_1cc04f4d3d6dc6c1)'
+clip-path='url(#clip_e2cebe2eda3b0e6e)'
 />
 <!-- T -->
-<clipPath id='clip_940c5778fc9a3571'>
+<clipPath id='clip_497cd454cabdfb0b'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,600
-C -1,620 -1,640 -1,660
-C 120,660 240,660 361,660
-C 361,640 361,620 361,600
-C 240,600 120,600 -1,600
+C -4,607 -6,613 -8,619
+C -9,624 -10,629 -9,633
+C -9,638 -8,642 -7,647
+C -5,651 -3,655 -1,660
+C 9,681 25,691 46,693
+C 67,696 94,690 125,684
+C 156,677 192,670 231,665
+C 271,661 314,660 361,660
+C 364,653 366,647 368,641
+C 369,636 370,631 369,627
+C 369,622 368,618 367,613
+C 365,609 363,605 361,600
+C 351,579 335,569 314,567
+C 293,564 266,570 235,576
+C 204,583 168,590 129,595
+C 89,599 46,600 -1,600
 Z
 M 149,660
-C 170,660 190,660 211,660
-C 211,439 211,221 211,-0
-C 190,-0 170,0 149,-0
-C 149,221 149,439 149,660
+C 156,663 163,665 168,666
+C 174,667 179,668 184,667
+C 188,667 193,666 197,665
+C 202,664 206,662 211,660
+C 245,647 262,620 265,583
+C 269,545 260,496 250,438
+C 239,380 227,313 219,239
+C 212,165 211,85 211,-0
+C 204,-3 197,-5 192,-6
+C 186,-7 181,-8 176,-7
+C 172,-7 167,-6 163,-5
+C 158,-4 154,-2 149,-0
+C 115,13 98,40 95,77
+C 91,115 100,164 110,222
+C 121,280 133,347 141,421
+C 148,495 149,575 149,660
 Z
 '
 transform='translate(7807,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_940c5778fc9a3571)'
+clip-path='url(#clip_497cd454cabdfb0b)'
 />
 <!-- U -->
-<clipPath id='clip_40531f9f55daa283'>
+<clipPath id='clip_52952735dec4be71'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,660
-C 18,660 42,660 61,660
-C 52,579 56,452 61,331
-C 67,224 63,60 180,60
-C 276,60 294,241 299,331
-C 305,458 346,552 299,660
-C 317,660 341,660 361,660
-C 409,549 367,444 361,329
-C 355,203 316,0 180,0
-C 60,-0 5,194 -1,329
-C -7,436 -13,550 -1,660
+C 5,663 11,665 17,666
+C 22,668 27,668 32,668
+C 37,668 42,667 47,666
+C 52,664 56,662 61,660
+C 80,650 90,634 92,612
+C 94,591 90,565 84,535
+C 79,505 71,472 67,438
+C 62,404 60,368 61,331
+C 62,310 65,283 69,253
+C 74,223 80,191 89,163
+C 98,134 110,108 125,89
+C 140,71 158,60 180,60
+C 202,60 220,70 235,85
+C 250,101 262,121 271,145
+C 280,168 287,196 291,228
+C 295,259 297,294 299,331
+C 301,373 303,404 308,431
+C 314,457 321,479 327,500
+C 333,521 336,542 332,566
+C 328,591 316,620 299,660
+C 306,663 312,666 318,667
+C 324,668 329,669 333,669
+C 338,668 343,667 347,666
+C 352,664 356,662 361,660
+C 381,650 391,635 395,616
+C 398,596 394,572 388,544
+C 383,515 376,483 371,447
+C 366,411 364,371 361,329
+C 359,281 357,237 350,199
+C 343,160 333,127 318,99
+C 303,71 284,47 261,30
+C 238,12 211,0 180,0
+C 149,-0 122,12 99,30
+C 76,47 57,71 42,99
+C 27,127 16,160 10,199
+C 3,237 1,281 -1,329
+C -3,370 -5,407 -6,441
+C -7,475 -7,505 -6,532
+C -6,559 -5,583 -5,604
+C -4,625 -3,644 -1,660
 Z
 '
 transform='translate(8210,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_40531f9f55daa283)'
+clip-path='url(#clip_52952735dec4be71)'
 />
 <!-- V -->
-<clipPath id='clip_77475577006529f4'>
+<clipPath id='clip_4f077a1f02f05d0c'>
 <rect x='-60' y='-360' width='462' height='1070'/>
 </clipPath>
 <path
 d='
 M 61,660
-C 61,640 60,619 61,600
-C -82,474 -12,61 180,60
-C 357,59 441,470 299,600
-C 299,620 298,640 299,660
-C 465,507 411,-1 180,0
-C -34,1 -114,506 61,660
+C 61,653 61,646 61,641
+C 61,635 61,631 61,626
+C 61,622 61,618 61,614
+C 61,609 61,605 61,600
+C 61,554 62,497 64,436
+C 66,376 70,312 78,256
+C 85,199 96,149 113,114
+C 129,79 151,60 180,60
+C 216,60 255,88 294,132
+C 334,176 371,235 394,294
+C 417,352 424,410 408,460
+C 391,510 351,553 299,600
+C 299,607 299,614 299,621
+C 300,628 300,634 300,640
+C 300,646 300,651 300,654
+C 299,658 299,660 299,660
+C 298,660 292,615 283,540
+C 274,466 262,364 250,271
+C 237,179 224,99 212,54
+C 200,8 188,-0 180,0
+C 145,0 103,37 58,92
+C 14,148 -30,221 -57,293
+C -84,365 -93,434 -73,494
+C -53,554 -3,604 61,660
 Z
 '
 transform='translate(8613,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_77475577006529f4)'
+clip-path='url(#clip_4f077a1f02f05d0c)'
 />
 <!-- W -->
-<clipPath id='clip_33d608c14337d2a3'>
+<clipPath id='clip_353321bf09a8b7db'>
 <rect x='-60' y='-360' width='674' height='1070'/>
 </clipPath>
 <path
 d='
 M 61,660
-C 61,640 60,620 61,600
-C -98,504 -35,60 143,60
-C 350,60 46,660 255,660
-C 459,660 158,60 367,60
-C 574,60 301,673 511,660
-C 511,640 507,620 511,600
-C 300,613 576,0 368,0
-C 164,-0 461,600 255,600
-C 45,600 352,-0 142,0
-C -75,0 -133,543 61,660
+C 61,653 61,646 61,641
+C 61,635 61,631 61,626
+C 61,622 61,618 61,614
+C 61,609 61,605 61,600
+C 61,554 63,498 66,440
+C 69,382 74,321 80,266
+C 87,210 95,160 106,122
+C 116,85 128,60 143,60
+C 148,60 157,69 167,111
+C 177,152 189,225 201,308
+C 213,392 224,484 234,551
+C 243,619 251,660 255,660
+C 259,660 267,621 276,558
+C 286,496 298,410 309,330
+C 321,250 333,176 344,128
+C 354,80 362,60 367,60
+C 375,60 389,105 405,175
+C 421,246 440,340 457,423
+C 474,507 489,577 499,616
+C 508,655 513,660 511,660
+C 511,653 511,647 511,642
+C 511,637 511,632 511,627
+C 511,623 511,618 511,614
+C 511,610 511,605 511,600
+C 511,549 507,486 501,421
+C 494,356 485,289 473,227
+C 461,166 446,110 428,69
+C 411,27 390,0 368,0
+C 362,-0 353,7 343,49
+C 332,90 320,163 309,247
+C 297,331 285,424 276,492
+C 266,560 259,600 255,600
+C 251,600 244,559 234,491
+C 224,422 213,329 201,245
+C 189,161 177,89 167,48
+C 157,7 148,-0 142,0
+C 114,0 77,41 39,104
+C 1,167 -38,251 -61,329
+C -84,408 -90,480 -69,534
+C -49,588 -1,623 61,660
 Z
 '
 transform='translate(9016,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_33d608c14337d2a3)'
+clip-path='url(#clip_353321bf09a8b7db)'
 />
 <!-- X -->
-<clipPath id='clip_700e0f823bf5a512'>
+<clipPath id='clip_40351e57bcb33a76'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,660
-C 20,660 37,660 61,660
-C 195,393 237,247 361,-0
-C 342,-0 321,-0 299,-0
-C 166,265 118,421 -1,660
+C 7,661 13,662 19,663
+C 24,663 29,664 34,663
+C 38,663 43,663 47,662
+C 51,662 56,661 61,660
+C 116,651 151,626 172,587
+C 194,548 203,496 213,435
+C 223,375 235,306 259,234
+C 283,161 319,85 361,-0
+C 353,-1 347,-2 341,-3
+C 336,-3 331,-4 326,-3
+C 322,-3 317,-3 313,-2
+C 309,-2 304,-1 299,-0
+C 244,9 209,34 188,73
+C 166,112 157,164 147,225
+C 137,285 125,354 101,426
+C 77,499 41,575 -1,660
 Z
 M 299,660
-C 307,660 345,660 361,660
-C 267,473 184,247 61,-0
-C 39,-0 17,0 -1,-0
-C 137,275 168,399 299,660
+C 306,664 312,667 318,669
+C 323,671 329,672 334,671
+C 339,671 343,670 348,668
+C 352,666 357,663 361,660
+C 383,643 385,614 373,575
+C 360,536 333,488 299,431
+C 265,373 224,307 184,235
+C 143,162 102,82 61,-0
+C 54,-4 48,-7 42,-9
+C 37,-11 31,-12 26,-11
+C 21,-11 17,-10 12,-8
+C 8,-6 3,-3 -1,-0
+C -23,17 -25,46 -13,85
+C -0,124 27,172 61,229
+C 95,287 136,353 176,425
+C 217,498 258,578 299,660
 Z
 '
 transform='translate(9569,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_700e0f823bf5a512)'
+clip-path='url(#clip_40351e57bcb33a76)'
 />
 <!-- Y -->
-<clipPath id='clip_f64c0636fecbe952'>
+<clipPath id='clip_70285a6074dc419d'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,660
-C 22,660 53,660 61,660
-C -43,490 50,360 180,360
-C 291,360 368,504 299,660
-C 300,660 348,660 361,660
-C 430,504 336,300 180,300
-C 38,300 -130,449 -1,660
+C 5,663 11,665 17,666
+C 22,667 27,668 32,668
+C 37,668 42,667 47,665
+C 51,664 56,662 61,660
+C 83,649 100,624 112,590
+C 125,555 134,512 141,474
+C 148,435 153,403 159,384
+C 165,365 171,360 180,360
+C 200,360 223,373 247,392
+C 270,411 294,436 310,463
+C 326,490 335,520 333,553
+C 331,585 317,620 299,660
+C 306,664 312,667 318,668
+C 323,670 329,671 333,671
+C 338,670 343,669 348,667
+C 352,666 356,663 361,660
+C 382,646 389,616 386,579
+C 384,542 371,498 352,456
+C 333,414 307,374 277,346
+C 247,317 214,300 180,300
+C 147,300 114,316 82,340
+C 51,364 21,396 0,432
+C -21,467 -34,506 -35,545
+C -36,584 -24,623 -1,660
 Z
 M 149,360
-C 170,360 190,360 211,360
-C 211,239 211,121 211,-0
-C 190,-0 170,-0 149,-0
-C 149,121 149,239 149,360
+C 156,363 162,365 168,367
+C 174,368 179,369 183,369
+C 188,368 193,367 197,366
+C 202,364 206,362 211,360
+C 232,350 242,334 245,313
+C 247,292 242,265 235,235
+C 228,204 221,168 216,129
+C 212,90 211,47 211,-0
+C 204,-3 198,-5 192,-7
+C 186,-8 181,-9 177,-9
+C 172,-8 167,-7 163,-6
+C 158,-4 154,-2 149,-0
+C 128,10 118,26 115,47
+C 113,68 118,95 125,125
+C 132,156 139,192 144,231
+C 148,270 149,313 149,360
 Z
 '
 transform='translate(9972,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_f64c0636fecbe952)'
+clip-path='url(#clip_70285a6074dc419d)'
 />
 <!-- Z -->
-<clipPath id='clip_332e96d4dae1f4e9'>
+<clipPath id='clip_23b813b9c82c697c'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 61,600
-C 40,600 18,599 -1,600
-C 75,684 289,750 356,646
-C 469,472 -28,247 59,42
-C 100,-56 279,1 361,60
-C 361,40 361,20 361,-0
-C 261,-72 52,-101 1,18
-C -84,218 426,425 304,614
-C 258,684 119,663 61,600
+C 54,598 46,596 39,595
+C 32,594 26,593 20,592
+C 14,592 9,592 6,594
+C 2,595 -0,597 -1,600
+C -3,609 15,621 45,633
+C 75,644 117,656 159,664
+C 202,672 246,676 282,674
+C 318,672 345,664 356,646
+C 371,623 357,584 326,536
+C 296,487 249,430 203,370
+C 157,310 112,247 83,191
+C 54,134 42,82 59,42
+C 69,19 86,3 108,-8
+C 129,-18 155,-23 183,-22
+C 210,-21 239,-13 269,1
+C 299,16 329,37 361,60
+C 364,53 366,47 367,41
+C 368,36 368,31 368,27
+C 368,22 367,18 366,13
+C 364,9 363,5 361,-0
+C 351,-27 326,-46 294,-59
+C 262,-71 223,-77 183,-75
+C 144,-73 104,-65 72,-49
+C 39,-34 13,-11 1,18
+C -16,59 -4,109 31,167
+C 66,225 121,289 173,349
+C 225,409 273,465 298,509
+C 322,553 322,585 304,614
+C 291,634 273,649 253,659
+C 233,670 211,676 189,677
+C 166,677 145,671 124,658
+C 103,645 83,624 61,600
 Z
 '
 transform='translate(10375,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_332e96d4dae1f4e9)'
+clip-path='url(#clip_23b813b9c82c697c)'
 />
 <!--   -->
 <clipPath id='clip_e3b0c44298fc1c14'>
@@ -23991,388 +28457,808 @@ style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
 clip-path='url(#clip_e3b0c44298fc1c14)'
 />
 <!-- ! -->
-<clipPath id='clip_cc3b9cf51c38b418'>
+<clipPath id='clip_1f5c4249d337a9e1'>
 <rect x='-60' y='-360' width='228' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,660
-C 20,660 40,660 61,660
-C 61,489 61,321 61,150
-C 40,150 20,150 -1,150
-C -1,321 -1,489 -1,660
+C 6,663 13,665 18,666
+C 24,668 29,668 34,668
+C 38,668 43,667 47,665
+C 52,664 56,662 61,660
+C 89,648 102,627 105,597
+C 108,568 101,530 93,486
+C 84,442 74,390 68,334
+C 62,278 61,216 61,150
+C 54,147 47,145 42,144
+C 36,142 31,142 26,142
+C 22,142 17,143 13,145
+C 8,146 4,148 -1,150
+C -29,162 -42,183 -45,213
+C -48,242 -41,280 -33,324
+C -24,368 -14,420 -8,476
+C -2,532 -1,594 -1,660
 Z
 M 30,-5
-C 49,-5 65,10 65,30
-C 65,49 48,65 30,65
-C 12,65 -5,49 -5,30
-C -5,11 11,-5 30,-5
+C 48,-5 65,12 65,30
+C 65,48 48,65 30,65
+C 12,65 -5,48 -5,30
+C -5,12 12,-5 30,-5
 Z
 '
 transform='translate(11031,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_cc3b9cf51c38b418)'
+clip-path='url(#clip_1f5c4249d337a9e1)'
 />
 <!-- " -->
-<clipPath id='clip_485d4c88e7e106fe'>
+<clipPath id='clip_79dee7f94b63e40d'>
 <rect x='-60' y='-360' width='424' height='1070'/>
 </clipPath>
 <path
 d='
 M 99,690
-C 120,690 140,690 161,690
-C 161,626 161,564 161,500
-C 140,500 120,500 99,500
-C 99,564 99,626 99,690
+C 106,693 112,696 118,698
+C 123,700 129,701 133,700
+C 138,700 143,699 147,697
+C 152,695 156,693 161,690
+C 173,682 179,673 180,661
+C 182,650 179,636 175,620
+C 171,605 167,587 164,567
+C 162,547 161,525 161,500
+C 154,497 148,494 142,492
+C 137,490 131,489 127,490
+C 122,490 117,491 113,493
+C 108,495 104,497 99,500
+C 87,508 81,517 80,529
+C 78,540 81,554 85,570
+C 89,585 93,603 96,623
+C 98,643 99,665 99,690
 Z
 M 199,690
-C 220,690 240,690 261,690
-C 261,626 261,564 261,500
-C 240,500 220,500 199,500
-C 199,564 199,626 199,690
+C 206,693 212,696 218,698
+C 223,700 229,701 233,700
+C 238,700 243,699 247,697
+C 252,695 256,693 261,690
+C 273,682 279,673 280,661
+C 282,650 279,636 275,620
+C 271,605 267,587 264,567
+C 262,547 261,525 261,500
+C 254,497 248,494 242,492
+C 237,490 231,489 227,490
+C 222,490 217,491 213,493
+C 208,495 204,497 199,500
+C 187,508 181,517 180,529
+C 178,540 181,554 185,570
+C 189,585 193,603 196,623
+C 198,643 199,665 199,690
 Z
 '
 transform='translate(11134,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_485d4c88e7e106fe)'
+clip-path='url(#clip_79dee7f94b63e40d)'
 />
 <!-- # -->
-<clipPath id='clip_acfc226fc1e00083'>
+<clipPath id='clip_8dced4f74da90b65'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,400
-C -1,420 -1,440 -1,460
-C 120,460 240,460 361,460
-C 361,440 361,420 361,400
-C 240,400 120,400 -1,400
+C -4,407 -6,413 -8,419
+C -9,424 -10,429 -9,433
+C -9,438 -8,442 -7,447
+C -5,451 -3,455 -1,460
+C 9,481 25,491 46,493
+C 67,496 94,490 125,484
+C 156,477 192,470 231,465
+C 271,461 314,460 361,460
+C 364,453 366,447 368,441
+C 369,436 370,431 369,427
+C 369,422 368,418 367,413
+C 365,409 363,405 361,400
+C 351,379 335,369 314,367
+C 293,364 266,370 235,376
+C 204,383 168,390 129,395
+C 89,399 46,400 -1,400
 Z
 M -1,200
-C -1,220 -1,240 -1,260
-C 120,260 240,260 361,260
-C 361,240 361,220 361,200
-C 240,200 120,200 -1,200
+C -4,207 -6,213 -8,219
+C -9,224 -10,229 -9,233
+C -9,238 -8,242 -7,247
+C -5,251 -3,255 -1,260
+C 9,281 25,291 46,293
+C 67,296 94,290 125,284
+C 156,277 192,270 231,265
+C 271,261 314,260 361,260
+C 364,253 366,247 368,241
+C 369,236 370,231 369,227
+C 369,222 368,218 367,213
+C 365,209 363,205 361,200
+C 351,179 335,169 314,167
+C 293,164 266,170 235,176
+C 204,183 168,190 129,195
+C 89,199 46,200 -1,200
 Z
 M 99,660
-C 120,660 140,660 161,660
-C 161,439 161,221 161,-0
-C 140,-0 120,0 99,-0
-C 99,221 99,439 99,660
+C 106,663 113,665 118,666
+C 124,667 129,668 134,667
+C 138,667 143,666 147,665
+C 152,664 156,662 161,660
+C 195,647 212,620 215,583
+C 219,545 210,496 200,438
+C 189,380 177,313 169,239
+C 162,165 161,85 161,-0
+C 154,-3 147,-5 142,-6
+C 136,-7 131,-8 126,-7
+C 122,-7 117,-6 113,-5
+C 108,-4 104,-2 99,-0
+C 65,13 48,40 45,77
+C 41,115 50,164 60,222
+C 71,280 83,347 91,421
+C 98,495 99,575 99,660
 Z
 M 199,660
-C 220,660 240,660 261,660
-C 261,439 261,221 261,-0
-C 240,-0 220,0 199,-0
-C 199,221 199,439 199,660
+C 206,663 213,665 218,666
+C 224,667 229,668 234,667
+C 238,667 243,666 247,665
+C 252,664 256,662 261,660
+C 295,647 312,620 315,583
+C 319,545 310,496 300,438
+C 289,380 277,313 269,239
+C 262,165 261,85 261,-0
+C 254,-3 247,-5 242,-6
+C 236,-7 231,-8 226,-7
+C 222,-7 217,-6 213,-5
+C 208,-4 204,-2 199,-0
+C 165,13 148,40 145,77
+C 141,115 150,164 160,222
+C 171,280 183,347 191,421
+C 198,495 199,575 199,660
 Z
 '
 transform='translate(11437,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_acfc226fc1e00083)'
+clip-path='url(#clip_8dced4f74da90b65)'
 />
 <!-- £ -->
-<clipPath id='clip_c437108757eb10af'>
+<clipPath id='clip_85b9cf75dd17e27b'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 361,540
-C 340,540 319,541 299,540
-C 272,575 228,605 184,600
-C 133,594 60,563 61,511
-C 63,471 96,437 109,401
-C 148,299 -101,60 30,60
-C 127,60 238,-9 299,60
-C 319,60 341,60 361,60
-C 293,-17 142,-0 30,0
-C -103,0 95,262 51,379
-C 35,422 -0,463 -1,509
-C -3,585 99,651 176,660
-C 251,669 317,598 361,540
+C 355,538 349,536 343,535
+C 338,534 333,534 328,534
+C 323,534 318,534 313,536
+C 309,537 304,538 299,540
+C 288,544 279,550 271,557
+C 262,564 254,573 246,580
+C 238,587 229,593 219,597
+C 209,601 198,602 184,600
+C 173,599 160,596 146,592
+C 132,587 118,582 105,575
+C 92,568 80,559 73,548
+C 65,538 61,525 61,511
+C 62,501 64,491 67,483
+C 71,474 75,466 80,457
+C 85,449 90,440 95,431
+C 100,422 105,412 109,401
+C 120,371 128,333 132,291
+C 136,249 137,203 134,164
+C 130,126 122,95 105,79
+C 89,62 64,60 30,60
+C 65,60 94,59 120,52
+C 146,45 169,34 189,25
+C 209,16 227,9 243,14
+C 260,18 276,34 299,60
+C 307,61 314,62 321,63
+C 329,64 335,65 341,65
+C 347,65 352,65 355,64
+C 359,63 361,62 361,60
+C 362,55 347,49 323,42
+C 300,36 267,29 231,23
+C 195,17 156,11 121,7
+C 85,3 53,0 30,0
+C 50,0 64,1 73,18
+C 82,36 86,70 86,114
+C 86,158 83,210 77,257
+C 71,305 63,347 51,379
+C 46,392 40,403 35,414
+C 29,425 24,435 18,444
+C 13,454 8,464 5,475
+C 1,485 -1,496 -1,509
+C -2,531 4,551 14,569
+C 25,586 40,601 58,614
+C 76,626 97,637 117,644
+C 138,652 158,658 176,660
+C 198,662 219,660 238,653
+C 257,645 275,633 291,619
+C 307,605 322,589 334,574
+C 346,560 355,548 361,540
 Z
 M -1,360
-C -1,380 -1,400 -1,420
-C 95,420 190,420 286,420
-C 286,400 286,380 286,360
-C 190,360 95,360 -1,360
+C -4,367 -7,373 -8,378
+C -10,384 -10,389 -10,393
+C -10,398 -9,402 -7,407
+C -5,411 -3,415 -1,420
+C 8,437 21,446 38,448
+C 55,450 76,445 100,440
+C 125,434 152,428 184,424
+C 215,421 249,420 286,420
+C 289,413 292,407 293,402
+C 295,396 295,391 295,387
+C 295,382 294,378 292,373
+C 290,369 288,365 286,360
+C 277,343 264,334 247,332
+C 230,330 209,335 185,340
+C 160,346 133,352 101,356
+C 70,359 36,360 -1,360
 Z
 '
 transform='translate(11840,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_c437108757eb10af)'
+clip-path='url(#clip_85b9cf75dd17e27b)'
 />
 <!-- $ -->
-<clipPath id='clip_39c3f92da30efef8'>
+<clipPath id='clip_4885093a0098c67a'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 361,450
-C 341,450 319,451 299,450
-C 303,514 247,604 182,600
-C 116,596 40,501 60,439
-C 77,387 151,383 196,356
-C 253,322 327,301 358,244
-C 406,156 280,1 180,0
-C 88,-1 -12,117 -1,210
-C 19,210 40,210 61,210
-C 53,145 114,59 180,60
-C 246,61 335,156 302,216
-C 276,264 211,276 164,304
-C 105,339 21,356 0,421
-C -31,515 80,654 178,660
-C 271,666 367,543 361,450
+C 355,448 349,446 344,444
+C 338,443 333,442 328,443
+C 323,443 318,443 313,445
+C 309,446 304,448 299,450
+C 284,457 272,471 263,487
+C 254,504 246,523 239,541
+C 232,559 225,575 216,585
+C 207,596 197,601 182,600
+C 167,599 150,592 134,582
+C 118,572 102,558 89,543
+C 76,527 66,510 60,492
+C 55,474 54,456 60,439
+C 65,425 72,416 81,410
+C 90,403 100,400 112,396
+C 123,392 136,388 150,381
+C 163,375 179,366 196,356
+C 217,343 235,333 251,324
+C 267,315 281,308 294,302
+C 306,295 318,288 329,279
+C 339,271 349,260 358,244
+C 372,219 376,191 371,164
+C 366,137 353,110 334,86
+C 315,62 290,41 264,25
+C 237,10 208,0 180,0
+C 156,-0 131,6 108,18
+C 85,29 63,45 46,64
+C 28,83 15,106 6,130
+C -2,155 -4,182 -1,210
+C 5,212 11,214 16,216
+C 22,217 27,217 32,217
+C 37,217 42,217 47,215
+C 51,214 56,212 61,210
+C 76,203 88,190 97,174
+C 106,158 113,139 121,122
+C 128,104 135,88 144,77
+C 153,66 164,60 180,60
+C 195,60 213,67 231,77
+C 249,87 266,101 280,116
+C 295,131 305,148 309,165
+C 314,182 311,199 302,216
+C 296,228 287,236 278,243
+C 269,249 259,254 247,260
+C 236,265 224,270 211,277
+C 197,285 182,294 164,304
+C 142,317 123,328 107,337
+C 90,345 75,352 61,358
+C 48,365 36,371 25,381
+C 15,390 6,403 0,421
+C -8,446 -8,473 -1,500
+C 6,526 19,552 37,576
+C 55,599 77,619 101,634
+C 125,649 152,658 178,660
+C 204,662 229,656 251,645
+C 274,634 295,618 312,598
+C 329,578 342,555 350,530
+C 359,505 363,477 361,450
 Z
 M 149,690
-C 170,690 190,690 211,690
-C 211,449 211,211 211,-30
-C 190,-30 170,-30 149,-30
-C 149,211 149,449 149,690
+C 156,693 163,695 168,696
+C 174,697 179,697 184,697
+C 188,697 193,696 197,695
+C 202,693 206,692 211,690
+C 248,677 265,648 269,607
+C 273,566 264,512 252,449
+C 241,385 228,312 220,231
+C 212,150 211,62 211,-30
+C 204,-33 197,-35 192,-36
+C 186,-37 181,-37 176,-37
+C 172,-37 167,-36 163,-35
+C 158,-33 154,-32 149,-30
+C 112,-17 95,12 91,53
+C 87,94 96,148 108,211
+C 119,275 132,348 140,429
+C 148,510 149,598 149,690
 Z
 '
 transform='translate(12243,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_39c3f92da30efef8)'
+clip-path='url(#clip_4885093a0098c67a)'
 />
 <!-- % -->
-<clipPath id='clip_2bcc773f032914bb'>
+<clipPath id='clip_7441159bc0d86530'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 110,621
-C 105,605 69,569 94,557
-C 95,556 90,556 91,557
-C 120,572 118,648 110,621
+C 108,613 105,605 102,598
+C 99,590 96,583 93,577
+C 91,571 89,566 89,563
+C 89,560 91,559 94,557
+C 94,557 93,557 93,557
+C 93,557 93,557 92,557
+C 92,557 92,557 92,557
+C 91,557 91,557 91,557
+C 98,561 103,564 106,568
+C 108,571 108,576 107,581
+C 107,587 105,593 106,600
+C 106,606 108,613 110,621
 Z
 M 119,503
-C 100,493 82,495 66,503
-C 23,525 47,628 50,639
-C 80,740 174,531 119,503
+C 115,501 110,499 106,498
+C 101,497 97,496 93,496
+C 88,496 84,497 79,498
+C 75,499 70,501 66,503
+C 54,509 45,518 41,528
+C 36,538 35,551 35,564
+C 36,578 38,592 41,605
+C 44,618 47,630 50,639
+C 43,617 36,598 36,580
+C 37,562 43,544 54,531
+C 65,517 78,506 90,502
+C 102,497 111,499 119,503
 Z
 M 276,60
-C 294,62 283,97 269,102
-C 268,102 267,102 266,102
-C 261,100 265,58 276,60
+C 282,61 289,34 293,23
+C 297,13 297,16 295,29
+C 292,43 287,65 283,80
+C 278,95 273,100 269,102
+C 269,102 268,102 268,102
+C 268,102 268,102 268,102
+C 268,102 267,102 267,102
+C 267,102 267,102 266,102
+C 264,101 263,100 262,96
+C 262,93 263,88 264,82
+C 266,77 268,71 270,66
+C 272,62 275,60 276,60
 Z
 M 244,158
-C 265,166 283,161 291,158
-C 353,135 372,11 284,0
-C 204,-10 164,127 244,158
+C 248,160 252,161 256,162
+C 260,163 264,163 267,163
+C 271,163 275,163 279,162
+C 283,161 287,160 291,158
+C 304,153 314,146 320,133
+C 325,120 325,102 322,83
+C 320,64 314,43 307,28
+C 300,12 292,1 284,0
+C 277,-1 269,7 260,22
+C 252,37 243,60 237,81
+C 230,103 227,123 228,137
+C 229,150 235,155 244,158
 Z
 M 299,690
-C 317,690 346,690 361,690
-C 264,476 191,257 61,-30
-C 41,-30 18,-30 -1,-30
-C 105,203 181,430 299,690
+C 306,694 312,697 318,699
+C 323,700 329,701 334,701
+C 338,701 343,700 348,698
+C 352,696 357,693 361,690
+C 385,673 388,642 376,600
+C 363,558 335,505 301,442
+C 266,379 225,307 184,227
+C 143,147 102,60 61,-30
+C 54,-34 48,-37 42,-39
+C 37,-40 31,-41 26,-41
+C 22,-41 17,-40 12,-38
+C 8,-36 3,-33 -1,-30
+C -25,-13 -28,18 -16,60
+C -3,102 25,155 59,218
+C 94,281 135,353 176,433
+C 217,513 258,600 299,690
 Z
 '
 transform='translate(12646,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_2bcc773f032914bb)'
+clip-path='url(#clip_7441159bc0d86530)'
 />
 <!-- & -->
-<clipPath id='clip_8cfd0bedf655bd6e'>
+<clipPath id='clip_2cac5f4cb3bbea0c'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 299,210
-C 319,210 341,210 361,210
-C 361,115 269,3 181,0
-C 95,-3 -1,97 -1,180
-C -2,307 197,368 224,487
-C 236,537 185,606 134,600
-C 86,594 60,529 61,481
-C 66,310 204,127 361,60
-C 361,40 362,20 361,-0
-C 193,72 4,290 -1,479
-C -4,554 51,651 126,660
-C 208,670 305,555 286,473
-C 258,353 61,304 61,180
-C 62,124 124,58 179,60
-C 244,62 299,141 299,210
+C 306,214 312,217 318,219
+C 324,221 329,223 334,222
+C 339,222 344,221 349,219
+C 353,217 357,214 361,210
+C 372,198 373,179 367,158
+C 360,136 346,111 328,87
+C 309,64 285,42 260,27
+C 235,11 207,1 181,0
+C 159,-1 137,5 115,14
+C 94,24 74,38 56,54
+C 39,71 25,90 14,112
+C 4,133 -1,156 -1,180
+C -2,215 10,244 28,270
+C 47,296 72,319 98,341
+C 125,363 153,385 176,408
+C 199,432 217,457 224,487
+C 228,502 228,517 225,530
+C 221,544 214,557 205,567
+C 196,578 185,587 173,593
+C 160,599 147,602 134,600
+C 121,599 111,594 101,586
+C 92,579 84,570 78,559
+C 72,549 67,536 64,523
+C 62,510 61,496 61,481
+C 63,439 71,399 81,358
+C 92,316 105,276 124,238
+C 144,201 170,167 209,139
+C 248,110 299,87 361,60
+C 365,53 368,47 370,41
+C 372,36 373,30 373,25
+C 373,20 372,15 370,11
+C 368,7 365,3 361,-0
+C 344,-13 314,-3 277,21
+C 240,46 197,87 156,136
+C 115,185 76,243 48,302
+C 19,362 0,423 -1,479
+C -2,501 0,523 6,543
+C 11,563 20,582 31,598
+C 43,614 57,628 73,639
+C 89,650 107,657 126,660
+C 149,662 171,658 192,648
+C 213,638 233,623 248,605
+C 264,587 276,565 283,543
+C 290,520 291,496 286,473
+C 279,442 260,417 238,394
+C 215,371 188,351 161,330
+C 135,309 110,288 91,264
+C 73,240 61,213 61,180
+C 62,164 65,148 71,133
+C 77,119 86,106 97,95
+C 108,84 121,75 135,69
+C 149,63 164,60 179,60
+C 196,61 213,66 228,73
+C 244,80 258,89 270,101
+C 281,113 289,127 294,145
+C 298,163 299,185 299,210
 Z
 '
 transform='translate(13049,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_8cfd0bedf655bd6e)'
+clip-path='url(#clip_2cac5f4cb3bbea0c)'
 />
 <!-- ' -->
-<clipPath id='clip_8cb50ae806feb40b'>
+<clipPath id='clip_9b3a59812d0bd912'>
 <rect x='-60' y='-360' width='224' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,690
-C 20,690 40,690 61,690
-C 61,626 61,564 61,500
-C 40,500 20,500 -1,500
-C -1,564 -1,626 -1,690
+C 6,693 12,696 18,698
+C 23,700 29,701 33,700
+C 38,700 43,699 47,697
+C 52,695 56,693 61,690
+C 73,682 79,673 80,661
+C 82,650 79,636 75,620
+C 71,605 67,587 64,567
+C 62,547 61,525 61,500
+C 54,497 48,494 42,492
+C 37,490 31,489 27,490
+C 22,490 17,491 13,493
+C 8,495 4,497 -1,500
+C -13,508 -19,517 -20,529
+C -22,540 -19,554 -15,570
+C -11,585 -7,603 -4,623
+C -2,643 -1,665 -1,690
 Z
 '
 transform='translate(13452,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_8cb50ae806feb40b)'
+clip-path='url(#clip_9b3a59812d0bd912)'
 />
 <!-- ( -->
-<clipPath id='clip_739ebb67268e8985'>
+<clipPath id='clip_c24152a3380c7a87'>
 <rect x='-60' y='-360' width='299' height='1070'/>
 </clipPath>
 <path
 d='
 M 74,690
-C 94,690 115,690 136,690
-C 82,578 61,448 61,330
-C 62,205 82,83 136,-30
-C 116,-30 94,-30 74,-30
-C 20,82 -1,207 -1,330
-C -2,456 19,577 74,690
+C 80,693 86,696 91,698
+C 97,699 102,700 107,700
+C 113,700 117,699 122,697
+C 127,696 132,693 136,690
+C 152,678 155,661 150,638
+C 144,616 131,588 116,557
+C 102,526 87,491 77,453
+C 66,414 61,373 61,330
+C 62,305 62,281 63,255
+C 64,229 64,202 67,174
+C 71,145 77,115 88,82
+C 99,48 116,12 136,-30
+C 129,-32 122,-34 117,-35
+C 111,-36 106,-36 101,-36
+C 97,-36 92,-35 88,-34
+C 83,-33 79,-32 74,-30
+C 47,-21 28,-6 17,15
+C 5,36 0,62 -2,94
+C -4,125 -3,161 -2,201
+C -2,240 -1,284 -1,330
+C -2,376 -1,417 3,453
+C 6,489 13,521 21,549
+C 29,577 39,603 48,626
+C 56,649 65,671 74,690
 Z
 '
 transform='translate(13555,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_739ebb67268e8985)'
+clip-path='url(#clip_c24152a3380c7a87)'
 />
 <!-- ) -->
-<clipPath id='clip_c29d60f69abada75'>
+<clipPath id='clip_51b35ab1d3d49979'>
 <rect x='-60' y='-360' width='299' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,690
-C 19,690 41,690 61,690
-C 115,578 137,452 136,330
-C 136,206 115,83 61,-30
-C 40,-30 20,-29 -1,-30
-C 52,81 73,206 74,330
-C 74,456 54,576 -1,690
+C 6,692 13,694 18,695
+C 24,696 29,696 34,696
+C 38,696 43,695 47,694
+C 52,693 56,692 61,690
+C 88,681 107,666 118,645
+C 130,624 135,598 137,566
+C 139,535 138,499 137,459
+C 137,420 137,376 136,330
+C 136,284 136,243 132,207
+C 129,171 122,139 114,111
+C 106,83 96,58 88,34
+C 79,11 70,-10 61,-30
+C 55,-33 49,-36 44,-38
+C 38,-39 33,-40 28,-40
+C 22,-40 18,-39 13,-37
+C 8,-36 3,-33 -1,-30
+C -17,-18 -20,-1 -15,22
+C -9,44 4,72 19,103
+C 33,134 48,169 58,208
+C 68,246 73,287 74,330
+C 74,355 73,380 72,405
+C 71,431 71,458 68,486
+C 65,515 59,545 47,579
+C 36,612 19,648 -1,690
 Z
 '
 transform='translate(13733,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_c29d60f69abada75)'
+clip-path='url(#clip_51b35ab1d3d49979)'
 />
 <!-- * -->
-<clipPath id='clip_ce2ce8b1d3f6694c'>
+<clipPath id='clip_fa6586128c72f367'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,360
-C -1,380 -1,400 -1,420
-C 118,349 243,311 361,240
-C 361,221 361,200 361,180
-C 243,251 119,288 -1,360
+C -5,367 -8,373 -10,378
+C -12,384 -13,389 -13,394
+C -13,399 -11,403 -9,408
+C -7,412 -5,416 -1,420
+C 12,434 30,436 52,430
+C 74,423 101,407 132,387
+C 162,367 197,343 236,317
+C 275,292 317,266 361,240
+C 365,233 368,227 370,222
+C 372,216 373,211 373,206
+C 373,201 371,197 369,192
+C 367,188 365,184 361,180
+C 348,166 330,164 308,170
+C 286,177 259,193 228,213
+C 198,233 163,257 124,283
+C 85,308 43,334 -1,360
 Z
 M -1,180
-C -1,200 -1,221 -1,240
-C 118,311 243,349 361,420
-C 361,400 361,380 361,360
-C 242,289 117,251 -1,180
+C -3,187 -4,194 -5,199
+C -6,204 -6,209 -6,214
+C -5,218 -5,222 -4,226
+C -3,231 -2,235 -1,240
+C 6,273 22,293 44,305
+C 67,317 96,322 129,328
+C 162,333 198,341 237,355
+C 275,370 315,393 361,420
+C 363,413 364,406 365,401
+C 366,396 366,391 366,386
+C 365,382 365,378 364,374
+C 363,369 362,365 361,360
+C 354,327 338,307 316,295
+C 293,283 264,278 231,272
+C 198,267 162,259 123,245
+C 85,230 45,207 -1,180
 Z
 M 149,500
-C 170,500 190,500 211,500
-C 211,373 211,247 211,120
-C 190,120 170,120 149,120
-C 149,247 149,373 149,500
+C 156,503 163,505 168,507
+C 174,508 179,509 183,509
+C 188,508 193,507 197,506
+C 202,504 206,502 211,500
+C 233,490 244,473 246,451
+C 248,428 243,401 236,368
+C 229,335 221,298 217,256
+C 212,215 211,169 211,120
+C 204,117 197,115 192,113
+C 186,112 181,111 177,111
+C 172,112 167,113 163,114
+C 158,116 154,118 149,120
+C 127,130 116,147 114,169
+C 112,192 117,219 124,252
+C 131,285 139,322 143,364
+C 148,405 149,451 149,500
 Z
 '
 transform='translate(13911,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_ce2ce8b1d3f6694c)'
+clip-path='url(#clip_fa6586128c72f367)'
 />
 <!-- + -->
-<clipPath id='clip_a88767370ed89b36'>
+<clipPath id='clip_a386890991f7612e'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,300
-C -1,320 -1,340 -1,360
-C 120,360 240,360 361,360
-C 361,340 361,320 361,300
-C 240,300 120,300 -1,300
+C -4,307 -6,313 -8,319
+C -9,324 -10,329 -9,333
+C -9,338 -8,342 -7,347
+C -5,351 -3,355 -1,360
+C 9,381 25,391 46,393
+C 67,396 94,390 125,384
+C 156,377 192,370 231,365
+C 271,361 314,360 361,360
+C 364,353 366,347 368,341
+C 369,336 370,331 369,327
+C 369,322 368,318 367,313
+C 365,309 363,305 361,300
+C 351,279 335,269 314,267
+C 293,264 266,270 235,276
+C 204,283 168,290 129,295
+C 89,299 46,300 -1,300
 Z
 M 149,510
-C 170,510 190,510 211,510
-C 211,389 211,271 211,150
-C 190,150 170,150 149,150
-C 149,271 149,389 149,510
+C 156,513 162,515 168,517
+C 174,518 179,519 183,519
+C 188,518 193,517 197,516
+C 202,514 206,512 211,510
+C 232,500 242,484 245,463
+C 247,442 242,415 235,385
+C 228,354 221,318 216,279
+C 212,240 211,197 211,150
+C 204,147 198,145 192,143
+C 186,142 181,141 177,141
+C 172,142 167,143 163,144
+C 158,146 154,148 149,150
+C 128,160 118,176 115,197
+C 113,218 118,245 125,275
+C 132,306 139,342 144,381
+C 148,420 149,463 149,510
 Z
 '
 transform='translate(14314,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_a88767370ed89b36)'
+clip-path='url(#clip_a386890991f7612e)'
 />
 <!-- , -->
-<clipPath id='clip_38a5c52e446f70c0'>
+<clipPath id='clip_dc814a9adb7fb4e6'>
 <rect x='-60' y='-360' width='299' height='1070'/>
 </clipPath>
 <path
 d='
 M 74,60
-C 94,60 116,60 136,60
-C 97,8 102,-46 61,-100
-C 41,-100 15,-99 -1,-100
-C 35,-51 38,12 74,60
+C 81,64 87,67 93,69
+C 99,71 104,73 109,73
+C 114,72 119,71 124,69
+C 128,67 132,64 136,60
+C 144,52 147,42 145,31
+C 144,20 138,8 130,-6
+C 122,-19 111,-34 99,-49
+C 87,-65 74,-82 61,-100
+C 54,-104 48,-107 42,-109
+C 36,-111 31,-113 26,-113
+C 21,-112 16,-111 11,-109
+C 7,-107 3,-104 -1,-100
+C -9,-92 -12,-82 -10,-71
+C -9,-60 -3,-48 5,-34
+C 13,-21 24,-6 36,9
+C 48,25 61,42 74,60
 Z
 '
 transform='translate(14717,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_38a5c52e446f70c0)'
+clip-path='url(#clip_dc814a9adb7fb4e6)'
 />
 <!-- - -->
-<clipPath id='clip_c5acd07bba07cea8'>
+<clipPath id='clip_ba8187f37d0d9326'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M -1,300
-C -1,320 -1,340 -1,360
-C 120,360 240,360 361,360
-C 361,340 361,320 361,300
-C 240,300 120,300 -1,300
+C -4,307 -6,313 -8,319
+C -9,324 -10,329 -9,333
+C -9,338 -8,342 -7,347
+C -5,351 -3,355 -1,360
+C 9,381 25,391 46,393
+C 67,396 94,390 125,384
+C 156,377 192,370 231,365
+C 271,361 314,360 361,360
+C 364,353 366,347 368,341
+C 369,336 370,331 369,327
+C 369,322 368,318 367,313
+C 365,309 363,305 361,300
+C 351,279 335,269 314,267
+C 293,264 266,270 235,276
+C 204,283 168,290 129,295
+C 89,299 46,300 -1,300
 Z
 '
 transform='translate(14895,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_c5acd07bba07cea8)'
+clip-path='url(#clip_ba8187f37d0d9326)'
 />
 <!-- . -->
-<clipPath id='clip_0858586df518c73b'>
+<clipPath id='clip_58c71ef1347935a3'>
 <rect x='-60' y='-360' width='228' height='1070'/>
 </clipPath>
 <path
 d='
 M 30,-5
-C 49,-5 65,10 65,30
-C 65,49 48,65 30,65
-C 12,65 -5,49 -5,30
-C -5,11 11,-5 30,-5
+C 48,-5 65,12 65,30
+C 65,48 48,65 30,65
+C 12,65 -5,48 -5,30
+C -5,12 12,-5 30,-5
 Z
 '
 transform='translate(15298,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_0858586df518c73b)'
+clip-path='url(#clip_58c71ef1347935a3)'
 />
 <!-- / -->
-<clipPath id='clip_de84f99a938fbb00'>
+<clipPath id='clip_3d3e01769b1602a3'>
 <rect x='-60' y='-360' width='524' height='1070'/>
 </clipPath>
 <path
 d='
 M 61,-30
-C 41,-30 17,-30 -1,-30
-C 101,194 178,424 299,690
-C 313,690 346,690 361,690
-C 267,482 196,266 61,-30
+C 54,-34 48,-37 42,-39
+C 37,-40 31,-41 26,-41
+C 22,-41 17,-40 12,-38
+C 8,-36 3,-33 -1,-30
+C -25,-13 -28,18 -16,60
+C -3,102 25,155 59,218
+C 94,281 135,353 176,433
+C 217,513 258,600 299,690
+C 306,694 312,697 318,699
+C 323,700 329,701 334,701
+C 338,701 343,700 348,698
+C 352,696 357,693 361,690
+C 385,673 388,642 376,600
+C 363,558 335,505 301,442
+C 266,379 225,307 184,227
+C 143,147 102,60 61,-30
 Z
 '
 transform='translate(15401,22592) scale(1,-1)'
 style='fill:#000000;fill-rule:nonzero;stroke:#000000;stroke-width:5'
-clip-path='url(#clip_de84f99a938fbb00)'
+clip-path='url(#clip_3d3e01769b1602a3)'
 />
 </g>
 </g>

--- a/src/generator/DactylSpline.fs
+++ b/src/generator/DactylSpline.fs
@@ -806,6 +806,48 @@ type DactylSpline(ctrlPts, isClosed) =
             if Double.IsNaN p.rd then
                 p.rd <- 0.
 
+        // Final pass to resolve any remaining NaN th_in/th_out using neighbour angles
+        for i in 0 .. result.Length - 1 do
+            let p = result.[i]
+
+            if Double.IsNaN p.th_in || Double.IsNaN p.th_out then
+                let prev = result.[(i - 1 + result.Length) % result.Length]
+                let next = result.[(i + 1) % result.Length]
+                // Only use neighbour coords if they are themselves valid
+                let fallback =
+                    if
+                        not (Double.IsNaN prev.x)
+                        && not (Double.IsNaN prev.y)
+                        && not (Double.IsNaN next.x)
+                        && not (Double.IsNaN next.y)
+                    then
+                        atan2 (next.y - prev.y) (next.x - prev.x)
+                    else
+                        0.0
+
+                if Double.IsNaN p.th_in then
+                    p.th_in <- fallback
+
+                if Double.IsNaN p.th_out then
+                    p.th_out <- fallback
+
+        // Validate: throw if any coordinate is still NaN so the caller can handle it cleanly
+        for i in 0 .. result.Length - 1 do
+            let p = result.[i]
+
+            if
+                Double.IsNaN p.x
+                || Double.IsNaN p.y
+                || Double.IsNaN p.th_in
+                || Double.IsNaN p.th_out
+                || Double.IsNaN p.ld
+                || Double.IsNaN p.rd
+            then
+                failwithf
+                    "NaN in solved BezierPoint[%d]: %s"
+                    i
+                    (p.tostring ())
+
         result
 
     member this.renderFromPoints(bezPts: BezierPoint[], showComb, showTangents) =

--- a/src/generator/Font.fs
+++ b/src/generator/Font.fs
@@ -425,12 +425,17 @@ type Font(axes: Axes) =
 
     member this.monospace =
         let mono e =
-            let monoFn (p: Point) =
-                let full_scale = _metrics.monospaceWidth / (this.elemWidth e)
-                let x_scale = (1.0 - axes.monospace) + axes.monospace * full_scale
-                { p with x = p.x * x_scale }
+            let w = this.elemWidth e
 
-            movePoints monoFn None e
+            if w = 0.0 then
+                e
+            else
+                let monoFn (p: Point) =
+                    let full_scale = _metrics.monospaceWidth / w
+                    let x_scale = (1.0 - axes.monospace) + axes.monospace * full_scale
+                    { p with x = p.x * x_scale }
+
+                movePoints monoFn None e
 
         applyIf (axes.monospace > 0.0) mono
 
@@ -912,7 +917,12 @@ type Font(axes: Axes) =
             let segs = List.map toSegment segments
 
             [ for i in 0 .. lines - 1 do
-                  let offset = (float thickness) * (float i / float (lines - 1) - 0.5) * 2.0
+                  let offset =
+                      if lines <= 1 then
+                          0.0
+                      else
+                          (float thickness) * (float i / float (lines - 1) - 0.5) * 2.0
+
                   clearElemTangents (Curve(this.offsetSegments segs 0 (segs.Length - 1) false true offset, true)) ]
         | SpiroDot(p) ->
             [ dotToClosedCurve p.x p.y thickness

--- a/src/spline-research/bezpath.fs
+++ b/src/spline-research/bezpath.fs
@@ -23,6 +23,8 @@ open System.Text
 /// <param name="value"></param>
 /// <returns></returns>
 let Format (value: float) =
+    if Double.IsNaN value || Double.IsInfinity value then
+        failwithf "NaN/Infinity coordinate in SVG path: %g" value
     (round value).ToString("F0")
 // sprintf "%d" (int value)
 // (int value).ToString()


### PR DESCRIPTION
## Summary
This PR adds robust NaN/Infinity validation and fixes several division-by-zero edge cases that could cause invalid calculations or silent failures.

## Key Changes

- **DactylSpline.fs**: Added final validation pass to resolve remaining NaN values in `th_in`/`th_out` using neighbor angles, followed by a comprehensive check that throws a descriptive error if any BezierPoint coordinate remains NaN after solving
- **Font.fs**: 
  - Fixed division-by-zero in `monospace` function by checking if element width is zero before calculating scale
  - Fixed division-by-zero in stroke rendering when `lines <= 1` by avoiding the offset calculation that would divide by zero
- **bezpath.fs**: Added NaN/Infinity validation in the `Format` function to catch invalid coordinates before they're written to SVG paths

## Implementation Details

The DactylSpline validation uses a fallback strategy: if a point's tangent angles are NaN, it attempts to compute them from neighboring point coordinates. If neighbors are also invalid, it defaults to 0.0. This ensures all points have valid angles before the final validation pass, which now fails fast with a descriptive error message rather than silently propagating NaN values.

The Font.fs fixes prevent runtime errors by checking preconditions before division operations, allowing graceful handling of edge cases (zero-width elements, single-line strokes).

https://claude.ai/code/session_01KGPihUbMsuwfV5ENd8PT7D