### PR TITLE
docs: forbid local visual snapshot regeneration in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,11 @@ npm run test:tabs:update     # regenerate snapshots
 intentional visual changes, trigger the `Visual Tests` CI workflow manually
 with `update_snapshots: true` to regenerate and auto-commit them.
 
+**IMPORTANT: Never regenerate or rebase visual test snapshots locally** (i.e.
+do not run `npm run test:tabs:update` or commit snapshot files yourself).
+Always use the `Visual Tests` GitHub Actions workflow with `update_snapshots:
+true` — it runs in a consistent environment and auto-commits the results.
+
 ### CI workflows
 
 | CI workflow | Trigger | What it does |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,10 +53,10 @@ npm run test:tabs:update     # regenerate snapshots
 intentional visual changes, trigger the `Visual Tests` CI workflow manually
 with `update_snapshots: true` to regenerate and auto-commit them.
 
-**IMPORTANT: Never regenerate or rebase visual test snapshots locally** (i.e.
-do not run `npm run test:tabs:update` or commit snapshot files yourself).
-Always use the `Visual Tests` GitHub Actions workflow with `update_snapshots:
-true` — it runs in a consistent environment and auto-commits the results.
+**IMPORTANT: Never regenerate or rebase visual test snapshots** — do not run
+`npm run test:tabs:update`, commit snapshot files yourself, or trigger the
+`Visual Tests` workflow with `update_snapshots: true`.  The user reviews visual
+diffs and runs the rebase action manually.
 
 ### CI workflows
 


### PR DESCRIPTION
Always use the Visual Tests CI workflow (update_snapshots: true) to
rebase snapshots, never run test:tabs:update locally.

https://claude.ai/code/session_017YEUbfy9SBwPWbRYQ9YMe2