### PR TITLE
Add SessionStart hook to install .NET 8 and dependencies for Claude web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in Claude Code on the web
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Install .NET 8 SDK if not present
+if ! command -v dotnet &>/dev/null; then
+  echo "Installing .NET 8 SDK..."
+  apt-get update -q || true
+  apt-get install -y dotnet-sdk-8.0
+fi
+
+# Initialize git submodules (fmin is a submodule under web/src/lib/fmin)
+git submodule update --init --recursive
+
+# Restore .NET packages and tools
+dotnet restore
+dotnet tool restore
+
+# Install root npm dependencies (concurrently)
+npm install
+
+# Install web npm dependencies
+npm install --prefix web

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Installs dotnet-sdk-8.0 via apt, initializes git submodules, restores
.NET packages and Fable tool, and installs npm deps for both root and
web — enabling F#, Fable, and the full dev toolchain in remote sessions.

https://claude.ai/code/session_01DLqPWQN2gbDiqLSB5EsYiU