### PR TITLE
Move show_comb from Axes to Font constructor parameter

### DIFF
--- a/src/explorer/Api.fs
+++ b/src/explorer/Api.fs
@@ -47,7 +47,7 @@ NOPQRST UVWXYZ
 <=>?@ [\\]^_`{|}~"
 
 let generateSvg (text: string) (axes: Axes) (autoscale: bool) (progress: (float -> unit) option) =
-    let font = Font axes
+    let font = Font(axes, true)
 
     let lines =
         if System.String.IsNullOrEmpty(text) then

--- a/src/explorer/Api.fs
+++ b/src/explorer/Api.fs
@@ -47,7 +47,7 @@ NOPQRST UVWXYZ
 <=>?@ [\\]^_`{|}~"
 
 let generateSvg (text: string) (axes: Axes) (autoscale: bool) (progress: (float -> unit) option) =
-    let font = Font(axes, true)
+    let font = Font axes
 
     let lines =
         if System.String.IsNullOrEmpty(text) then

--- a/src/explorer/Api.fs
+++ b/src/explorer/Api.fs
@@ -124,34 +124,38 @@ let generateSplineDebugSvgFromDefs (defsText: string) (inputAxes: Axes) (progres
     let axes =
         { inputAxes with
             clip_rect = false
-            show_comb = true
             show_tangents = true }
 
     // Create fonts with specific settings
     let fontSpiro =
-        Font
+        Font(
             { axes with
                 spline2 = false
-                dactyl_spline = false }
+                dactyl_spline = false },
+            true
+        )
 
     let fontSpline2 =
-        Font
+        Font(
             { axes with
                 spline2 = true
-                dactyl_spline = false }
+                dactyl_spline = false },
+            true
+        )
 
     let fontDactylSpline =
-        Font
+        Font(
             { axes with
                 spline2 = false
-                dactyl_spline = true }
+                dactyl_spline = true },
+            true
+        )
 
     let fontGuides =
         Font
             { axes with
                 spline2 = false
                 show_knots = false
-                show_comb = false
                 show_tangents = false
                 debug = false }
 
