### PR TITLE
Fix doc inaccuracies found during line-by-line review

### DIFF
--- a/.agent/workflows/run_tests.md
+++ b/.agent/workflows/run_tests.md
@@ -5,17 +5,17 @@ description: Run all unit tests for the generator project
 To run the full test suite:
 
 ```bash
-dotnet test src/generator/generator.tests.fsproj
+dotnet test src/generator/tests/generator.tests.fsproj
 ```
 
 To run only the Solver tests (including typical regression tests):
 
 ```bash
-dotnet test src/generator/generator.tests.fsproj --filter "FullyQualifiedName~SolverTests"
+dotnet test src/generator/tests/generator.tests.fsproj --filter "FullyQualifiedName~SolverTests"
 ```
 
 To run Variable Point tests:
 
 ```bash
-dotnet test src/generator/generator.tests.fsproj --filter "FullyQualifiedName~VariablePointTests"
+dotnet test src/generator/tests/generator.tests.fsproj --filter "FullyQualifiedName~VariablePointTests"
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ diffs and runs the rebase action manually.
 | CI workflow | Trigger | What it does |
 |-------------|---------|-------------|
 | `.NET Core` (`dotnet-core.yml`) | push to `main` or `claude/**`; PRs to `main` | `dotnet build` + `dotnet test` (F# unit tests) |
-| `Visual Tests` (`visual-tests.yml`) | PRs to `main`; `workflow_dispatch` | Playwright screenshot tests against production build; auto-commits new baselines |
+| `Visual Tests` (`visual-tests.yml`) | push to `main`; PRs to `main`; `workflow_dispatch` | Playwright screenshot tests against production build; auto-commits new baselines |
 | `Deploy Pages` (`deploy-pages.yml`) | push to `main` only | Builds and deploys to GitHub Pages |
 
 ## Key source files

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -49,7 +49,7 @@ npm run build
 # Run tab screenshot tests (compare against baselines)
 npm run test:tabs
 
-# Run tween screenshot tests (generates per-axis screenshots)
+# Run tween screenshot tests (compare against saved baseline PNGs)
 npm run test:tweens
 
 # Regenerate tab baselines after an intentional visual change

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A few predefined Dactyl fonts are available to download in the [ttf](https://git
 
 - [DactylGlyph Documentation](docs/DactylGlyphs.md) — How glyph string definitions work
 - [DactylSpline Documentation](docs/DactylSpline.md) — The DactylSpline curve implementation
+- [Font Rendering Pipeline](docs/FontPipeline.md) — Spine → outline → SVG pipeline, caps, serifs, and font export
 
 ## Spiro Curves
 

--- a/docs/DactylGlyphs.md
+++ b/docs/DactylGlyphs.md
@@ -99,10 +99,10 @@ The generator UI features a **Glyphs** tab, an invaluable tool for creating and 
 ### How to Use It
 1. **Live Preview:** Enter your Dactyl Glyphs string into the definition editor. The browser instantly renders the resulting glyph geometry on screen.
 2. **Visual Diagnostics:** The browser overlays essential debugging features over the rendered stroke:
-   - **Control Points:** Shows the exact solved coordinates of every parsed point.
+   - **Knots:** Shows the exact solved coordinates of every parsed point.
    - **Tangents:** Visualizes the incoming and outgoing tangent vectors at each knot (especially helpful for confirming sharp corners vs. smooth joins).
-   - **Curvature Combs:** Provides a "comb" heat map that visualizes the rate of curvature along bezier segments. Spikes or uneven comb distribution indicate jagged transitions that you might wish to fix via coordinate fitting (brackets) or explicit tangents.
-3. **Toggle `dactyl_spline` / `Spiro`:** Use the checkboxes to view how your string behaves under the newer robust Dactyl solver vs. the legacy Spiro solver.
+   - **Comb:** Provides a "comb" heat map that visualizes the rate of curvature along bezier segments. Spikes or uneven comb distribution indicate jagged transitions that you might wish to fix via coordinate fitting (brackets) or explicit tangents.
+3. **Toggle DactylSpline / Spline2 / Spiro:** Use the checkboxes to view how your string behaves under the three available solvers — the newer robust **DactylSpline**, Raph Levien's **Spline2**, and the legacy **Spiro** solver.
    - *Note on Spiro Limitations:* The legacy `Spiro` matrix solver may struggle or throw exceptions on tightly packed closed loops containing only three points (such as `tl-blE~hr~`). Using the robust `DactylSpline` backend handles these topologies elegantly.
 
 By iterating within the Glyphs tab, you can visually tune specific coordinate points and explicit tangents until your glyph achieves a flawless, production-ready continuous outline!

--- a/docs/DactylGlyphs.md
+++ b/docs/DactylGlyphs.md
@@ -77,6 +77,13 @@ By default, the sequence of points draws an **open** path from the first point t
 To automatically close the shape (forming a continuous loop), simply leave a trailing `-` or `~` separator at the very end of your sequence. 
 - *Example:* `tl-bl-br~tr~` loops the `tr` point back to the starting `tl` point via a curve.
 
+### Solo Points → Dots
+A sub-path string containing exactly one point (no separator at all) is rendered as a **filled dot** (circle) rather than a stroke.  This is how punctuation glyphs get their dots: the period `'.'` is defined as `"bl"` (a single bottom-left point), the colon `':'` as `"xbl bl"` (two separate sub-paths, each a solo point), and so on.
+
+The dot diameter scales with the `thickness` axis.  Any valid point expression works — `hc` places a dot at the half-height centre, `bc` at the bottom-centre, etc.
+
+*Example:* `tl-bl-br-tr- bc` draws a rectangle (closed via the trailing `-`) and then a separate dot at the bottom-centre — useful for building glyphs like `!` or `¡`.
+
 ---
 
 ## 3. Tangents and Corners: Advanced Rules

--- a/docs/FontPipeline.md
+++ b/docs/FontPipeline.md
@@ -1,0 +1,130 @@
+# Dactyl Font Rendering Pipeline
+
+This document describes how a character travels from a glyph string definition through to final SVG output.  The code lives primarily in `src/generator/Font.fs`, with types defined in `src/generator/GeneratorTypes.fs` and `src/generator/Axes.fs`.
+
+---
+
+## Pipeline overview
+
+```
+Character (char)
+  │
+  ▼  Font.charToElem
+  ├─ GlyphStringDefs.glyphMap lookup → glyph string (e.g. "x(c)~(xb)l~")
+  ├─ parse_curves → Element tree (Curve / Dot / EList / Space)
+  ├─ constrainTangents   (if axes.constraints)
+  ├─ monospace           (if axes.monospace > 0)
+  ├─ translateByThickness
+  └─ italicise           (if axes.italic ≠ 0)
+       │
+       ▼  Font.getOutline
+       ├─ stroked mode      → getStroked (four parallel lines per stroke)
+       ├─ scratches mode    → getScratches (textured paint-stroke effect)
+       └─ outline mode:
+            ├─ constant_offset  → getDactylConstantOffsetOutlines
+            ├─ dactyl_spline    → getDactylSansOutlines
+            └─ (legacy)         → getSpiroSansOutlines
+                 │  optionally: constrainTangents
+                 ▼
+             Element tree of outline Curves
+                 │
+                 ▼  Font.elementToSvgPath
+             SVG <path d="…"> strings
+```
+
+---
+
+## Stage 1 — Spine construction (`charToElem`)
+
+`Font.charToElem` builds the **spine** (the single-width centreline) of a glyph:
+
+1. `Glyph(ch)` is looked up in `GlyphStringDefs.glyphMap` and parsed by `parse_curves` into an `Element` tree — a union of `Curve`, `Dot`, `EList`, and `Space` nodes.
+2. **`constrainTangents`** (optional) clips tangent angles so smooth curves cannot exit the glyph bounding box.
+3. **`monospace`** normalises advance widths to a fixed cell when `axes.monospace > 0`.
+4. **`translateByThickness`** shifts the spine outward by half the stroke thickness so that the outline stays within the original bounding box.
+5. **`italicise`** applies an affine horizontal shear.  Because shearing distorts Bézier handles, this step subdivides curves first for a better approximation.
+
+---
+
+## Stage 2 — Outline expansion (`getOutline`)
+
+`Font.getOutline` dispatches to one of four strategies based on axes:
+
+### `getDactylSansOutlines` (default)
+The main outline path.  For each solved Bézier segment from the DactylSpline:
+- Calls `offsetSegment` to build the left and right offset paths at distance ±`thickness/2`.
+- Joins adjacent segments with **miter** geometry at convex corners and a **bisector** point at concave corners.
+- Calls `startCap` / `endCap` to close open stroke ends.
+
+### `getDactylConstantOffsetOutlines` (when `constant_offset = true`)
+Walks every cubic Bézier at 16 t-steps, emitting perpendicular offset samples as straight-line `Corner` knots.  Produces smoother outlines for strongly curved strokes at the cost of more points.  Cap and join logic is shared with the default path.
+
+### `getSpiroSansOutlines` (legacy, when `dactyl_spline = false`)
+Same structural approach as the DactylSpline path but uses the Spiro-solved segments.
+
+### `getStroked` / `getScratches`
+Alternative rendering modes (four-line backscratch font; textured scratch effect) that bypass the normal outline logic entirely.
+
+---
+
+## Cap types
+
+Both outline modes call the shared `cap` helper, which selects the cap geometry based on axes:
+
+| Condition | Result |
+|-----------|--------|
+| `serif ≠ 0` and not a joint | Rectangular bracketed serif (6 corner knots) |
+| `flare ≠ 0` and not a joint | Flared endcap (bell-curve profile, 4–5 knots) |
+| `end_bulb ≠ 0` and not a joint | Circular bulb at stroke end |
+| joint (two strokes meeting) | Simple miter / bevel join, no cap decoration |
+| default | Flat perpendicular endcap (2 corner knots) |
+
+`axis_align_caps` snaps cap angles to the nearest 90° so they stay visually horizontal or vertical.
+
+---
+
+## Soft corners (`roundCorners`)
+
+When `soft_corners > 0`, every `Corner` knot in the outline (excluding joint knots) is replaced by a small arc.  The arc radius is proportional to `soft_corners × thickness`, clamped to 40% of each adjacent segment so short segments are never over-consumed.
+
+---
+
+## Stage 3 — SVG output (`elementToSvgPath`)
+
+The outline `Element` tree is walked recursively.  Each `Curve` is solved (DactylSpline or Spiro depending on axes) and emitted as an SVG `<path d="…">`.  `Dot` nodes become small filled `<circle>` elements.  Multiple sub-paths within a glyph (e.g. the dot and body of `!`) are emitted as separate paths sharing the same colour fill.
+
+---
+
+## Key types
+
+| Type | Where | Purpose |
+|------|-------|---------|
+| `Element` | `GeneratorTypes.fs` | Union: `Curve \| Dot \| EList \| Space \| Glyph` |
+| `Knot` | `GeneratorTypes.fs` | One point on a `Curve`, with `SpiroPointType` and optional `th_in`/`th_out` |
+| `FontMetrics` | `GeneratorTypes.fs` | Computed guide coordinates (L/R/C/T/X/H/B/D) from axes |
+| `Axes` | `Axes.fs` | All font parameters; `DefaultAxes` holds sensible defaults |
+| `Font` | `Font.fs` | Stateful renderer; instantiated once per axes combination |
+
+---
+
+## SplineEditor tab (`web/src/SplineEditor.jsx`)
+
+The **Splines** tab provides an interactive canvas for building `DactylSpline` control-point sequences without writing glyph strings.  Features:
+
+- Add, drag, and delete knots on a canvas with guide lines.
+- Set each knot's type: Corner, Smooth, Line-Curve, or Curve-Line.
+- Set explicit incoming/outgoing tangent angles via cardinal preset buttons or a degree input.
+- Toggle open/closed path and see the DactylSpline solve update in real time.
+- The **Spline Grid** tab (`SplineGrid.jsx`) shows the same knot sequence rendered across a grid of axis values.
+
+The editor uses `solveSplineEditor` from `Api.fs` (via `worker.js`) to run the Nelder-Mead solver and returns SVG path data for the canvas overlay.
+
+---
+
+## OTF font export (`web/src/fontExport.js`)
+
+When the user downloads a font, `buildFontDataUrl` converts the SVG glyph data to an OTF binary via `opentype.js`.  Because `Font.fs` strokes each curve as an independent closed ribbon, intersecting strokes (e.g. the bowl and stem of `b`) produce overlapping contours.  OTF/CFF requires non-self-intersecting outlines, so `fontExport.js` runs a paper.js boolean union:
+
+1. **Single unite** (`CompoundPath.unite()`): correct and fast for most glyphs.
+2. **Iterative unite**: each contour is self-resolved, then accumulated pairwise.  Needed when three or more strokes overlap (e.g. the middle bar of `B`), which can produce winding number 3 that paper.js's single-pass operator misresolves.
+3. **Fallback**: raw contours are used if both strategies produce an output that does not match the expected fill area (checked by sampling just inside each contour edge).

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -740,9 +740,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -760,9 +757,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -780,9 +774,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -800,9 +791,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -820,9 +808,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -840,9 +825,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2185,9 +2167,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2209,9 +2188,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2233,9 +2209,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2257,9 +2230,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
- run_tests.md: correct test project path (missing tests/ subdir)
- CLAUDE.md: add missing 'push to main' trigger for Visual Tests CI
- DactylGlyphs.md: rename 'Control Points' overlay to 'Knots' (matches UI),
  rename 'Curvature Combs' to 'Comb', and expand toggle description to
  cover all three checkboxes (DactylSpline / Spline2 / Spiro)
- DEVELOPING.md: fix tweens test comment — it compares baselines, not just generates

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AemJrw3SyWzmXLS2JPBMNf