### PR TITLE
fix: wrap spline toolbar checkboxes and prevent horizontal overflow on mobile

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -774,4 +774,5 @@
     padding: 0;
     display: flex;
     flex-direction: column;
+    overflow: hidden;
 }

--- a/web/src/SplineEditor.css
+++ b/web/src/SplineEditor.css
@@ -16,11 +16,17 @@
 }
 
 .se-glyph-picker,
-.se-curve-picker,
+.se-curve-picker {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .se-options {
   display: flex;
   align-items: center;
   gap: 6px;
+  flex-wrap: wrap;
 }
 
 .se-glyph-picker label,


### PR DESCRIPTION
On narrow screens the checkbox options row overflowed horizontally, causing
a white scrollable gap beside the dark spline editor. Two fixes:
- Add flex-wrap:wrap to .se-options so Comb/Outline/Curvature/Spiro/Spline2
  wrap to a second line instead of extending past the viewport.
- Add overflow:hidden to .preview-content.spline-mode so the white preview
  background cannot scroll into view; the curvature graph SVG already uses
  width:100% + preserveAspectRatio:none so it scales to fit without clipping.

https://claude.ai/code/session_01VRj5W12WRHvyhGQie7xcdU