### PR TITLE
Embed axis overrides in font filename and style name

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -312,7 +312,7 @@ function App() {
       if (error) {
         console.error('Font generation error:', error)
       } else {
-        downloadFont(result)
+        downloadFont(result, axes, defaultAxes)
       }
     }
     worker.postMessage({ id: 1, type: 'fontData', args: [axes] })

--- a/web/src/fontExport.js
+++ b/web/src/fontExport.js
@@ -222,12 +222,35 @@ export function parseSvgPath(pathData) {
   return commands
 }
 
+/** Find axes whose values differ from the defaults. */
+function getOverriddenAxes(axes, defaultAxes) {
+  return Object.entries(axes).filter(([key, val]) => val !== defaultAxes[key])
+}
+
+/** Format one axis override as a compact string for filenames and style names. */
+function formatAxisOverride(key, val) {
+  if (typeof val === 'boolean') return val ? key : `no_${key}`
+  const n = typeof val === 'number' ? val : Number(val)
+  const s = Number.isInteger(n) ? String(n) : n.toFixed(2).replace(/0+$/, '').replace(/\.$/, '')
+  return `${key}${s}`
+}
+
+function buildStyleName(overrides) {
+  if (!overrides.length) return 'Regular'
+  return overrides.map(([k, v]) => formatAxisOverride(k, v)).join(' ')
+}
+
+function buildFilename(overrides, family = 'Dactyl') {
+  if (!overrides.length) return `${family}-Regular.otf`
+  return `${family}-${overrides.map(([k, v]) => formatAxisOverride(k, v)).join('-')}.otf`
+}
+
 /**
  * Build an opentype.Font from the glyph data returned by generateFontGlyphData.
  * Coordinates from the F# generator are already Y-up (baseline at 0, positive
  * values go up), which matches the opentype.js coordinate convention directly.
  */
-function buildFont(glyphData, familyName = 'Dactyl') {
+function buildFont(glyphData, familyName = 'Dactyl', styleName = 'Regular') {
   const { glyphs: glyphsData, ascender, descender, unitsPerEm } = glyphData
 
   const notdef = new opentype.Glyph({
@@ -263,10 +286,14 @@ function buildFont(glyphData, familyName = 'Dactyl') {
 
   return new opentype.Font({
     familyName,
-    styleName: 'Regular',
+    styleName,
     unitsPerEm: Math.round(unitsPerEm),
     ascender: Math.round(ascender),
     descender: Math.round(descender),
+    copyright: `Copyright ${new Date().getFullYear()} Terry Spitz`,
+    designer: 'Terry Spitz',
+    license: 'This Font Software is licensed under the SIL Open Font License, Version 1.1.',
+    licenseURL: 'https://openfontlicense.org',
     glyphs,
   })
 }
@@ -286,9 +313,13 @@ export function buildFontDataUrl(glyphData, familyName = 'DactylPreview') {
 
 /**
  * Build a font from the glyph data and trigger a browser download of the OTF file.
+ * Pass axes and defaultAxes to embed overridden axis values in the filename and style name.
  */
-export function downloadFont(glyphData, filename = 'dactyl.otf') {
-  const font = buildFont(glyphData)
+export function downloadFont(glyphData, axes, defaultAxes) {
+  const overrides = axes && defaultAxes ? getOverriddenAxes(axes, defaultAxes) : []
+  const styleName = buildStyleName(overrides)
+  const filename = buildFilename(overrides)
+  const font = buildFont(glyphData, 'Dactyl', styleName)
   const buffer = font.toArrayBuffer()
   const blob = new Blob([buffer], { type: 'font/otf' })
   const url = URL.createObjectURL(blob)


### PR DESCRIPTION
## Summary

When downloading variable fonts with non-default axis values, the filename and style name now reflect the axis overrides. This makes it easier to identify which font variant was generated and provides proper metadata for the OTF file.

## Changes

- **New helper functions in `fontExport.js`:**
  - `getOverriddenAxes()` — identifies axes that differ from defaults
  - `formatAxisOverride()` — formats individual axis overrides as compact strings (e.g., `wght700`, `no_serif`)
  - `buildStyleName()` — constructs OpenType style name from overrides (e.g., "wght700 slnt-12")
  - `buildFilename()` — constructs OTF filename from overrides (e.g., "Dactyl-wght700-slnt-12.otf")

- **Updated `buildFont()` function:**
  - Now accepts `styleName` parameter (defaults to 'Regular')
  - Added copyright, designer, license, and licenseURL metadata to the font object

- **Updated `downloadFont()` function:**
  - Now accepts `axes` and `defaultAxes` parameters
  - Computes style name and filename from axis overrides
  - Passes style name to `buildFont()`

- **Updated `App.jsx`:**
  - Passes `axes` and `defaultAxes` to `downloadFont()` when triggering font download

## Implementation Details

- Boolean axes are formatted as `key` (true) or `no_key` (false)
- Numeric axes are formatted as `key` + value, with trailing zeros and decimal points stripped
- When no axes are overridden, the filename defaults to "Dactyl-Regular.otf" and style name to "Regular"
- Font metadata now includes SIL Open Font License information

https://claude.ai/code/session_012eHsYaPPCxHnnHT3SA8gRL