### PR TITLE
Fix figure-8 distortion under italic by symmetrising in the de-sheared frame

### DIFF
--- a/src/generator/DactylSpline.fs
+++ b/src/generator/DactylSpline.fs
@@ -852,6 +852,13 @@ type DactylSpline(ctrlPts, isClosed) =
     member this.ctrlPts: DControlPoint array = ctrlPts
     member this.isClosed = isClosed
 
+    /// Horizontal shear (italic slant) applied to the glyph before solving: x' = x + Shear*y.
+    /// The post-solve symmetrisation assumes the glyph is mirror-symmetric about a vertical
+    /// (or horizontal) axis, which a non-zero shear breaks.  We therefore symmetrise in the
+    /// de-sheared frame (x - Shear*y) so symmetric free coords are matched and averaged
+    /// correctly, then re-apply the shear.  Defaults to 0 (no slant).
+    member val Shear = 0.0 with get, set
+
     /// Pre-process LineToCurve/CurveToLine points: fix their tangent to the line direction.
     /// Must be called before segment iteration in both solveAndGetPoints and solveAndRenderTuple.
     member this.preprocessLineTangents() =
@@ -943,7 +950,13 @@ type DactylSpline(ctrlPts, isClosed) =
             let pts = solver.points()
             let n = innerPts.Length - 1  // actual point count; pts[n] duplicates pts[0]
 
-            // Centroid of fixed x coords and fixed y coords separately
+            // Work in the de-sheared frame so italic glyphs are matched/averaged correctly.
+            // A horizontal shear maps x → x + Shear*y; the mirror symmetry the solver should
+            // converge to exists in the upright frame, so de-shear x before comparing.
+            let shear = this.Shear
+            let deshearX i = pts.[i].x - shear * pts.[i].y
+
+            // Centroid of fixed (de-sheared) x coords and fixed y coords separately
             let mutable sumX = 0.0
             let mutable cntX = 0
             let mutable sumY = 0.0
@@ -951,7 +964,7 @@ type DactylSpline(ctrlPts, isClosed) =
 
             for i in 0 .. n - 1 do
                 if not pts.[i].fit_x then
-                    sumX <- sumX + pts.[i].x
+                    sumX <- sumX + deshearX i
                     cntX <- cntX + 1
 
                 if not pts.[i].fit_y then
@@ -963,15 +976,15 @@ type DactylSpline(ctrlPts, isClosed) =
                 let cy = sumY / float cntY
                 let mutable symmetrized = false
 
-                // Symmetrise free-y knots.  Group them by their (rounded) fixed-x value.
-                // Only average a pair when each mirror-x bucket has EXACTLY ONE knot;
+                // Symmetrise free-y knots.  Group them by their (rounded) de-sheared fixed-x
+                // value.  Only average a pair when each mirror-x bucket has EXACTLY ONE knot;
                 // this prevents figure-8 glyphs from being incorrectly collapsed — '8'
                 // has two free-y knots at x=L and two at x=R, so the mirror buckets have
                 // size 2 and are skipped.
                 let freeYByX =
                     [| 0 .. n - 1 |]
                     |> Array.filter (fun i -> pts.[i].fit_y && not pts.[i].fit_x)
-                    |> Array.groupBy (fun i -> System.Math.Round(pts.[i].x))
+                    |> Array.groupBy (fun i -> System.Math.Round(deshearX i))
 
                 for (px, idxA) in freeYByX do
                     let mirrorPx = System.Math.Round(2.0 * cx - px)
@@ -980,6 +993,7 @@ type DactylSpline(ctrlPts, isClosed) =
                         | Some (_, idxB) when idxA.Length = 1 && idxB.Length = 1 ->
                             let i = idxA.[0]
                             let j = idxB.[0]
+                            // y is unaffected by horizontal shear, so average directly.
                             let avg = (pts.[i].y + pts.[j].y) / 2.0
                             pts.[i].y <- avg
                             pts.[j].y <- avg
