### PR TITLE
fix: stack Splines tab vertically on mobile so canvas is visible

### DIFF
--- a/web/src/SplineEditor.css
+++ b/web/src/SplineEditor.css
@@ -402,3 +402,24 @@
   flex-shrink: 0;
   display: block;
 }
+
+/* Mobile: stack canvas above table so the spline is always visible */
+@media (max-width: 700px) {
+  .se-main {
+    flex-direction: column;
+  }
+
+  .se-canvas-area {
+    flex: 1 1 0;
+    min-height: 0;
+  }
+
+  .se-table-panel {
+    width: 100%;
+    min-width: 0;
+    border-left: none;
+    border-top: 1px solid rgba(255,255,255,0.08);
+    flex: 0 0 auto;
+    max-height: 40vh;
+  }
+}


### PR DESCRIPTION
On narrow screens the table panel (min-width 340px) was dominating the
layout and hiding the SVG canvas. A 700px media query switches .se-main
to flex-direction:column, gives the canvas area all remaining height,
and caps the table panel at 40vh so it stays scrollable below the spline.

https://claude.ai/code/session_01GswT1xQCCerkMJqt9hKUca