### PR TITLE
Refactor: eliminate duplication in Api.fs, DactylSpline.fs, Font.fs

### DIFF
--- a/src/explorer/Api.fs
+++ b/src/explorer/Api.fs
@@ -371,6 +371,13 @@ let spiroToSplinePointType (ty: SpiroPointType) =
     | SpiroPointType.Left -> Curves.SplinePointType.CurveToLine
     | _ -> Curves.SplinePointType.Corner
 
+let splineToSpiroPointType (ty: Curves.SplinePointType) =
+    match ty with
+    | Curves.SplinePointType.CurveToLine -> SpiroPointType.Left
+    | Curves.SplinePointType.LineToCurve -> SpiroPointType.Right
+    | Curves.SplinePointType.Smooth      -> SpiroPointType.G2
+    | _                                  -> SpiroPointType.Corner
+
 let computeCurvatureData (bezPts: DactylSpline.BezierPoint array) (isClosed: bool) =
     let steps = 20
     let count = if isClosed then bezPts.Length else bezPts.Length - 1
@@ -418,12 +425,6 @@ let solveSplineEditor (ctrlPts: DactylSpline.DControlPoint array) (isClosed: boo
 /// Return SVG path data for Spiro and Spline2 interpretations of the same control points.
 let solveAltSplines (ctrlPts: DactylSpline.DControlPoint array) (isClosed: bool) (inputAxes: Axes) =
     let baseAxes = { inputAxes with outline = false; filled = false; debug = false; show_comb = false; show_tangents = false }
-    let splineToSpiro (ty: Curves.SplinePointType) =
-        match ty with
-        | Curves.SplinePointType.CurveToLine -> SpiroPointType.Left
-        | Curves.SplinePointType.LineToCurve -> SpiroPointType.Right
-        | Curves.SplinePointType.Smooth      -> SpiroPointType.G2
-        | _                                  -> SpiroPointType.Corner
     let knots =
         ctrlPts
         |> Array.map (fun cp ->
@@ -431,7 +432,7 @@ let solveAltSplines (ctrlPts: DactylSpline.DControlPoint array) (isClosed: bool)
                      y = cp.y |> Option.defaultValue 0.0
                      x_fit = false
                      y_fit = false }
-              ty = splineToSpiro cp.ty
+              ty = splineToSpiroPointType cp.ty
               th_in = cp.th_in
               th_out = cp.th_out
               label = None })
@@ -451,12 +452,6 @@ let getSplineOutlinePath (ctrlPts: DactylSpline.DControlPoint array) (isClosed: 
     try
         let axes = { inputAxes with outline = true; filled = true; dactyl_spline = true }
         let font = Font axes
-        let splineToSpiro (ty: Curves.SplinePointType) =
-            match ty with
-            | Curves.SplinePointType.CurveToLine -> SpiroPointType.Left
-            | Curves.SplinePointType.LineToCurve -> SpiroPointType.Right
-            | Curves.SplinePointType.Smooth      -> SpiroPointType.G2
-            | _                                  -> SpiroPointType.Corner
         let knots =
             ctrlPts
             |> Array.map (fun cp ->
@@ -464,7 +459,7 @@ let getSplineOutlinePath (ctrlPts: DactylSpline.DControlPoint array) (isClosed: 
                          y = cp.y |> Option.defaultValue 0.0
                          x_fit = cp.x.IsNone
                          y_fit = cp.y.IsNone }
-                  ty = splineToSpiro cp.ty
+                  ty = splineToSpiroPointType cp.ty
                   th_in = cp.th_in
                   th_out = cp.th_out
                   label = None })