@@ -999,9 +1013,11 @@ type DactylSpline(ctrlPts, isClosed) =
                         | Some (_, idxB) when idxA.Length = 1 && idxB.Length = 1 ->
                             let i = idxA.[0]
                             let j = idxB.[0]
-                            let avg = (pts.[i].x + pts.[j].x) / 2.0
-                            pts.[i].x <- avg
-                            pts.[j].x <- avg
+                            // Average in the de-sheared frame, then re-apply each knot's shear
+                            // (their y differs, so their final x differs by Shear*Δy).
+                            let avg = (deshearX i + deshearX j) / 2.0
+                            pts.[i].x <- avg + shear * pts.[i].y
+                            pts.[j].x <- avg + shear * pts.[j].y
                             symmetrized <- true
                         | _ -> ()
 

--- a/src/generator/Font.fs
+++ b/src/generator/Font.fs
@@ -340,13 +340,21 @@ type Font(axes: Axes, ?showCombOpt: bool) =
                      th_in = k.th_in
                      th_out = k.th_out } |]
 
+    /// Construct a DactylSpline for this font's control points, tagged with the current
+    /// italic shear so its post-solve symmetrisation can de-shear before matching mirror
+    /// coords.  All DactylSpline instances in Font must go through here — constructing one
+    /// directly would silently drop the shear and distort sheared (italic) glyphs.
+    let mkDactylSpline ctrlPts isClosed =
+        let spline = DactylSpline(ctrlPts, isClosed)
+        spline.Shear <- axes.italic
+        spline
+
     let rec elementToDactylSvg (elem: Element) =
         if axes.debug then
             printfn "elementToDactylSvg %A" elem
 
         let ctrlPtsToSvg ctrlPts isClosed =
