### PR TITLE
Use npm ci in session-start hook to avoid lockfile churn

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -21,7 +21,10 @@ dotnet restore
 dotnet tool restore
 
 # Install root npm dependencies (concurrently)
-npm install
+# Use `npm ci` so the lockfiles are installed verbatim and never rewritten
+# (`npm install` can mutate package-lock.json, e.g. dropping libc metadata,
+# leaving spurious uncommitted changes every session).
+npm ci
 
 # Install web npm dependencies
-npm install --prefix web
+npm ci --prefix web


### PR DESCRIPTION
npm install can rewrite web/package-lock.json (e.g. dropping libc
metadata), leaving spurious uncommitted changes every web session.
npm ci installs the lockfile verbatim and never rewrites it, matching
the build pipeline documented in CLAUDE.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DmE1QQpaSa779HX3SS1psY