### PR TITLE
Replace HTML5 drag with pointer events for row reordering

### DIFF
--- a/web/src/SplineEditor.css
+++ b/web/src/SplineEditor.css
@@ -268,6 +268,7 @@
   padding: 0 4px;
   text-align: center;
   user-select: none;
+  touch-action: none;
 }
 
 .se-drag-handle:hover {

--- a/web/src/SplineEditor.jsx
+++ b/web/src/SplineEditor.jsx
@@ -108,10 +108,15 @@ function SplineEditor({ axes }) {
   const workerRef = useRef(null)
   const solveIdRef = useRef(0)
   const dragRef = useRef(null) // { type: 'knot'|'th_in'|'th_out', curveIdx, idx }
+  const rowPointerRef = useRef({ dragging: false, fromIdx: null, toIdx: null })
 
   // Always-current snapshot of curves without triggering stale closures in callbacks
   const curvesRef = useRef(curves)
   useEffect(() => { curvesRef.current = curves }, [curves])
+
+  // Always-current solveResult for use in pointer callbacks (avoids stale closure)
+  const solveResultRef = useRef(solveResult)
+  useEffect(() => { solveResultRef.current = solveResult }, [solveResult])
 
   // Refs for guides and viewBox — accessed in pointer callbacks without stale closure risk
   const guidesRef = useRef(guides)
@@ -344,7 +349,7 @@ function SplineEditor({ axes }) {
       }
       updatePoint(curveIdx, idx, { x: Math.round(sx), y: Math.round(sy) })
     } else if (type === 'th_in' || type === 'th_out') {
-      const bp = solveResult?.bezierPoints?.[idx]
+      const bp = solveResultRef.current?.bezierPoints?.[idx]
       const px = pt.x ?? bp?.x ?? 0
       const py = pt.y ?? bp?.y ?? 0
       const angle = Math.atan2(y - py, x - px)
@@ -477,6 +482,43 @@ function SplineEditor({ axes }) {
     })
     setSelectedPt(toIdx)
   }, [activeCurve, pushUndo])
+
+  // Pointer-based row drag handlers (replaces HTML5 drag to avoid SVG pointer event interference)
+  const handleRowDragStart = useCallback((e, fromIdx) => {
+    e.stopPropagation()
+    e.preventDefault()
+    rowPointerRef.current = { dragging: true, fromIdx, toIdx: fromIdx }
+    setDragRowIdx(fromIdx)
+    e.currentTarget.setPointerCapture(e.pointerId)
+  }, [])
+
+  const handleRowDragMove = useCallback((e) => {
+    if (!rowPointerRef.current.dragging) return
+    const el = document.elementFromPoint(e.clientX, e.clientY)
+    const tr = el?.closest('[data-row-idx]')
+    if (tr) {
+      const idx = parseInt(tr.dataset.rowIdx)
+      if (!isNaN(idx) && idx !== rowPointerRef.current.toIdx) {
+        rowPointerRef.current.toIdx = idx
+        setDragOverRowIdx(idx)
+      }
+    }
+  }, [])
+
+  const handleRowDragEnd = useCallback(() => {
+    if (!rowPointerRef.current.dragging) return
+    const { fromIdx, toIdx } = rowPointerRef.current
+    rowPointerRef.current = { dragging: false, fromIdx: null, toIdx: null }
+    setDragRowIdx(null)
+    setDragOverRowIdx(null)
+    if (fromIdx !== null && toIdx !== null && fromIdx !== toIdx) movePoint(fromIdx, toIdx)
+  }, [movePoint])
+
+  const handleRowDragCancel = useCallback(() => {
+    rowPointerRef.current = { dragging: false, fromIdx: null, toIdx: null }
+    setDragRowIdx(null)
+    setDragOverRowIdx(null)
+  }, [])
 
   const toggleClosed = useCallback(() => {
     pushUndo()
@@ -702,6 +744,7 @@ function SplineEditor({ axes }) {
             viewBox={`${viewBox.x} ${viewBox.y} ${viewBox.w} ${viewBox.h}`}
             onPointerMove={handlePointerMove}
             onPointerUp={handlePointerUp}
+            onPointerCancel={handlePointerUp}
             onClick={handleSvgClick}
             onDoubleClick={handleDblClick}
           >
@@ -860,19 +903,15 @@ function SplineEditor({ axes }) {
               <tbody>
                 {points.map((p, i) => (
                   <tr key={i}
+                    data-row-idx={i}
                     className={[i === selectedPt ? 'selected' : '', i === dragOverRowIdx ? 'se-drag-over' : ''].filter(Boolean).join(' ')}
                     onClick={() => setSelectedPt(i)}
-                    onDragOver={e => { e.preventDefault(); setDragOverRowIdx(i) }}
-                    onDragLeave={() => setDragOverRowIdx(null)}
-                    onDrop={() => {
-                      if (dragRowIdx !== null) movePoint(dragRowIdx, i)
-                      setDragRowIdx(null); setDragOverRowIdx(null)
-                    }}
-                    onDragEnd={() => { setDragRowIdx(null); setDragOverRowIdx(null) }}
                   >
                     <td className="se-drag-handle"
-                      draggable
-                      onDragStart={e => { e.stopPropagation(); setDragRowIdx(i) }}
+                      onPointerDown={e => handleRowDragStart(e, i)}
+                      onPointerMove={handleRowDragMove}
+                      onPointerUp={handleRowDragEnd}
+                      onPointerCancel={handleRowDragCancel}
                       title="Drag to reorder"
                     >⠿</td>
                     <td className="se-idx">{i}</td>


### PR DESCRIPTION
## Summary
Replaced HTML5 drag-and-drop with pointer events for reordering points in the table. This avoids conflicts with SVG pointer event handling and provides more reliable drag interactions.

## Key Changes
- **Pointer-based drag handlers**: Implemented `handleRowDragStart`, `handleRowDragMove`, `handleRowDragEnd`, and `handleRowDragCancel` to manage row reordering using pointer events instead of HTML5 drag API
- **Pointer capture**: Added `setPointerCapture()` to ensure drag operations continue even when the pointer moves outside the element
- **State management**: Added `rowPointerRef` to track drag state (`dragging`, `fromIdx`, `toIdx`) without relying on stale closures
- **Stale closure fix**: Added `solveResultRef` to maintain current `solveResult` in pointer callbacks, fixing a bug where tangent handle dragging used stale data
- **SVG pointer cancel handling**: Added `onPointerCancel` handler to SVG element to properly clean up drag state
- **CSS update**: Added `touch-action: none` to drag handle to prevent browser default touch behaviors
- **Data attributes**: Added `data-row-idx` to table rows for easier element identification during drag operations

## Implementation Details
- Removed all HTML5 drag event handlers (`onDragStart`, `onDragOver`, `onDragLeave`, `onDrop`, `onDragEnd`) from table rows and drag handle
- Uses `document.elementFromPoint()` to detect which row is under the pointer during drag, avoiding reliance on drag events
- Pointer events are attached to the drag handle (`<td>`) rather than the entire row, providing better control over drag initiation

https://claude.ai/code/session_01WSkRzUzagyQNkhyu6mW2Fa