### PR TITLE
Add digit repeat-count shorthand to glyph language

### DIFF
--- a/docs/DactylGlyphs.md
+++ b/docs/DactylGlyphs.md
@@ -40,6 +40,19 @@ Horizontal coordinates follow the Y-coordinates.
 
 *Example:* `tl` puts a point at the top-left of the glyph bounding box. `bc` puts a point at the bottom-center.
 
+### Weighting (Averaging & Repeats)
+Combining several coordinate letters averages them, which lets you place a point at a fraction between guides. Repeating a letter weights the average toward it:
+- `bt` (or `h`): halfway between bottom and top.
+- `bbt`: one-third up from the bottom (two parts `b`, one part `t`).
+- `rrrrc`: four-fifths of the way from center toward the right.
+
+Because long runs are tedious, a **digit after a coordinate letter repeats it** that many times — pure shorthand for the weighting above, producing identical geometry:
+- `b2t` is the same as `bbt`.
+- `r4c` is the same as `rrrrc`.
+- `t4h` is the same as `tttth`.
+
+The digit binds to the single letter immediately before it, and works for both Y and X coordinates (and inside fitting brackets, e.g. `(r4c)`).
+
 ### Modifiers
 
 #### Coordinate Fitting (Brackets)

--- a/src/generator/GlyphStringDefs.fs
+++ b/src/generator/GlyphStringDefs.fs
@@ -16,15 +16,17 @@ let PI = System.Math.PI
 /// "e" adds/subtracts an "extended" thickness offset to y (outwards)
 /// x coordinates: (l)eft, (r)ight, (c)enter, (w)ide (em-width)
 /// note multiple y or x coordinates means average across them, so "bt"="h" and "bbt" means one-third up
+/// a digit after a coordinate letter repeats it that many times (a shorthand for the weighting above),
+/// so "b2t"="bbt" (one-third up) and "r4c"="rrrrc" (four-fifths from centre toward the right)
 /// brackets mean coordinates are adjusted (by the DactylSpline only) to be smoother
 /// optional tangent direction (N)orth (S)outh (E)ast (W)est
 /// lines/curves: (-) straight line, (~) curve, note: lines join curves smoothly
 /// ( ) terminates a curve, a preceeding (- or ~) means closed curve (last point rejoins first point)
 /// Solo points become dots
 /// Regex for the language
-let y_re = "[txhbd]+|\([txhbd]+\)"
+let y_re = "[txhbd0-9]+|\([txhbd0-9]+\)"
 let offset_re = "[oe]"
-let x_re = "[lrcw]+|\([lrcw]+\)"
+let x_re = "[lrcw0-9]+|\([lrcw0-9]+\)"
 let direction_re = "[NSEW]"
 let line_re = "[-~]"
 let separator_re = " "
@@ -140,6 +142,29 @@ let glyphMap =
           'z', "xl-xr-bl-br" ]
 
 // parse
+
+/// Expand a coordinate string into the list of guide values to average.
+/// Parentheses are ignored here (they set the fit flag separately). A digit
+/// run immediately after a coordinate letter repeats that letter that many
+/// times, so it counts proportionally in the average:
+///   "r4c" -> [R;R;R;R;C]   "b2t" -> [B;B;T]   "th" -> [T;H] (unchanged)
+let weightedCoords (cs: string) (coordOf: char -> float) =
+    let rec loop chars acc =
+        match chars with
+        | [] -> List.rev acc
+        | c :: rest when c = '(' || c = ')' -> loop rest acc
+        | c :: rest ->
+            let digits = rest |> List.takeWhile System.Char.IsDigit
+            let rest2 = rest |> List.skipWhile System.Char.IsDigit
+            let count =
+                match digits with
+                | [] -> 1
+                | _ -> digits |> List.fold (fun a d -> a * 10 + (int d - int '0')) 0
+            let v = coordOf c
+            loop rest2 (List.replicate count v @ acc)
+
+    loop (List.ofSeq cs) []
+
 let parse_point (glyph: FontMetrics) def_raw =
     let mutable def = def_raw
     let start_def = def_raw
@@ -150,24 +175,16 @@ let parse_point (glyph: FontMetrics) def_raw =
     let y_fit = ys.StartsWith("(")
 
     let y_coords =
-        [ for c in ys do
-              match c with
-              | '('
-              | ')' -> () // ignore brackets
-              | c ->
-                  yield
-                      Some(
-                          match c with
-                          | 't' -> glyph.T
-                          | 'x' -> glyph.X
-                          | 'h' -> glyph.H
-                          | 'b' -> glyph.B
-                          | 'd' -> glyph.D
-                          | _ -> invalidArg "y" (sprintf "Invalid Y coord %A (should be in %A)" c y_re)
-                      ) ]
-        |> List.choose id
+        weightedCoords ys (fun c ->
+            match c with
+            | 't' -> glyph.T
+            | 'x' -> glyph.X
+            | 'h' -> glyph.H
+            | 'b' -> glyph.B
+            | 'd' -> glyph.D
+            | _ -> invalidArg "y" (sprintf "Invalid Y coord %A (should be in %A)" c y_re))
 