-            let spline = DactylSpline(ctrlPts, isClosed)
-            spline.Shear <- axes.italic
+            let spline = mkDactylSpline ctrlPts isClosed
 
             spline.solveAndRenderSvg (
                 axes.max_spline_iter,
@@ -1116,7 +1124,7 @@ type Font(axes: Axes, ?showCombOpt: bool) =
             if axes.debug then
                 printfn "solveCurveSegs ctrlPts: %A" ctrlPts
 
-            let spline = DactylSpline(ctrlPts, isClosed)
+            let spline = mkDactylSpline ctrlPts isClosed
 
             let bezPts =
                 spline.solveAndGetPoints (axes.max_spline_iter, axes.flatness, axes.end_flatness, axes.debug)
@@ -1323,7 +1331,7 @@ type Font(axes: Axes, ?showCombOpt: bool) =
             let startAlign = pts.IsEmpty || isClosed || not (isFreeCurveEnd pts.[0].ty)
             let endAlign   = pts.IsEmpty || isClosed || not (isFreeCurveEnd (List.last pts).ty)
             let ctrlPts = toDactylSplineControlPoints pts
-            let spline = DactylSpline(ctrlPts, isClosed)
+            let spline = mkDactylSpline ctrlPts isClosed
             let bezPts = spline.solveAndGetPoints (axes.max_spline_iter, axes.flatness, axes.end_flatness, axes.debug)
             buildOutlineFromBez bezPts isClosed startAlign endAlign
 
@@ -1670,8 +1678,7 @@ type Font(axes: Axes, ?showCombOpt: bool) =
             match elem with
             | Curve(pts, isClosed) ->
                 let ctrlPts = toDactylSplineControlPoints pts
-                let spline = DactylSpline(ctrlPts, isClosed)
-                spline.Shear <- axes.italic
+                let spline = mkDactylSpline ctrlPts isClosed
                 let bezPts = spline.solveAndGetPoints(axes.max_spline_iter, axes.flatness, axes.end_flatness, false)
                 bezPts |> Array.toList |> List.map (fun bp -> bp.x, bp.y)
             | EList(elems) -> List.collect collect elems

--- a/src/generator/Font.fs
+++ b/src/generator/Font.fs
@@ -346,6 +346,7 @@ type Font(axes: Axes, ?showCombOpt: bool) =
 
         let ctrlPtsToSvg ctrlPts isClosed =
             let spline = DactylSpline(ctrlPts, isClosed)
+            spline.Shear <- axes.italic
 
             spline.solveAndRenderSvg (
                 axes.max_spline_iter,
@@ -1670,6 +1671,7 @@ type Font(axes: Axes, ?showCombOpt: bool) =
             | Curve(pts, isClosed) ->
                 let ctrlPts = toDactylSplineControlPoints pts
                 let spline = DactylSpline(ctrlPts, isClosed)
+                spline.Shear <- axes.italic
                 let bezPts = spline.solveAndGetPoints(axes.max_spline_iter, axes.flatness, axes.end_flatness, false)
                 bezPts |> Array.toList |> List.map (fun bp -> bp.x, bp.y)
             | EList(elems) -> List.collect collect elems

--- a/src/generator/tests/FontTest.fs
+++ b/src/generator/tests/FontTest.fs
@@ -778,6 +778,50 @@ type FontTests() =
             sprintf "'8' backbone bottom (%.1f) should be below 30%% of cap height (%.1f)" minY (capT * 0.3)
         )
 
+    [<Test>]
+    member this.Figure8_Italic_LoopsDoNotCollapse() =
+        // With any italic slant, the figure-8 must still span both loops vertically.
+        // The post-solve symmetrisation used to average the top/bottom centre knots
+        // (t(c)/b(c)) ignoring the horizontal shear, which un-sheared the loop centres
+        // and let the side knots collapse toward half-height, squashing the loops.
+        // Symmetrisation is now performed in the de-sheared frame so this no longer happens.
+        let axes =
+            { Axes.DefaultAxes with
+                dactyl_spline = true
+                outline = true
+                italic = 0.5 }
+
+        let font = Font.Font(axes)
+        let pts = font.charToSolvedBackbonePoints '8'
+        Assert.That(pts, Is.Not.Empty, "italic '8' backbone should have points")
+
+        let ys = pts |> List.map snd
+        let translate = float axes.thickness
+        let capT = float axes.height + translate
+        Assert.That(
+            List.max ys,
+            Is.GreaterThan(capT * 0.7),
+            sprintf "italic '8' backbone top (%.1f) should reach above 70%% of cap height (%.1f)" (List.max ys) (capT * 0.7)
+        )
+        Assert.That(
+            List.min ys,
+            Is.LessThan(capT * 0.3),
+            sprintf "italic '8' backbone bottom (%.1f) should be below 30%% of cap height (%.1f)" (List.min ys) (capT * 0.3)
+        )
+
+        // The top-centre and bottom-centre knots (the only free-x mirror pair) must keep the
+        // shear offset between them: x_top - x_bot ≈ italic*(y_top - y_bot).  Before the fix
+        // they were averaged to the same x.
+        let topCentre = pts |> List.maxBy snd
+        let botCentre = pts |> List.minBy snd
+        let dx = fst topCentre - fst botCentre
+        let expected = axes.italic * (snd topCentre - snd botCentre)
+        Assert.That(
+            abs (dx - expected),
+            Is.LessThan(20.0),
+            sprintf "italic '8' top/bottom centres should differ in x by ~%.1f (shear), got %.1f" expected dx
+        )
+
 [<TestFixture>]
 type KnotSequenceValidationTests() =
     let pt x y = { x = x; y = y; x_fit = false; y_fit = false }

--- a/src/generator/tests/FontTest.fs
+++ b/src/generator/tests/FontTest.fs
@@ -792,21 +792,33 @@ type FontTests() =
                 italic = 0.5 }
 
         let font = Font.Font(axes)
