### PR TITLE
Prevent worker result reset when switching tabs

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -243,6 +243,7 @@ function App() {
   const loadingRef = useRef(false)
   const previewRef = useRef(null)
   const activeTabRef = useRef(activeTab)
+  const prevEffectTabRef = useRef(null)
   useEffect(() => { activeTabRef.current = activeTab }, [activeTab])
 
   const handleWheelZoom = useCallback((e) => {
@@ -297,7 +298,10 @@ function App() {
     }
 
     const id = ++renderIdRef.current
-    setWorkerResult(null)
+    if (activeTab !== prevEffectTabRef.current) {
+      setWorkerResult(null)
+      prevEffectTabRef.current = activeTab
+    }
     setLoading(true)
     loadingRef.current = true
     setProgressValue(0)


### PR DESCRIPTION
## Summary
Fixes an issue where the worker result was being cleared every time the render effect ran, even when the active tab hadn't changed. This caused unnecessary re-renders and loss of cached results.

## Changes
- Added `prevEffectTabRef` to track the previously rendered active tab
- Modified the worker result reset logic to only clear results when the active tab actually changes
- This prevents redundant `setWorkerResult(null)` calls on every render cycle

## Implementation Details
The fix uses a ref to compare the current `activeTab` with the previous value. The worker result is now only reset when transitioning between tabs, rather than on every render. This preserves the cached result while the user is viewing the same tab, improving performance and preventing unnecessary re-computation.

https://claude.ai/code/session_01KEbz9Q4iEzm4uSiq3qWDx9