### PR TITLE
fix: prevent page scroll when dragging spline knots on mobile

### DIFF
--- a/web/src/SplineEditor.css
+++ b/web/src/SplineEditor.css
@@ -101,6 +101,7 @@
   min-height: 0;
   background: var(--bg-color, #0f0f1a);
   cursor: crosshair;
+  touch-action: none;
 }
 
 .se-table-panel {


### PR DESCRIPTION
Add touch-action: none to .se-canvas so the browser does not claim
touch gestures for scrolling before pointer events reach the SVG drag
handlers.

https://claude.ai/code/session_01JUpgcgaxTUUfwUkWB4GU2x