+
+        // charToSolvedBackbonePoints and the production outline render now share the same
+        // spline-construction helper (mkDactylSpline, which tags the shear), so these
+        // backbone points are exactly the spine the outline path offsets.
         let pts = font.charToSolvedBackbonePoints '8'
         Assert.That(pts, Is.Not.Empty, "italic '8' backbone should have points")
 
-        let ys = pts |> List.map snd
         let translate = float axes.thickness
         let capT = float axes.height + translate
+        let ys = pts |> List.map snd
+
+        // The squash signature is the four free-y *side* knots ((th)l/r, (bh)l/r) collapsing
+        // toward half-height.  A healthy figure-8 keeps a full top loop and a full bottom loop:
+        // the top loop ((th)l, t(c), (th)r) sits well above centre and the bottom loop
+        // ((bh)l, b(c), (bh)r) well below.  (A global max/min check is too weak — t(c)/b(c)
+        // are pinned to top/bottom and pass even when the loops are squashed flat.)
+        let upperCount = ys |> List.filter (fun y -> y > capT * 0.55) |> List.length
+        let lowerCount = ys |> List.filter (fun y -> y < capT * 0.45) |> List.length
         Assert.That(
-            List.max ys,
-            Is.GreaterThan(capT * 0.7),
-            sprintf "italic '8' backbone top (%.1f) should reach above 70%% of cap height (%.1f)" (List.max ys) (capT * 0.7)
+            upperCount,
+            Is.GreaterThanOrEqualTo(3),
+            sprintf "italic '8' top loop collapsed: only %d knots above 0.55*capH (%.1f); ys=%A" upperCount (capT * 0.55) ys
         )
         Assert.That(
-            List.min ys,
-            Is.LessThan(capT * 0.3),
-            sprintf "italic '8' backbone bottom (%.1f) should be below 30%% of cap height (%.1f)" (List.min ys) (capT * 0.3)
+            lowerCount,
+            Is.GreaterThanOrEqualTo(3),
+            sprintf "italic '8' bottom loop collapsed: only %d knots below 0.45*capH (%.1f); ys=%A" lowerCount (capT * 0.45) ys
         )
 
         // The top-centre and bottom-centre knots (the only free-x mirror pair) must keep the
@@ -821,6 +833,14 @@ type FontTests() =
             Is.LessThan(20.0),
             sprintf "italic '8' top/bottom centres should differ in x by ~%.1f (shear), got %.1f" expected dx
         )
+
+        // End-to-end: the production outline path (charToSvg → getOutline → constant-offset
+        // outliner, which solves the spine at a *different* call site) must render cleanly and
+        // not fall back to the red error stroke.
+        let svgStr = font.charToSvg '8' 0.0 0.0 "black" |> String.concat " "
+        Assert.That(svgStr, Does.Contain("M "), "italic '8' outline should contain a moveto")
+        Assert.That(svgStr, Does.Not.Contain("NaN"), "italic '8' outline should not contain NaN")
+        Assert.That(svgStr, Does.Not.Contain("stroke:#e00000"), "italic '8' outline should not be the red error fallback")
 
 [<TestFixture>]
 type KnotSequenceValidationTests() =


### PR DESCRIPTION
The DactylSpline post-solve symmetrisation averaged mirror-symmetric free
coords assuming a vertical/horizontal axis of symmetry. A non-zero italic
shear (x -> x + italic*y) breaks that assumption: the top/bottom centre
knots of the '8' (the free-x mirror pair) were averaged to the same x,
un-shearing the loop centres and letting the side knots collapse toward
half-height, squashing both loops.

Thread the italic shear into DactylSpline (new Shear property, set from
axes.italic) and perform the symmetrisation in the de-sheared frame
(x - Shear*y): match/bucket and average free coords upright, then re-apply
each knot's shear. Reduces to the previous behaviour when Shear = 0.

Add a regression test asserting the italic '8' loops stay open and the
top/bottom centres keep the expected shear offset.