### PR TITLE
Generate labeled animated GIF diffs when updating visual snapshots

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -130,8 +130,35 @@ jobs:
             git push
           fi
 
+      - name: Generate failure diff GIFs
+        if: failure()
+        run: |
+          mkdir -p web/test-results/diffs
+          find web/test-results -name '*-actual.png' | while IFS= read -r actual; do
+            expected="${actual%-actual.png}-expected.png"
+            [ -f "$expected" ] || continue
+            name=$(basename "${actual%-actual.png}")
+            convert "$expected" \
+              -fill 'rgba(0,0,0,0.75)' -draw 'rectangle 0,0 150,36' \
+              -fill white -font DejaVu-Sans-Bold -pointsize 24 \
+              -gravity NorthWest -annotate +8+28 'BEFORE' \
+              /tmp/frame-before.png
+            convert "$actual" \
+              -fill 'rgba(0,0,0,0.75)' -draw 'rectangle 0,0 150,36' \
+              -fill white -font DejaVu-Sans-Bold -pointsize 24 \
+              -gravity NorthWest -annotate +8+28 'AFTER' \
+              /tmp/frame-after.png
+            convert -delay 100 /tmp/frame-before.png \
+                    -delay 100 /tmp/frame-after.png \
+                    -loop 0 "web/test-results/diffs/${name}.gif"
+            echo "Generated diff: ${name}.gif"
+          done
+          echo "Failure diffs:"
+          ls web/test-results/diffs/ 2>/dev/null || echo "(none)"
+
       - name: Upload screenshots on failure
         if: failure()
+        id: artifact-upload
         uses: actions/upload-artifact@v4
         with:
           name: playwright-screenshots
@@ -140,3 +167,7 @@ jobs:
             web/test-results/
             web/playwright-report/
           retention-days: 7
+
+      - name: Log artifact URL
+        if: failure()
+        run: echo "Diff GIFs and screenshots uploaded. Download at ${{ steps.artifact-upload.outputs.artifact-url }}"

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -52,11 +52,57 @@ jobs:
       - name: Install Playwright browsers
         run: cd web && npx playwright install --with-deps chromium
 
+      - name: Install ImageMagick
+        run: sudo apt-get install -y imagemagick fonts-dejavu-core
+
       - name: Build web app
         run: cd web && npm run build
 
+      - name: Save snapshots before update
+        if: inputs.update_snapshots
+        run: |
+          while IFS= read -r dir; do
+            for f in "$dir"/*.png; do
+              [ -f "$f" ] && cp "$f" "${f%.png}__before.png"
+            done
+          done < <(find web/tests -name '*-snapshots' -type d)
+
       - name: Run visual tests
         run: cd web && npm run test:visual${{ inputs.update_snapshots && ':update' || '' }}
+
+      - name: Generate diff GIFs
+        if: inputs.update_snapshots
+        run: |
+          mkdir -p web/tests/diffs
+          rm -f web/tests/diffs/*.gif
+          while IFS= read -r dir; do
+            for after in "$dir"/*.png; do
+              [ -f "$after" ] || continue
+              [[ "$after" == *__before.png ]] && continue
+              before="${after%.png}__before.png"
+              [ ! -f "$before" ] && continue
+              if ! cmp -s "$after" "$before"; then
+                name=$(basename "${after%.png}")
+                convert "$before" \
+                  -fill 'rgba(0,0,0,0.75)' -draw 'rectangle 0,0 150,36' \
+                  -fill white -font DejaVu-Sans-Bold -pointsize 24 \
+                  -gravity NorthWest -annotate +8+28 'BEFORE' \
+                  /tmp/frame-before.png
+                convert "$after" \
+                  -fill 'rgba(0,0,0,0.75)' -draw 'rectangle 0,0 150,36' \
+                  -fill white -font DejaVu-Sans-Bold -pointsize 24 \
+                  -gravity NorthWest -annotate +8+28 'AFTER' \
+                  /tmp/frame-after.png
+                convert -delay 100 /tmp/frame-before.png \
+                        -delay 100 /tmp/frame-after.png \
+                        -loop 0 "web/tests/diffs/${name}.gif"
+                echo "Generated diff: ${name}.gif"
+              fi
+            done
+          done < <(find web/tests -name '*-snapshots' -type d)
+          find web/tests -name '*__before.png' -delete
+          echo "Diffs generated:"
+          ls web/tests/diffs/ 2>/dev/null || echo "(none)"
 
       - name: Commit updated snapshots
         if: inputs.update_snapshots
@@ -67,7 +113,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "No snapshot changes to commit."
           else
-            git commit -m "Update visual regression snapshots"
+            git commit -m "Update visual regression snapshots + diff GIFs"
             git push
           fi
 


### PR DESCRIPTION
When the Visual Tests workflow runs with update_snapshots=true, it now:
- Saves copies of existing snapshots before the test run
- After updating, compares each before/after pair and generates an
  animated GIF (1s per frame, looping) for any that changed
- Labels each frame with "BEFORE" / "AFTER" in the top-left corner
- Commits the GIFs to web/tests/diffs/ alongside the updated snapshots

This makes it easy to review subtle visual changes on mobile by viewing
the GIFs directly in the GitHub web UI.

https://claude.ai/code/session_01H4Kz4Arho9yuHoe3DTgnb1