### PR TITLE
Fix session-start hook: apt-get update fails on ondrej/php PPA label change

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -9,7 +9,10 @@ fi
 # Install .NET 8 SDK if not present
 if ! command -v dotnet &>/dev/null; then
   echo "Installing .NET 8 SDK..."
-  apt-get update -q || true
+  # -o Acquire::AllowReleaseInfoChange::Label=true tolerates third-party PPAs
+  # (e.g. ondrej/php) that change their Release file's Label field, which apt
+  # otherwise treats as a hard error and aborts `apt-get update`.
+  apt-get update -q -o Acquire::AllowReleaseInfoChange::Label=true || true
   apt-get install -y dotnet-sdk-8.0
 fi
 


### PR DESCRIPTION
## Summary

- Session setup was failing because `apt-get update` in `.claude/hooks/session-start.sh` hit a hard error when the `ondrej/php` PPA changed its Release file's `Label` value — apt aborts the update in that case rather than just warning.
- Pass `-o Acquire::AllowReleaseInfoChange::Label=true` to `apt-get update` so this class of change (and future ones like it from other repos) is tolerated, instead of relying only on the trailing `|| true` to mask the failure.

## Test plan

- [x] `bash -n .claude/hooks/session-start.sh` — syntax check passes
- [x] Ran `apt-get update -q -o Acquire::AllowReleaseInfoChange::Label=true` directly in this environment (which has the `ondrej/php` PPA configured) — completes successfully (exit 0) instead of erroring on the Label change


---
_Generated by [Claude Code](https://claude.ai/code/session_01U7Lp1ZYkhe2rLxki6Lxab6)_