@@ -407,7 +411,7 @@ let solveSplineEditor (ctrlPts: DactylSpline.DControlPoint array) (isClosed: boo
 
 /// Return SVG path data for Spiro and Spline2 interpretations of the same control points.
 let solveAltSplines (ctrlPts: DactylSpline.DControlPoint array) (isClosed: bool) (inputAxes: Axes) =
-    let baseAxes = { inputAxes with outline = false; filled = false; debug = false; show_comb = false; show_tangents = false }
+    let baseAxes = { inputAxes with outline = false; filled = false; debug = false; show_tangents = false }
     let knots =
         ctrlPts
         |> Array.map (fun cp ->

--- a/src/explorer/Api.fs
+++ b/src/explorer/Api.fs
@@ -303,9 +303,9 @@ let generateSplineDebugSvgFromDefs (defsText: string) (inputAxes: Axes) (progres
                 safeElementToSvgPath fontDactylSpline outlineDactylSpline orange
 
             // Spine fonts: never fill the thin centerline paths
-            let fontSpiroSpine = Font { fontSpiro.axes with filled=false }
-            let fontSpline2Spine = Font { fontSpline2.axes with filled=false }
-            let fontDactylSplineSpine = Font { fontDactylSpline.axes with filled=false }
+            let fontSpiroSpine = Font({ fontSpiro.axes with filled=false }, true)
+            let fontSpline2Spine = Font({ fontSpline2.axes with filled=false }, true)
+            let fontDactylSplineSpine = Font({ fontDactylSpline.axes with filled=false }, true)
 
             let guidesLayer = wrapClass "guides-layer" guidesSvg
 

--- a/src/generator/Axes.fs
+++ b/src/generator/Axes.fs
@@ -35,7 +35,6 @@ type Axes =
       max_spline_iter: int //max number of iterations to solve spline curves
       show_knots: bool //show small circles for the points used to define lines/curves
       show_tangents: bool //show lines for the tangents at each knot
-      show_comb: bool //show curvature comb
       joints: bool //check joints to turn off serifs
       smooth: bool //no corners
       clip_rect: bool //clip each glyph to it's bounding rect (helps with degenerate curves)
@@ -67,7 +66,6 @@ type Axes =
           max_spline_iter = 100
           show_knots = false
           show_tangents = false
-          show_comb = false
           joints = true
           constraints = false
           smooth = false
@@ -101,7 +99,6 @@ type Axes =
           "max_spline_iter", Range(0, 200), "experimental"
           "show_knots", Checkbox, "debug"
           "show_tangents", Checkbox, "debug"
-          "show_comb", Checkbox, "debug"
           "joints", Checkbox, "debug"
           "smooth", Checkbox, "default"
           "clip_rect", Checkbox, "debug"

--- a/src/generator/Font.fs
+++ b/src/generator/Font.fs
@@ -74,9 +74,10 @@ let dotToClosedCurve x y r =
 
 
 //class
-type Font(axes: Axes) =
+type Font(axes: Axes, ?showCombOpt: bool) =
     //basic manipulation using class variables
 
+    let showComb = defaultArg showCombOpt false
     let _metrics = FontMetrics(axes)
     let thickness = _metrics.thickness
 
@@ -350,7 +351,7 @@ type Font(axes: Axes) =
                 axes.max_spline_iter,
                 axes.flatness,
                 debug = axes.debug,
-                showComb = axes.show_comb,
+                showComb = showComb,
                 showTangents = axes.show_tangents
             )
 
@@ -1224,11 +1225,11 @@ type Font(axes: Axes) =
     member this.spiroToSvgWithComb spiro =
         match spiro with
         | SpiroOpenCurve(segs) ->
-            let bc = SpiroCombContext(axes.show_comb, segs.Length * 20)
+            let bc = SpiroCombContext(showComb, segs.Length * 20)
             Spiro.SpirosToBezier (Array.ofList segs) false bc |> ignore
             ([ bc.GetPathData ], bc.GetCombSvg)
         | SpiroClosedCurve(segs) ->
-            let bc = SpiroCombContext(axes.show_comb, segs.Length * 20)
+            let bc = SpiroCombContext(showComb, segs.Length * 20)
             Spiro.SpirosToBezier (Array.ofList segs) true bc |> ignore
             ([ bc.GetPathData ], bc.GetCombSvg)
         | SpiroDot(p) -> (svgCircle p.x p.y thickness, [])

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -44,7 +44,7 @@ function App() {
     dspline: true,
     guides: true,
     knots: true,
-    comb: false,
+    comb: true,
     tangents: true,
     labels: true,
   })

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -44,7 +44,7 @@ function App() {
     dspline: true,
     guides: true,
     knots: true,
-    comb: true,
+    comb: false,
     tangents: true,
     labels: true,
   })


### PR DESCRIPTION
## Summary
Refactors the `show_comb` debug flag from a global axis property to a per-Font instance parameter, allowing different Font instances to have independent comb visualization settings.

## Key Changes
- **Axes.fs**: Removed `show_comb` field from the `Axes` record type and its default/metadata definitions
- **Font.fs**: 
  - Modified `Font` constructor to accept an optional `showCombOpt` parameter (defaults to `false`)
  - Updated internal `showComb` binding to use the constructor parameter instead of `axes.show_comb`
  - Updated `spiroToSvgWithComb` method to reference the instance-level `showComb` instead of `axes.show_comb`
- **Api.fs**: 
  - Updated all three Font instantiations (`fontSpiro`, `fontSpline2`, `fontDactylSpline`) to pass `true` as the second constructor argument
  - Removed `show_comb = true` from the axes record override in `generateSplineDebugSvgFromDefs`
  - Removed `show_comb = false` from the `fontGuides` axes record
  - Removed `show_comb = false` from `solveAltSplines` baseAxes

## Implementation Details
This change decouples the comb visualization setting from the global axis configuration, enabling more flexible control over which Font instances display the curvature comb. The debug SVG generation now explicitly enables comb display for the three main spline variants while keeping it disabled for guide fonts.

https://claude.ai/code/session_01UhY9vEtRUTsMq1DR8HDWLH