### PR TITLE
feat: improve spline curvature graph — responsive width, per-segment jumps, fitted lines

### DIFF
--- a/src/explorer/Api.fs
+++ b/src/explorer/Api.fs
@@ -381,8 +381,7 @@ let splineToSpiroPointType (ty: Curves.SplinePointType) =
 let computeCurvatureData (bezPts: DactylSpline.BezierPoint array) (isClosed: bool) =
     let steps = 20
     let count = if isClosed then bezPts.Length else bezPts.Length - 1
-    let samples = ResizeArray()
-    let knotArcs = ResizeArray()
+    let segments = ResizeArray()
     let mutable arcLen = 0.0
     for i in 0 .. count - 1 do
         let p1 = bezPts.[i]
@@ -393,21 +392,36 @@ let computeCurvatureData (bezPts: DactylSpline.BezierPoint array) (isClosed: boo
         let cp2y = p2.y - p2.ld * sin p2.th_in
         let p0x, p0y = p1.x, p1.y
         let p3x, p3y = p2.x, p2.y
-        if i = 0 then knotArcs.Add(arcLen)
+        // Sample curvature at t=0, 1/steps, ..., 1 (steps+1 points)
+        let localArcs = Array.zeroCreate (steps + 1)
+        let curvatures = Array.zeroCreate (steps + 1)
+        for s in 0 .. steps do
+            let t = float s / float steps
+            let mt = 1.0 - t
+            let dx1 = 3.0 * (mt*mt*(cp1x-p0x) + 2.0*mt*t*(cp2x-cp1x) + t*t*(p3x-cp2x))
+            let dy1 = 3.0 * (mt*mt*(cp1y-p0y) + 2.0*mt*t*(cp2y-cp1y) + t*t*(p3y-cp2y))
+            let dx2 = 6.0 * ((1.0-t)*(cp2x-2.0*cp1x+p0x) + t*(p3x-2.0*cp2x+cp1x))
+            let dy2 = 6.0 * ((1.0-t)*(cp2y-2.0*cp1y+p0y) + t*(p3y-2.0*cp2y+cp1y))
+            let speed = sqrt(dx1*dx1 + dy1*dy1)
+            let denom = speed * speed * speed
+            curvatures.[s] <- if denom < 1e-10 then 0.0 else (dx1*dy2 - dy1*dx2) / denom
+        // Build local arc lengths using midpoint speed between consecutive t values
+        localArcs.[0] <- 0.0
         for s in 0 .. steps - 1 do
             let tmid = (float s + 0.5) / float steps
             let mt = 1.0 - tmid
-            let dx1 = 3.0 * (mt*mt*(cp1x-p0x) + 2.0*mt*tmid*(cp2x-cp1x) + tmid*tmid*(p3x-cp2x))
-            let dy1 = 3.0 * (mt*mt*(cp1y-p0y) + 2.0*mt*tmid*(cp2y-cp1y) + tmid*tmid*(p3y-cp2y))
-            let dx2 = 6.0 * ((1.0-tmid)*(cp2x-2.0*cp1x+p0x) + tmid*(p3x-2.0*cp2x+cp1x))
-            let dy2 = 6.0 * ((1.0-tmid)*(cp2y-2.0*cp1y+p0y) + tmid*(p3y-2.0*cp2y+cp1y))
-            let speed = sqrt(dx1*dx1 + dy1*dy1)
-            let denom = speed * speed * speed
-            let kappa = if denom < 1e-10 then 0.0 else (dx1*dy2 - dy1*dx2) / denom
-            samples.Add({| arcLen = arcLen; curvature = kappa |})
-            arcLen <- arcLen + speed / float steps
-        knotArcs.Add(arcLen)
-    {| samples = samples.ToArray(); knotArcs = knotArcs.ToArray() |}
+            let dxm = 3.0 * (mt*mt*(cp1x-p0x) + 2.0*mt*tmid*(cp2x-cp1x) + tmid*tmid*(p3x-cp2x))
+            let dym = 3.0 * (mt*mt*(cp1y-p0y) + 2.0*mt*tmid*(cp2y-cp1y) + tmid*tmid*(p3y-cp2y))
+            localArcs.[s+1] <- localArcs.[s] + sqrt(dxm*dxm + dym*dym) / float steps
+        let segArcLen = localArcs.[steps]
+        let segSamples =
+            Array.init (steps + 1) (fun s ->
+                {| arcLen = arcLen + localArcs.[s]; curvature = curvatures.[s] |})
+        // Linear regression: k(localArc) = m * localArc + c
+        let m, c, _ = DactylSpline.linear_regression localArcs curvatures (steps + 1)
+        segments.Add({| samples = segSamples; m = m; c = c |})
+        arcLen <- arcLen + segArcLen
+    {| segments = segments.ToArray() |}
 
 let solveSplineEditor (ctrlPts: DactylSpline.DControlPoint array) (isClosed: bool) (maxIter: int) =
     let spline = DactylSpline.DactylSpline(ctrlPts, isClosed)

--- a/src/explorer/Api.fs
+++ b/src/explorer/Api.fs
@@ -378,50 +378,7 @@ let splineToSpiroPointType (ty: Curves.SplinePointType) =
     | Curves.SplinePointType.Smooth      -> SpiroPointType.G2
     | _                                  -> SpiroPointType.Corner
 
-let computeCurvatureData (bezPts: DactylSpline.BezierPoint array) (isClosed: bool) =
-    let steps = 20
-    let count = if isClosed then bezPts.Length else bezPts.Length - 1
-    let segments = ResizeArray()
-    let mutable arcLen = 0.0
-    for i in 0 .. count - 1 do
-        let p1 = bezPts.[i]
-        let p2 = bezPts.[(i + 1) % bezPts.Length]
-        let cp1x = p1.x + p1.rd * cos p1.th_out
-        let cp1y = p1.y + p1.rd * sin p1.th_out
-        let cp2x = p2.x - p2.ld * cos p2.th_in
-        let cp2y = p2.y - p2.ld * sin p2.th_in
-        let p0x, p0y = p1.x, p1.y
-        let p3x, p3y = p2.x, p2.y
-        // Sample curvature at t=0, 1/steps, ..., 1 (steps+1 points)
-        let localArcs = Array.zeroCreate (steps + 1)
-        let curvatures = Array.zeroCreate (steps + 1)
-        for s in 0 .. steps do
-            let t = float s / float steps
-            let mt = 1.0 - t
-            let dx1 = 3.0 * (mt*mt*(cp1x-p0x) + 2.0*mt*t*(cp2x-cp1x) + t*t*(p3x-cp2x))
-            let dy1 = 3.0 * (mt*mt*(cp1y-p0y) + 2.0*mt*t*(cp2y-cp1y) + t*t*(p3y-cp2y))
-            let dx2 = 6.0 * ((1.0-t)*(cp2x-2.0*cp1x+p0x) + t*(p3x-2.0*cp2x+cp1x))
-            let dy2 = 6.0 * ((1.0-t)*(cp2y-2.0*cp1y+p0y) + t*(p3y-2.0*cp2y+cp1y))
-            let speed = sqrt(dx1*dx1 + dy1*dy1)
-            let denom = speed * speed * speed
-            curvatures.[s] <- if denom < 1e-10 then 0.0 else (dx1*dy2 - dy1*dx2) / denom
-        // Build local arc lengths using midpoint speed between consecutive t values
-        localArcs.[0] <- 0.0
-        for s in 0 .. steps - 1 do
-            let tmid = (float s + 0.5) / float steps
-            let mt = 1.0 - tmid
-            let dxm = 3.0 * (mt*mt*(cp1x-p0x) + 2.0*mt*tmid*(cp2x-cp1x) + tmid*tmid*(p3x-cp2x))
-            let dym = 3.0 * (mt*mt*(cp1y-p0y) + 2.0*mt*tmid*(cp2y-cp1y) + tmid*tmid*(p3y-cp2y))
-            localArcs.[s+1] <- localArcs.[s] + sqrt(dxm*dxm + dym*dym) / float steps
-        let segArcLen = localArcs.[steps]
-        let segSamples =
-            Array.init (steps + 1) (fun s ->
-                {| arcLen = arcLen + localArcs.[s]; curvature = curvatures.[s] |})
-        // Linear regression: k(localArc) = m * localArc + c
-        let m, c, _ = DactylSpline.linear_regression localArcs curvatures (steps + 1)
-        segments.Add({| samples = segSamples; m = m; c = c |})
-        arcLen <- arcLen + segArcLen
-    {| segments = segments.ToArray() |}
+let computeCurvatureData = DactylSpline.computeCurvatureData
 
 let solveSplineEditor (ctrlPts: DactylSpline.DControlPoint array) (isClosed: bool) (maxIter: int) =
     let spline = DactylSpline.DactylSpline(ctrlPts, isClosed)

--- a/src/generator/DactylSpline.fs
+++ b/src/generator/DactylSpline.fs
@@ -244,6 +244,36 @@ let getBezPt (p0x, p0y) (p1x, p1y) (p2x, p2y) (p3x, p3y) t =
     { x = c0 * p0x + c1 * p1x + c2 * p2x + c3 * p3x
       y = c0 * p0y + c1 * p1y + c2 * p2y + c3 * p3y }
 
+let computeCurvatureData (bezPts: BezierPoint array) (isClosed: bool) =
+    let steps = 20
+    let count = if isClosed then bezPts.Length else bezPts.Length - 1
+    let segments = ResizeArray()
+    let mutable arcLen = 0.0
+    for i in 0 .. count - 1 do
+        let p1 = bezPts.[i]
+        let p2 = bezPts.[(i + 1) % bezPts.Length]
+        let cp1 = (p1.x + p1.rd * cos p1.th_out, p1.y + p1.rd * sin p1.th_out)
+        let cp2 = (p2.x - p2.ld * cos p2.th_in,  p2.y - p2.ld * sin p2.th_in)
+        let p0 = (p1.x, p1.y)
+        let p3 = (p2.x, p2.y)
+        let localArcs = Array.zeroCreate (steps + 1)
+        let curvatures = Array.init (steps + 1) (fun s ->
+            getCurvature p0 cp1 cp2 p3 (float s / float steps))
+        for s in 0 .. steps - 1 do
+            let pa = getBezPt p0 cp1 cp2 p3 (float s / float steps)
+            let pb = getBezPt p0 cp1 cp2 p3 (float (s + 1) / float steps)
+            let dx = pb.x - pa.x
+            let dy = pb.y - pa.y
+            localArcs.[s + 1] <- localArcs.[s] + sqrt (dx * dx + dy * dy)
+        let segArcLen = localArcs.[steps]
+        let segSamples =
+            Array.init (steps + 1) (fun s ->
+                {| arcLen = arcLen + localArcs.[s]; curvature = curvatures.[s] |})
+        let m, c, _ = linear_regression localArcs curvatures (steps + 1)
+        segments.Add({| samples = segSamples; m = m; c = c |})
+        arcLen <- arcLen + segArcLen
+    {| segments = segments.ToArray() |}
+
 type Solver(ctrlPts: DControlPoint array, isClosed: bool, flatness: float, debug: bool) =
     let _points: BezierPoint array = Array.init ctrlPts.Length (fun _ -> BezierPoint())
     let STEPS = 8

--- a/web/src/SplineEditor.jsx
+++ b/web/src/SplineEditor.jsx
@@ -53,34 +53,53 @@ const snapToGuide = (value, guideArray, thresholdUnits) => {
 
 // Evaluate a cubic bezier at t: returns {x, y}
 // SVG curvature graph component — data comes pre-computed from F# via solveResult.curvatureData
-function CurvatureGraph({ curvatureData, width = 400, height = 100 }) {
-  const { samples, knotArcs } = curvatureData || { samples: [], knotArcs: [] }
+function CurvatureGraph({ curvatureData }) {
+  const { segments } = curvatureData || { segments: [] }
 
-  if (!samples.length) return null
+  if (!segments || !segments.length) return null
 
-  const totalArc = samples[samples.length - 1]?.arcLen || 1
-  const maxAbs = Math.max(1e-6, ...samples.map(s => Math.abs(s.curvature)))
+  const allSamples = segments.flatMap(seg => seg.samples)
+  if (!allSamples.length) return null
 
+  const totalArc = allSamples[allSamples.length - 1]?.arcLen || 1
+  const maxAbs = Math.max(1e-6, ...allSamples.map(s => Math.abs(s.curvature)))
+
+  // Fixed viewBox coordinate space; SVG scales to fill container via CSS width:100%
+  const W = 800
+  const H = 100
   const pad = { t: 6, b: 6, l: 4, r: 4 }
-  const gw = width - pad.l - pad.r
-  const gh = height - pad.t - pad.b
+  const gw = W - pad.l - pad.r
+  const gh = H - pad.t - pad.b
   const midY = pad.t + gh / 2
 
   const toX = (arc) => pad.l + (arc / totalArc) * gw
   const toY = (k) => midY - (k / maxAbs) * (gh / 2)
 
-  const pts = samples.map(s => `${toX(s.arcLen).toFixed(1)},${toY(s.curvature).toFixed(1)}`).join(' ')
-
   return (
-    <svg className="se-curvature-graph" width={width} height={height}>
+    <svg className="se-curvature-graph" viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none">
       {/* Zero baseline */}
       <line x1={pad.l} y1={midY} x2={pad.l + gw} y2={midY} stroke="#444" strokeWidth="1" />
-      {/* Curvature polyline */}
-      <polyline points={pts} fill="none" stroke="#4af" strokeWidth="1.5" />
-      {/* Knot markers */}
-      {knotArcs.map((arc, i) => {
-        const x = toX(arc)
-        return <line key={i} x1={x} y1={pad.t} x2={x} y2={pad.t + gh} stroke="#f84" strokeWidth="1" strokeDasharray="2,2" />
+      {segments.map((seg, i) => {
+        const arcStart = seg.samples[0].arcLen
+        const arcEnd = seg.samples[seg.samples.length - 1].arcLen
+        const segLen = arcEnd - arcStart
+        const pts = seg.samples.map(s => `${toX(s.arcLen).toFixed(1)},${toY(s.curvature).toFixed(1)}`).join(' ')
+        return (
+          <g key={i}>
+            {/* Fitted line: k(s) = m*s + c over local arc length */}
+            <line
+              x1={toX(arcStart).toFixed(1)} y1={toY(seg.c).toFixed(1)}
+              x2={toX(arcEnd).toFixed(1)} y2={toY(seg.m * segLen + seg.c).toFixed(1)}
+              stroke="#888" strokeWidth="1.5" strokeDasharray="4,3"
+            />
+            {/* Actual curvature polyline for this segment */}
+            <polyline points={pts} fill="none" stroke="#4af" strokeWidth="1.5" />
+            {/* Knot marker at segment start (skip first) */}
+            {i > 0 && (
+              <line x1={toX(arcStart).toFixed(1)} y1={pad.t} x2={toX(arcStart).toFixed(1)} y2={pad.t + gh} stroke="#f84" strokeWidth="1" strokeDasharray="2,2" />
+            )}
+          </g>
+        )
       })}
     </svg>
   )


### PR DESCRIPTION
- Fix mobile cutoff: SVG now uses viewBox + preserveAspectRatio=none so it scales
  to 100% of its container width instead of clipping at a fixed 400px
- Plot t=0 and t=1 curvature for each segment separately so discontinuities at knots
  appear as vertical jumps in the graph (polylines are drawn per-segment, not joined)
- Overlay a grey dotted line per segment showing the linear fit k(s)=m·s+c computed
  via least-squares regression over the segment's arc length; exposes the Euler-spiral
  quality of each segment at a glance
- Backend (Api.fs): computeCurvatureData now samples at t=0…1 inclusive, accumulates
  local arc lengths, runs linear_regression per segment, and returns segments[] instead
  of the flat samples[]+knotArcs[] structure

https://claude.ai/code/session_017M1bu6qnsirVaTe7vuXJKc