### PR TITLE
docs: document the Grow tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ NOTE: This README is best viewed at https://terryspitz.github.io/dactyl-font/REA
 
 ## tl;dr
 
-Play with the [Dactyl Live Explorer](https://terryspitz.github.io/dactyl-font) — design fonts interactively using 30+ axes, then download a custom OTF. Switch between tabs to inspect individual **Glyphs**, watch **Tweens** animate axis changes, compare **Visual Diffs** across settings, explore the **Spline** maths, or review **Proofs** with real text.
+Play with the [Dactyl Live Explorer](https://terryspitz.github.io/dactyl-font) — design fonts interactively using 30+ axes, then download a custom OTF. Switch between tabs to inspect individual **Glyphs**, watch **Tweens** animate axis changes, compare **Visual Diffs** across settings, explore the **Spline** maths, review **Proofs** with real text, or **Grow** letterforms into blobby Y2K logotypes.
 
 ## What & Why
 
@@ -38,6 +38,7 @@ The [Dactyl Live Explorer](https://terryspitz.github.io/dactyl-font) runs entire
 | **Splines** | Interactive spline curve editor |
 | **Spline Grid** | Grid of curve variations |
 | **Proofs** | Real prose rendered with the current font for proofing |
+| **Grow** | Grows strokes out of the backbones to fill whitespace (constant-gap inflation), with layered Y2K keylines; save as PNG/SVG |
 
 ## Documentation
 
@@ -46,6 +47,7 @@ The [Dactyl Live Explorer](https://terryspitz.github.io/dactyl-font) runs entire
 - [DactylSpline Documentation](docs/DactylSpline.md) — The DactylSpline curve implementation
 - [DactylSpline Optimization Suggestions](docs/suggestions.md) — Ideas for improving the spline solver
 - [Font Rendering Pipeline](docs/FontPipeline.md) — Spine → outline → SVG pipeline, caps, serifs, and font export
+- [Growing Fonts](docs/growth-brainstorm.md) — Design notes for the **Grow** tab and future generative-growth directions
 - [TODO](docs/TODO.md) — Planned features and known issues
 - [Developing](DEVELOPING.md) — Building, running, testing, and contributing
 

--- a/docs/ExplorerGuide.md
+++ b/docs/ExplorerGuide.md
@@ -9,7 +9,7 @@ The [Dactyl Live Explorer](https://terryspitz.github.io/dactyl-font) lets you de
 ```
 ┌──────────────┬──────────────────────────────────────────┐
 │              │  [Font][Glyphs][Tweens][Visual Diffs]    │
-│   Sidebar    │  [Splines][Spline Grid][Proofs]  [ ⬇ ]  │
+│   Sidebar    │  [Splines][Spline Grid][Proofs][Grow] [⬇]│
 │  (Controls)  │                                           │
 │              │              Preview area                 │
 │              │                                           │
@@ -120,6 +120,33 @@ Renders the font using professionally designed proof texts (sourced from [typogr
 
 The Proofs tab renders using a live CSS `@font-face` built from the current axes, so it reflects the real typeset appearance (not SVG outlines).
 
+### Grow
+Grows the letterforms out of the current backbones — an experimental generative
+mode inspired by Namco's *Techno Drive* (1998) logotype.  Instead of offsetting
+each spine by a fixed thickness, every stroke swells into the surrounding
+whitespace until the channel between it and the nearest *opposing* stroke
+narrows to a constant gap.  Counters (the holes in `a`, `e`, `o`) stay open
+because the opposing stroke pushes back, while joints (`n`, `e`) don't pinch.
+All the usual axes still apply, since growth starts from the same backbones.
+
+**Controls in the top bar:**
+| Control | Effect |
+|---------|--------|
+| `grow` | 0 = classic constant offset … 1 = full space-filling bulge |
+| `gap` | Whitespace channel preserved between opposing strokes |
+| `layers` | Emit nested keyline bands (near-white core → light blue → dark blue → black keyline) that fuse between glyphs for a Y2K logotype look |
+| `animate` | Ramp the growth up and down so the letters visibly grow (WebGL only) |
+
+**Save controls** (top bar, right): a **copy** icon copies the result as a
+transparent PNG to the clipboard, and a **download** icon saves a PNG by
+default — its caret dropdown offers PNG (transparent, high-res) or SVG (vector).
+
+The preview renders on the GPU where WebGL2 is available: the worker computes a
+distance field once per text/axes change and a fragment shader thresholds it,
+so dragging `grow`/`gap`/`layers` never re-runs the worker.  Without WebGL2 it
+falls back to a worker-rendered SVG.  Multi-line text is supported; a
+determinate progress bar shows while the field is (re)built.
+
 ---
 
 ## URL parameters
@@ -128,7 +155,7 @@ All tabs and settings are bookmarkable via URL parameters.
 
 | Parameter | Values | Effect |
 |-----------|--------|--------|
-| `?view=` | `font` `glyphs` `tweens` `visualDiffs` `splines` `splineGrid` `proofs` | Open the named tab on load |
+| `?view=` | `font` `glyphs` `tweens` `visualDiffs` `splines` `splineGrid` `proofs` `grow` | Open the named tab on load |
 | `?zoom=` | e.g. `0.85` | Set initial zoom level for all tabs |
 | `?proof=` | `lowercase` `uppercase` `alphabet` `classic` | Select a proof preset |
 | `?book=` | integer index | Pre-select a specific classic book |
@@ -146,6 +173,11 @@ web/
 │   ├── App.jsx           — Root React component; tab routing, sidebar, worker orchestration
 │   ├── SplineEditor.jsx  — Interactive spline editor (Splines tab)
 │   ├── SplineGrid.jsx    — Grid view of spline shapes (Spline Grid tab)
+│   ├── GrowCanvas.jsx    — WebGL2 field-threshold preview (Grow tab)
+│   ├── growth.js         — Grow tab engine: distance field + marching-squares contours
+│   ├── growthSvg.js      — Grow tab back end: strokes → field / layered SVG (worker side)
+│   ├── glyphSpines.js    — Solves glyph backbones into polylines (Grow tab seed geometry)
+│   ├── growthExport.js   — Grow tab PNG/SVG save + clipboard helpers
 │   ├── fontExport.js     — OTF font assembly via opentype.js + paper.js boolean union
 │   ├── fontExport.test.js — Vitest unit tests for font export
 │   ├── worker.js         — Web worker: calls Fable-compiled F# API off the main thread


### PR DESCRIPTION
Follow-up to #179 (the Grow tab), which shipped without user-facing docs. This adds them.

## Changes

**`README.md`**
- Add a **Grow** row to the Tabs table.
- Mention Grow in the tl;dr blurb.
- Link the growth design notes (`docs/growth-brainstorm.md`) from the Documentation list.

**`docs/ExplorerGuide.md`**
- New **Grow** section: what it does (constant-gap inflation from the backbones), the `grow` / `gap` / `layers` / `animate` controls, the copy-PNG / download-PNG-or-SVG save options, GPU-vs-SVG-fallback rendering, and the progress bar.
- Add the tab to the layout diagram.
- Add `grow` to the `?view=` URL-parameter values.
- List the new source files (`GrowCanvas.jsx`, `growth.js`, `growthSvg.js`, `glyphSpines.js`, `growthExport.js`) in the web directory map.

Docs-only — no code, no tests affected. `README.html` is generated at deploy time by the Pages workflow, so no HTML needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LosK2gRkUdR2E4F6se3SGf)_