### PR TITLE
Add real progress bar for Visual Diffs compare-font mode

### DIFF
--- a/src/explorer/Api.fs
+++ b/src/explorer/Api.fs
@@ -597,7 +597,7 @@ let solveSplineGrid () =
                                error = error |})
     results.ToArray()
 
-let generateFontGlyphData (axes: Axes) =
+let generateFontGlyphData (axes: Axes) (progress: (float -> unit) option) =
     let fontAxes = { axes with outline = true; filled = true }
     let font = Font fontAxes
     let metrics = FontMetrics(axes)
@@ -610,9 +610,18 @@ let generateFontGlyphData (axes: Axes) =
     // does not trigger O(n²) NelderMead; cached on the font instance.
     let outlineFont = font.outlineFont
 
+    let totalChars = chars.Length
+    let mutable charCount = 0
+
     let glyphs =
         chars
         |> Seq.map (fun c ->
+            charCount <- charCount + 1
+
+            match progress with
+            | Some p -> p (float charCount / float totalChars)
+            | None -> ()
+
             try
                 let outline = font.CharToOutline c
                 let svg, _, _ = outlineFont.elementToSvg outline

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -653,7 +653,6 @@ function App() {
   useEffect(() => {
     if (activeTab !== 'visualDiffs' || compareMode !== 'font') return
     const worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' })
-    const id = ++renderIdRef.current
     setLoading(true)
     loadingRef.current = true
     setShowProgress(false)
@@ -661,13 +660,17 @@ function App() {
 
     // generateFontGlyphData has no progress callback, so this is a plain
     // (debounced) indeterminate spinner rather than a tracked percentage.
+    // Staleness here is only about *this* effect's own axes/mode changes, so
+    // a locally-scoped worker (cancelled via terminate() in cleanup) is the
+    // right guard — renderIdRef is shared with unrelated effects (e.g. the
+    // main render effect bumps it on every text change too) and would drop
+    // this effect's still-valid, still-in-flight response.
     const timer = setTimeout(() => {
-      if (id === renderIdRef.current && loadingRef.current) setShowProgress(true)
+      if (loadingRef.current) setShowProgress(true)
     }, 400)
 
     worker.onmessage = (e) => {
-      const { id: msgId, result, error } = e.data
-      if (msgId !== renderIdRef.current) return
+      const { result, error } = e.data
       clearTimeout(timer)
       worker.terminate()
       if (error) setCompareError(error)
@@ -676,7 +679,7 @@ function App() {
       loadingRef.current = false
       setShowProgress(false)
     }
-    worker.postMessage({ id, type: 'fontData', args: [axes] })
+    worker.postMessage({ id: ++renderIdRef.current, type: 'fontData', args: [axes] })
     return () => {
       clearTimeout(timer)
       worker.terminate()

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -383,7 +383,8 @@ function App() {
     setDownloadingFont(true)
     const worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' })
     worker.onmessage = (e) => {
-      const { result, error } = e.data
+      const { result, error, type } = e.data
+      if (type === 'progress') return
       worker.terminate()
       setDownloadingFont(false)
       if (error) {

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -653,14 +653,34 @@ function App() {
   useEffect(() => {
     if (activeTab !== 'visualDiffs' || compareMode !== 'font') return
     const worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' })
+    const id = ++renderIdRef.current
+    setLoading(true)
+    loadingRef.current = true
+    setShowProgress(false)
+    setProgressValue(0)
+
+    // generateFontGlyphData has no progress callback, so this is a plain
+    // (debounced) indeterminate spinner rather than a tracked percentage.
+    const timer = setTimeout(() => {
+      if (id === renderIdRef.current && loadingRef.current) setShowProgress(true)
+    }, 400)
+
     worker.onmessage = (e) => {
-      const { result, error } = e.data
+      const { id: msgId, result, error } = e.data
+      if (msgId !== renderIdRef.current) return
+      clearTimeout(timer)
       worker.terminate()
       if (error) setCompareError(error)
-      else setDactylGlyphData(result)
+      else { setDactylGlyphData(result); setCompareError(null) }
+      setLoading(false)
+      loadingRef.current = false
+      setShowProgress(false)
     }
-    worker.postMessage({ id: ++renderIdRef.current, type: 'fontData', args: [axes] })
-    return () => worker.terminate()
+    worker.postMessage({ id, type: 'fontData', args: [axes] })
+    return () => {
+      clearTimeout(timer)
+      worker.terminate()
+    }
   }, [axes, activeTab, compareMode])
 
   // Vector overlay SVG (outline sources). Rebuilt when the font, alignment,

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -658,19 +658,23 @@ function App() {
     setShowProgress(false)
     setProgressValue(0)
 
-    // generateFontGlyphData has no progress callback, so this is a plain
-    // (debounced) indeterminate spinner rather than a tracked percentage.
-    // Staleness here is only about *this* effect's own axes/mode changes, so
-    // a locally-scoped worker (cancelled via terminate() in cleanup) is the
-    // right guard — renderIdRef is shared with unrelated effects (e.g. the
-    // main render effect bumps it on every text change too) and would drop
-    // this effect's still-valid, still-in-flight response.
+    // Debounced so a fast regeneration doesn't flash the bar. Staleness here
+    // is only about *this* effect's own axes/mode changes, so a locally-scoped
+    // worker (cancelled via terminate() in cleanup) is the right guard —
+    // renderIdRef is shared with unrelated effects (e.g. the main render
+    // effect bumps it on every text change too) and would drop this effect's
+    // still-valid, still-in-flight response.
     const timer = setTimeout(() => {
       if (loadingRef.current) setShowProgress(true)
     }, 400)
 
     worker.onmessage = (e) => {
-      const { result, error } = e.data
+      const { result, error, type, value } = e.data
+      if (type === 'progress') {
+        setProgressValue(value)
+        if (value > 0) setShowProgress(true)
+        return
+      }
       clearTimeout(timer)
       worker.terminate()
       if (error) setCompareError(error)

--- a/web/src/glyphSpines.js
+++ b/web/src/glyphSpines.js
@@ -70,7 +70,7 @@ export function glyphToSpines(char, axes, spacing = 8) {
 /// onProgress(frac 0..1) is called after each glyph is solved (solving each
 /// glyph's splines via the Fable API is the dominant cost of growth).
 export function textToStrokes(text, axes, spacing = 8, onProgress) {
-    const fontData = generateFontGlyphData(axes)
+    const fontData = generateFontGlyphData(axes, undefined)
     const advance = new Map()
     for (const g of fontData.glyphs) advance.set(g.unicode, g.advanceWidth)
 

--- a/web/src/worker.js
+++ b/web/src/worker.js
@@ -94,12 +94,14 @@ self.onmessage = (e) => {
             }
             case 'fontData': {
                 const [fontAxes] = args
-                result = generateFontGlyphData(fontAxes)
+                result = generateFontGlyphData(fontAxes, (p) => {
+                    self.postMessage({ id, type: 'progress', value: p });
+                })
                 break
             }
             case 'fontPreview': {
                 const [fontAxes] = args
-                result = buildFontDataUrl(generateFontGlyphData(fontAxes), 'DactylPreview')
+                result = buildFontDataUrl(generateFontGlyphData(fontAxes, undefined), 'DactylPreview')
                 break
             }
             case 'splineOutline': {


### PR DESCRIPTION
## Summary
- Fixes a bug reported on the Visual Diffs tab in "Compare font" mode (e.g. comparing against a Google Font): dragging the height axis sometimes showed no progress bar, sometimes showed a stuck indeterminate spinner looping forever.
- Root cause: the effect that regenerates Dactyl's outlines for this mode (`web/src/App.jsx`, the dedicated `fontData` worker effect) never touched the shared `loading`/`showProgress` state at all. The progress bar just reflected whatever was left over from some unrelated previous render — stuck true if it had been left on, invisible if it hadn't — regardless of the actual (sometimes lengthy) regeneration in flight.
- A first fix wired this effect into the existing debounced *indeterminate* spinner pattern (mirroring the Grow tab's GPU field-rebuild effect), since `generateFontGlyphData` had no way to report a real percentage.
- Follow-up (this PR now also includes): added a real progress callback to `generateFontGlyphData` itself (`src/explorer/Api.fs`), invoked once per character, mirroring `generateSvg`'s existing `progress` parameter. The compare-font effect now reports genuine determinate progress (tracked percentage) instead of an indeterminate spinner, matching how every other tab's progress bar behaves. Other callers (`fontPreview`, the Grow tab's `textToStrokes`) pass no callback, so their behavior is unchanged.
- Along the way, also fixed a regression the first attempt introduced: an added staleness guard compared the worker's response id against a globally-shared `renderIdRef` counter that unrelated effects also bump (e.g. on every text change), which could drop this effect's still-valid in-flight response and hang the app (caught by CI: `font-compare.spec.js` timed out waiting for `.svg-container svg`). Fixed by relying solely on `worker.terminate()` in this effect's own cleanup, which already fully covers its own staleness.

## Test plan
- [x] `npx vitest run` (50 passed)
- [x] `dotnet test src/generator/tests/generator.tests.fsproj` (96 passed)
- [x] Reproduced the original bug against the pre-fix code with a Playwright script that drags the height slider in `?view=visualDiffs&compare=font` and samples `.progress-bar-container` — confirmed it never appears (matches "no progress bar" symptom).
- [x] Verified the final fix with a fine-grained Playwright trace showing the determinate bar's width climbing smoothly (e.g. 1% → 3% → 7% → ... → 88%) during the initial compare-font regeneration — confirms real, monotonically increasing progress rather than a spinner or stuck state.