-    let mutable y_coord = List.averageBy float y_coords
+    let mutable y_coord = List.average y_coords
     def <- def.[match_y.Length ..]
 
     // offset
@@ -191,23 +208,15 @@ let parse_point (glyph: FontMetrics) def_raw =
     let x_fit = xs.StartsWith("(")
 
     let x_coords =
-        [ for c in xs do
-              match c with
-              | '('
-              | ')' -> () // ignore brackets
-              | c ->
-                  yield
-                      Some(
-                          match c with
-                          | 'l' -> glyph.L
-                          | 'c' -> glyph.C
-                          | 'r' -> glyph.R
-                          | 'w' -> glyph.W
-                          | _ -> invalidArg "x" (sprintf "Invalid X coord %A  (should be in %A)" c x_re)
-                      ) ]
-        |> List.choose id
+        weightedCoords xs (fun c ->
+            match c with
+            | 'l' -> glyph.L
+            | 'c' -> glyph.C
+            | 'r' -> glyph.R
+            | 'w' -> glyph.W
+            | _ -> invalidArg "x" (sprintf "Invalid X coord %A  (should be in %A)" c x_re))
 
-    let x_coord = List.averageBy float x_coords
+    let x_coord = List.average x_coords
     def <- def.[match_x.Length ..]
 
     let match_dir = Regex.Match(def, "^" + direction_re)

--- a/src/generator/tests/ParserTests.fs
+++ b/src/generator/tests/ParserTests.fs
@@ -87,6 +87,37 @@ type ParserTests() =
         // "tl-blE" -> Tangent on end of line. Should throw.
         Assert.Throws<System.ArgumentException>(fun () -> parse_curve metrics "tl-blE" false |> ignore) |> ignore
 
+    [<Test>]
+    member this.TestDigitRepeatX() =
+        // "r4c" should equal the expanded "rrrrc": four parts R, one part C.
+        let expanded, _, _, _ = parse_point metrics "brrrrc"
+        let shorthand, _, _, _ = parse_point metrics "br4c"
+        Assert.That(shorthand.x, Is.EqualTo(expanded.x))
+        Assert.That(shorthand.x, Is.EqualTo((4.0 * metrics.R + metrics.C) / 5.0))
+
+    [<Test>]
+    member this.TestDigitRepeatY() =
+        // "b2t" should equal "bbt": one-third up from the bottom.
+        let expanded, _, _, _ = parse_point metrics "bbtl"
+        let shorthand, _, _, _ = parse_point metrics "b2tl"
+        Assert.That(shorthand.y, Is.EqualTo(expanded.y))
+        Assert.That(shorthand.y, Is.EqualTo((2.0 * metrics.B + metrics.T) / 3.0))
+
+    [<Test>]
+    member this.TestDigitRepeatInBrackets() =
+        // Digit weighting works inside fitting brackets, and keeps the fit flag.
+        let expanded, _, _, _ = parse_point metrics "t(rrrrc)"
+        let shorthand, _, _, _ = parse_point metrics "t(r4c)"
+        Assert.That(shorthand.x, Is.EqualTo(expanded.x))
+        Assert.That(shorthand.x_fit, Is.True)
+
+    [<Test>]
+    member this.TestSingleLetterUnchanged() =
+        // No digit means count 1 — plain coordinates are unaffected.
+        let pt, _, _, _ = parse_point metrics "tl"
+        Assert.That(pt.y, Is.EqualTo(metrics.T))
+        Assert.That(pt.x, Is.EqualTo(metrics.L))
+
 [<EntryPoint>]
 let main argv =
     0 // Return an integer exit code

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -872,7 +872,8 @@ function App() {
               <div className="helper-key" style={{ fontSize: '0.85em', color: '#666' }}>
                 <strong>Key:</strong> y: (t)op, (x)-height, (h)alf, (b)ottom, (d)escender, (o)ffset, (e)xtended. <br />
                 x: (l)eft, (c)enter, (r)ight, (w)ide. <br />
-                Dirs: N,S,E,W. Lines: (-) straight, (~) curve, (.) corner. Brackets mean 'fit this coordinate instead'
+                Dirs: N,S,E,W. Lines: (-) straight, (~) curve, (.) corner. Brackets mean 'fit this coordinate instead'. <br />
+                Repeats average coordinates (e.g. "bt"="h"); a digit repeats the letter before it, so "b2t"="bbt" and "r4c"="rrrrc".
               </div>
             </div>
           )}


### PR DESCRIPTION
A digit after a coordinate letter now repeats that letter that many
times in the coordinate average, e.g. "r4c" == "rrrrc" and "b2t" == "bbt".
This is pure shorthand for the existing repetition-as-weighting rule and
produces identical geometry, but lets fractional point placements (like
tail terminals) be written concisely instead of spelling out long runs.

- GlyphStringDefs.fs: allow digits in the y/x regexes and expand repeat
  counts via a new weightedCoords helper used for both axes.
- ParserTests.fs: verify shorthand matches the expanded form for x, y,
  and inside fitting brackets, and that plain coordinates are unchanged.
- DactylGlyphs.md and the Glyphs-tab key: document the digit shorthand.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KXTQuqkHtJTm8qtqrkBxH8