--- a/src/generator/DactylSpline.fs
+++ b/src/generator/DactylSpline.fs
@@ -308,6 +308,9 @@ type Solver(ctrlPts: DControlPoint array, isClosed: bool, flatness: float, debug
             let dpl = point.vec - _points.[max (i - 1) 0].vec //pointing from previous point to this
             let dpr = _points.[min (i + 1) (_points.Length - 1)].vec - point.vec
 
+            let lth = dpl.atan2 ()
+            let rth = dpr.atan2 ()
+
             match ctrlPt.th_in, ctrlPt.th_out with
             | Some th_i, Some th_o ->
                 point.th_in <- th_i
@@ -317,20 +320,12 @@ type Solver(ctrlPts: DControlPoint array, isClosed: bool, flatness: float, debug
             | Some th_i, None ->
                 point.th_in <- th_i
                 point.fit_th_in <- false
-                // Initialise th_out from geometry, leave fittable
-                let lth = dpl.atan2 ()
-                let rth = dpr.atan2 ()
                 point.th_out <- if i < ctrlPts.Length - 1 then rth else lth
             | None, Some th_o ->
                 point.th_out <- th_o
                 point.fit_th_out <- false
-                // Initialise th_in from geometry, leave fittable
-                let lth = dpl.atan2 ()
-                let rth = dpr.atan2 ()
                 point.th_in <- if i > 0 then lth else rth
             | None, None ->
-                let lth = dpl.atan2 ()
-                let rth = dpr.atan2 ()
 
                 let new_th =
                     if i = 0 then
@@ -579,19 +574,19 @@ type Solver(ctrlPts: DControlPoint array, isClosed: bool, flatness: float, debug
                         else
                             mapping.Add((i, j))
                             initial.Add(_points.[i].arr.[j])
+            let syncSmooth (index1: int) (index2: int) (value: float) =
+                if index2 = int BezierIndex.ThIn
+                   && ctrlPts.[index1].ty = SplinePointType.Smooth
+                   && _points.[index1].fit_th_out
+                then
+                    _points.[index1].th_out <- value
+
 #if FABLE_COMPILER
             let objectiveFunction (x: float[]) =
                 for i in 0 .. x.Length - 1 do
                     let (index1, index2) = mapping.[i]
                     _points.[index1].arr.[index2] <- x[i]
-
-                    // Synchronize th_out for smooth points
-                    if
-                        index2 = int BezierIndex.ThIn
-                        && ctrlPts.[index1].ty = SplinePointType.Smooth
-                        && _points.[index1].fit_th_out
-                    then
-                        _points.[index1].th_out <- x[i]
+                    syncSmooth index1 index2 x[i]
 
                 if isClosed then
                     _points.[_points.Length - 1].th_in <- _points.[0].th_in
@@ -605,13 +600,7 @@ type Solver(ctrlPts: DControlPoint array, isClosed: bool, flatness: float, debug
             for i in 0 .. best.Length - 1 do
                 let (index1, index2) = mapping.[i]
                 _points.[index1].arr.[index2] <- best[i]
-
-                if
-                    index2 = int BezierIndex.ThIn
-                    && ctrlPts.[index1].ty = SplinePointType.Smooth
-                    && _points.[index1].fit_th_out
-                then
-                    _points.[index1].th_out <- best[i]
+                syncSmooth index1 index2 best[i]
 #else
             let minimiser: Optimization.NelderMeadSimplex =
                 Optimization.NelderMeadSimplex(1e-5, maxIter)
@@ -622,14 +611,7 @@ type Solver(ctrlPts: DControlPoint array, isClosed: bool, flatness: float, debug
                 for i in 0 .. x.Count - 1 do
                     let (index1, index2) = mapping.[i]
                     _points.[index1].arr.[index2] <- x[i]
-
-                    // Synchronize th_out for smooth points
-                    if
-                        index2 = int BezierIndex.ThIn
-                        && ctrlPts.[index1].ty = SplinePointType.Smooth
-                        && _points.[index1].fit_th_out
-                    then
-                        _points.[index1].th_out <- x[i]
+                    syncSmooth index1 index2 x[i]
 
                 this.computeErr ()
 
@@ -649,13 +631,7 @@ type Solver(ctrlPts: DControlPoint array, isClosed: bool, flatness: float, debug
             for i in 0 .. resultVec.Count - 1 do
                 let (index1, index2) = mapping.[i]
                 _points.[index1].arr.[index2] <- resultVec.[i]
-
-                if
-                    index2 = int BezierIndex.ThIn
-                    && ctrlPts.[index1].ty = SplinePointType.Smooth
-                    && _points.[index1].fit_th_out
-                then
-                    _points.[index1].th_out <- resultVec.[i]
+                syncSmooth index1 index2 resultVec.[i]
 #endif
 
 // DactylSpline handles general sequence of lines & curves, including corners.

--- a/src/generator/Font.fs
+++ b/src/generator/Font.fs
@@ -656,15 +656,11 @@ type Font(axes: Axes) =
 
     member this.offsetSegment (seg: Segment) (lastSeg: Segment) reverse dist =
         let newType =
-            if reverse then
-                match seg.Type with
-                | SpiroPointType.Left -> SpiroPointType.Right
-                | SpiroPointType.Right -> SpiroPointType.Left
-                | _ -> seg.Type
-            else
-                match seg.Type with
-                | SpiroPointType.EndOpenContour -> Corner
-                | _ -> seg.Type
+            match seg.Type, reverse with
+            | SpiroPointType.Left, true -> SpiroPointType.Right
+            | SpiroPointType.Right, true -> SpiroPointType.Left
+            | SpiroPointType.EndOpenContour, false -> Corner
+            | _ -> seg.Type
 
         let angle = if reverse then -PI / 2. else PI / 2.
 
@@ -872,24 +868,9 @@ type Font(axes: Axes) =
 
     member this.getSpiroSansOutlines e =
         let fthickness = float thickness
-
-        let startCap (seg: Segment) =
-            let ty =
-                if seg.Type = SpiroPointType.Anchor then
-                    SpiroPointType.Anchor
-                else
-                    Corner
-
-            this.startCap seg e ty
-
-        let endCap (seg: Segment) (lastSeg: Segment) =
-            let ty =
-                if seg.Type = SpiroPointType.Anchor then
-                    SpiroPointType.Anchor
-                else
-                    Corner
-
-            this.endCap seg lastSeg e ty
+        let capType (seg: Segment) = if seg.Type = SpiroPointType.Anchor then SpiroPointType.Anchor else Corner
+        let startCap (seg: Segment) = this.startCap seg e (capType seg)
+        let endCap (seg: Segment) (lastSeg: Segment) = this.endCap seg lastSeg e (capType seg)
 
         let spiroToOutline spiro =
             match spiro with


### PR DESCRIPTION
- Api.fs: extract duplicate local splineToSpiro match into module-level
  splineToSpiroPointType (mirrors existing spiroToSplinePointType)
- Font.fs: collapse offsetSegment's nested if/match into single tuple match;
  collapse getSpiroSansOutlines startCap/endCap into one-liners via capType helper
- DactylSpline.fs: hoist lth/rth atan2 calls before the th_in/th_out match to
  eliminate three copies; extract syncSmooth helper to replace four identical
  "synchronize th_out for smooth points" blocks in both Fable and .NET solve paths

https://claude.ai/code/session_01NWgCRJeXLEfYCebVujWxut