### PR TITLE
Add SIL OFL font license and headless OTF QA (fontbakery) tooling

### DIFF
--- a/FONTLICENSE.md
+++ b/FONTLICENSE.md
@@ -30,19 +30,28 @@ We deliberately chose the OFL over Creative Commons for the fonts because:
 
 ### Reserved Font Name
 
-`OFL.txt` currently declares **no Reserved Font Name**, which keeps the fonts
-eligible for Google Fonts (Google refuses fonts that reserve a name).
+`OFL.txt` reserves **"Dactyl"** as a Reserved Font Name. This means anyone who
+ships a *modified* version of the fonts must release it under a different
+primary family name — the word "Dactyl" cannot appear in a derivative's name.
+This protects the name so that a font called "Dactyl" always means the design
+released here, not someone else's altered copy. As the copyright holder, this
+restriction does not apply to your own releases.
 
-If you would rather stop others from shipping modified fonts under the
-"Dactyl" name, add a reserved-name line to the copyright block in `OFL.txt`:
+**Google Fonts caveat:** Google Fonts refuses fonts that carry a Reserved Font
+Name, because its build pipeline needs to rebuild and rename freely. So the
+reserved name and a Google Fonts listing are mutually exclusive *for the same
+files*.
+
+The OFL permits the same design to be distributed under separate copyright
+notices, so if you later want to put a family on Google Fonts, make a copy of
+`OFL.txt` for that distribution with the Reserved Font Name line removed:
 
 ```
-Copyright 2020 The Dactyl Project Authors ..., with Reserved Font Name "Dactyl".
+Copyright 2020 The Dactyl Project Authors (...)
 ```
 
-Note that doing so means the flagship family cannot be submitted to Google
-Fonts under that name — the two goals are mutually exclusive, so decide per
-distribution channel.
+Keep the RFN on your own releases (this repo, your site, dafont, FontSpace);
+drop it only on the specific copy submitted to Google Fonts.
 
 ## The proofs and prose → Creative Commons BY-NC-SA 4.0
 

--- a/FONTLICENSE.md
+++ b/FONTLICENSE.md
@@ -1,0 +1,61 @@
+# Licensing
+
+Dactyl is two different kinds of work in one repository, so it uses two
+licenses. Which one applies depends on *what* you are reusing.
+
+## The fonts and the generator → SIL Open Font License 1.1
+
+The generated font files (OTF/TTF) and the source that produces them are
+licensed under the **SIL Open Font License, Version 1.1** — see
+[`OFL.txt`](OFL.txt).
+
+The OFL is the standard licence for libre/freeware fonts. In short, you may
+use, study, modify, embed and redistribute the fonts freely — including in
+commercial products and documents — provided that:
+
+- you don't sell the fonts *on their own*;
+- derivative fonts stay under the OFL and carry the copyright notice;
+- derivatives don't use a Reserved Font Name (see below).
+
+We deliberately chose the OFL over Creative Commons for the fonts because:
+
+- CC licences were designed for creative works (images, prose), not for
+  software or fonts, and map awkwardly onto font *embedding*.
+- The OFL is what the font ecosystem expects. It is the entry requirement for
+  **Google Fonts** and is understood by every major freeware distributor
+  (dafont, FontSpace, Fontshare, …).
+- A **NonCommercial** CC clause (as previously used, see below) would make the
+  fonts ineligible for Google Fonts and most freeware sites, and leaves users
+  unsure whether embedding in a commercial document is allowed.
+
+### Reserved Font Name
+
+`OFL.txt` currently declares **no Reserved Font Name**, which keeps the fonts
+eligible for Google Fonts (Google refuses fonts that reserve a name).
+
+If you would rather stop others from shipping modified fonts under the
+"Dactyl" name, add a reserved-name line to the copyright block in `OFL.txt`:
+
+```
+Copyright 2020 The Dactyl Project Authors ..., with Reserved Font Name "Dactyl".
+```
+
+Note that doing so means the flagship family cannot be submitted to Google
+Fonts under that name — the two goals are mutually exclusive, so decide per
+distribution channel.
+
+## The proofs and prose → Creative Commons BY-NC-SA 4.0
+
+The proof texts under [`proofs/`](proofs/) remain under
+**Creative Commons Attribution-NonCommercial-ShareAlike 4.0** — see
+[`proofs/license.md`](proofs/license.md). These are sample writing used to
+show the fonts, not part of the Font Software, so the NonCommercial clause
+there does **not** restrict commercial use of the fonts themselves.
+
+## Summary
+
+| What you're reusing | Licence |
+|---------------------|---------|
+| Font files (OTF/TTF) | SIL OFL 1.1 |
+| Font generator source (F#, JS build) | SIL OFL 1.1 |
+| Proof texts in `proofs/` | CC BY-NC-SA 4.0 |

--- a/FONTLICENSE.md
+++ b/FONTLICENSE.md
@@ -47,7 +47,7 @@ notices, so if you later want to put a family on Google Fonts, make a copy of
 `OFL.txt` for that distribution with the Reserved Font Name line removed:
 
 ```
-Copyright 2020 The Dactyl Project Authors (...)
+Copyright 2020 Terry Spitz (...)
 ```
 
 Keep the RFN on your own releases (this repo, your site, dafont, FontSpace);

--- a/OFL.txt
+++ b/OFL.txt
@@ -1,4 +1,4 @@
-Copyright 2020 The Dactyl Project Authors (https://github.com/terryspitz/dactyl-font),
+Copyright 2020 Terry Spitz (https://github.com/terryspitz/dactyl-font),
 with Reserved Font Name "Dactyl".
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.

--- a/OFL.txt
+++ b/OFL.txt
@@ -1,0 +1,90 @@
+Copyright 2020 The Dactyl Project Authors (https://github.com/terryspitz/dactyl-font)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply to any
+document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical writer or
+other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components, in
+Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or in
+the appropriate machine-readable metadata fields within text or binary
+files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any Modified
+Version, except to acknowledge the contribution(s) of the Copyright
+Holder(s) and the Author(s) or with their explicit written permission.
+
+5) The Font Software, modified or unmodified, in part or in whole, must be
+distributed entirely under this license, and must not be distributed under
+any other license. The requirement for fonts to remain under this license
+does not apply to any document created using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are not
+met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER
+DEALINGS IN THE FONT SOFTWARE.

--- a/OFL.txt
+++ b/OFL.txt
@@ -1,4 +1,5 @@
-Copyright 2020 The Dactyl Project Authors (https://github.com/terryspitz/dactyl-font)
+Copyright 2020 The Dactyl Project Authors (https://github.com/terryspitz/dactyl-font),
+with Reserved Font Name "Dactyl".
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:

--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ On letter spacing, tracking and kerning:
 - [Typography.com: Turning Type Sideways](https://www.typography.com/blog/turning-type-sideways)
 - [Google Fonts](https://design.google/library/google-fonts)
 
+## License
+
+The fonts and the generator that produces them are licensed under the
+[SIL Open Font License 1.1](OFL.txt). The proof texts under `proofs/` remain
+under CC BY-NC-SA 4.0. See [FONTLICENSE.md](FONTLICENSE.md) for why the two
+differ and what it means for reuse.
+
 ## Where It All Started
 
 [Donald Knuth's MetaFont paper](http://www.math.lsa.umich.edu/~millerpd/docs/501_Winter13/Knuth79.pdf)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -20,6 +20,19 @@
 -  balance (mid height > 1/2)
 - debug 'sharp bend' duplicate points in 'e'
 -
+**Publishing to freeware font sites** (see FONTLICENSE.md)
+- licensing: fonts under SIL OFL 1.1 with Reserved Font Name "Dactyl" (done); proofs stay CC BY-NC-SA
+- exporter now produces fontbakery-clean OTFs (name table, version, .notdef, nbspace) — done
+- curate a small flagship family (a few static styles) to submit; do NOT bulk-submit generated variants — dafont/FontSpace review by hand and flag mass/duplicate uploads
+- host the full generated corpus on GitHub/Pages instead (bulk is fine there)
+- add kerning (GPOS) — currently a fontbakery WARN (see "calculate kerning" above)
+- run fontbakery in CI against exported OTFs to catch regressions
+- Google Fonts submission (highest-value channel, separate packaging effort):
+  - make an RFN-stripped copy of OFL.txt for the GF distribution (Google refuses Reserved Font Names)
+  - add METADATA.pb, DESCRIPTION.en_us.html / article/, and a reproducible open-source build of the OTF from source
+  - sign the Google Contributor License Agreement
+- submit curated fonts to dafont and FontSpace for reach
+
 **DONE: Implemented Features**
 - add documentation links
 - add punctuation chars

--- a/web/scripts/buildOtf.mjs
+++ b/web/scripts/buildOtf.mjs
@@ -1,0 +1,12 @@
+// Headless OTF builder: runs the same Fable API + opentype.js pipeline the
+// browser uses, so we can produce a real font file for QA (fontbakery) offline.
+// Usage: node scripts/buildOtf.mjs [outPath]
+import { writeFileSync } from 'node:fs'
+import { generateFontGlyphData, defaultAxes } from '../src/lib/fable/Api.js'
+import { buildFont } from '../src/fontExport.js'
+
+const out = process.argv[2] || '/tmp/Dactyl-Regular.otf'
+const glyphData = generateFontGlyphData(defaultAxes, undefined)
+const font = buildFont(glyphData, 'Dactyl', 'Regular')
+writeFileSync(out, Buffer.from(font.toArrayBuffer()))
+console.log(`wrote ${out} (${glyphData.glyphs.length} glyphs)`)

--- a/web/src/fontExport.js
+++ b/web/src/fontExport.js
@@ -343,7 +343,8 @@ export function buildFont(glyphData, familyName = 'Dactyl', styleName = 'Regular
     version: FONT_VERSION,
     copyright: COPYRIGHT,
     designer: 'Terry Spitz',
-    designerURL: 'https://github.com/terryspitz/dactyl-font',
+    // Points at the live Explorer site; the source repo is in the copyright.
+    designerURL: 'https://terryspitz.github.io/dactyl-font',
     manufacturer: 'Terry Spitz',
     license: 'This Font Software is licensed under the SIL Open Font License, Version 1.1.',
     licenseURL: 'https://openfontlicense.org',

--- a/web/src/fontExport.js
+++ b/web/src/fontExport.js
@@ -257,6 +257,24 @@ function buildFilename(overrides, family = 'Dactyl') {
 // issue #115.  We scale every coordinate and metric to this em on export.
 const EXPORT_UPM = 1000
 
+// Font metadata, kept in sync with OFL.txt at the repo root.  fontbakery's
+// Google Fonts profile compares the embedded copyright/version against these,
+// so any change here must match the licence file.
+const COPYRIGHT =
+  'Copyright 2020 Terry Spitz (https://github.com/terryspitz/dactyl-font), with Reserved Font Name "Dactyl".'
+const FONT_VERSION = 1.0
+const VERSION_STRING = 'Version 1.000'
+
+// A visible outline for .notdef (a hollow box), which OpenType requires to be a
+// real drawing rather than blank — the inner contour winds opposite the outer
+// so the non-zero fill leaves it hollow.
+function notdefPath() {
+  const p = new opentype.Path()
+  p.moveTo(80, 0); p.lineTo(520, 0); p.lineTo(520, 700); p.lineTo(80, 700); p.close()
+  p.moveTo(160, 80); p.lineTo(160, 620); p.lineTo(440, 620); p.lineTo(440, 80); p.close()
+  return p
+}
+
 /**
  * Build an opentype.Font from the glyph data returned by generateFontGlyphData.
  * Coordinates from the F# generator are already Y-up (baseline at 0, positive
@@ -270,49 +288,77 @@ export function buildFont(glyphData, familyName = 'Dactyl', styleName = 'Regular
   const scale = EXPORT_UPM / unitsPerEm
   const s = (n) => Math.round(n * scale)
 
+  const charGlyphs = glyphsData
+    .filter(g => g.unicode >= 32 && (g.pathData || g.unicode === 32))
+    .sort((a, b) => a.unicode - b.unicode)
+    .filter((g, i, arr) => i === 0 || g.unicode !== arr[i - 1].unicode)
+    .map(g => {
+      const path = new opentype.Path()
+      for (const cmd of unionPath(g.pathData)) {
+        switch (cmd.type) {
+          case 'M': path.moveTo(s(cmd.x), s(cmd.y)); break
+          case 'L': path.lineTo(s(cmd.x), s(cmd.y)); break
+          case 'C': path.bezierCurveTo(s(cmd.x1), s(cmd.y1), s(cmd.x2), s(cmd.y2), s(cmd.x), s(cmd.y)); break
+          case 'Z': path.close(); break
+        }
+      }
+      return new opentype.Glyph({
+        name: `uni${g.unicode.toString(16).padStart(4, '0')}`,
+        unicode: g.unicode,
+        advanceWidth: s(g.advanceWidth),
+        path,
+      })
+    })
+
+  // U+00A0 no-break space: required whitespace glyph, drawn as an empty outline
+  // with the same advance as the regular space (U+0020) so the two match.
+  const space = charGlyphs.find(g => g.unicode === 32)
+  if (space) {
+    charGlyphs.push(new opentype.Glyph({
+      name: 'uni00a0',
+      unicode: 0x00a0,
+      advanceWidth: space.advanceWidth,
+      path: new opentype.Path(),
+    }))
+  }
+
+  // opentype.js derives hhea.advanceWidthMax from the character glyphs, so give
+  // .notdef the same max advance rather than a wider one that would make hmtx
+  // and hhea disagree.
+  const maxAdvance = charGlyphs.reduce((m, g) => Math.max(m, g.advanceWidth), 0)
   const notdef = new opentype.Glyph({
     name: '.notdef',
-    advanceWidth: Math.round(EXPORT_UPM / 2),
-    path: new opentype.Path(),
+    advanceWidth: maxAdvance,
+    path: notdefPath(),
   })
 
-  const glyphs = [
-    notdef,
-    ...glyphsData
-      .filter(g => g.unicode >= 32 && (g.pathData || g.unicode === 32))
-      .sort((a, b) => a.unicode - b.unicode)
-      .filter((g, i, arr) => i === 0 || g.unicode !== arr[i - 1].unicode)
-      .map(g => {
-        const path = new opentype.Path()
-        for (const cmd of unionPath(g.pathData)) {
-          switch (cmd.type) {
-            case 'M': path.moveTo(s(cmd.x), s(cmd.y)); break
-            case 'L': path.lineTo(s(cmd.x), s(cmd.y)); break
-            case 'C': path.bezierCurveTo(s(cmd.x1), s(cmd.y1), s(cmd.x2), s(cmd.y2), s(cmd.x), s(cmd.y)); break
-            case 'Z': path.close(); break
-          }
-        }
-        return new opentype.Glyph({
-          name: `uni${g.unicode.toString(16).padStart(4, '0')}`,
-          unicode: g.unicode,
-          advanceWidth: s(g.advanceWidth),
-          path,
-        })
-      }),
-  ]
+  const glyphs = [notdef, ...charGlyphs]
 
-  return new opentype.Font({
+  const font = new opentype.Font({
     familyName,
     styleName,
     unitsPerEm: EXPORT_UPM,
     ascender: s(ascender),
     descender: s(descender),
-    copyright: `Copyright ${new Date().getFullYear()} Terry Spitz`,
+    version: FONT_VERSION,
+    copyright: COPYRIGHT,
     designer: 'Terry Spitz',
+    designerURL: 'https://github.com/terryspitz/dactyl-font',
+    manufacturer: 'Terry Spitz',
     license: 'This Font Software is licensed under the SIL Open Font License, Version 1.1.',
     licenseURL: 'https://openfontlicense.org',
     glyphs,
   })
+
+  // opentype.js 1.3.4 fills every unset name field with a single space, which
+  // fontbakery flags as empty / trailing-whitespace records.  Drop the ones we
+  // don't populate, and set explicit version and unique-id strings (the latter
+  // is otherwise built from the now-removed manufacturer field).
+  for (const key of ['manufacturerURL', 'description', 'trademark']) delete font.names[key]
+  font.names.version = { en: VERSION_STRING }
+  font.names.uniqueID = { en: `1.000;Terry Spitz;${familyName}-${styleName}` }
+
+  return font
 }
 
 /**

--- a/web/src/fontExport.test.js
+++ b/web/src/fontExport.test.js
@@ -200,6 +200,12 @@ describe('buildFont metadata (fontbakery requirements)', () => {
     expect(copyright).toContain('Reserved Font Name "Dactyl"')
   })
 
+  it('links the designer URL to the live site and the repo in the copyright', () => {
+    const names = buildFont(glyphData).names
+    expect(names.designerURL.en).toBe('https://terryspitz.github.io/dactyl-font')
+    expect(names.copyright.en).toContain('https://github.com/terryspitz/dactyl-font')
+  })
+
   it('includes a U+00A0 no-break space matching the space advance', () => {
     const font = buildFont(glyphData)
     const space = font.glyphs.get(font.charToGlyphIndex(' '))

--- a/web/src/fontExport.test.js
+++ b/web/src/fontExport.test.js
@@ -161,3 +161,61 @@ describe('buildFont em normalisation', () => {
     expect(bb.y2 - bb.y1).toBe(100) // 200 * 0.5
   })
 })
+
+describe('buildFont metadata (fontbakery requirements)', () => {
+  // Glyph data including a space (U+0020), so buildFont adds the required
+  // no-break space and picks up a real advance width for it.
+  const glyphData = {
+    unitsPerEm: 1000,
+    ascender: 700,
+    descender: -300,
+    glyphs: [
+      { unicode: 32, advanceWidth: 250, pathData: '' },
+      { unicode: 65, advanceWidth: 400, pathData: 'M 0,0 L 100,0 L 100,200 L 0,200 Z' },
+      { unicode: 66, advanceWidth: 520, pathData: 'M 0,0 L 100,0 L 100,200 L 0,200 Z' },
+    ],
+  }
+
+  // opentype.js 1.3.4 defaults every unset name field to a single space, which
+  // fontbakery flags as empty / trailing-whitespace records.
+  it('emits no empty or whitespace-only name records', () => {
+    const names = buildFont(glyphData).names
+    for (const [key, langs] of Object.entries(names)) {
+      for (const value of Object.values(langs)) {
+        expect(value, key).toBeTruthy()
+        expect(value.trim(), key).not.toBe('')
+      }
+    }
+  })
+
+  it('sets matching version strings and a unique id', () => {
+    const names = buildFont(glyphData).names
+    expect(names.version.en).toBe('Version 1.000')
+    expect(names.uniqueID.en).toContain('1.000')
+  })
+
+  it('embeds the OFL copyright with the reserved font name', () => {
+    const copyright = buildFont(glyphData).names.copyright.en
+    expect(copyright).toContain('Terry Spitz')
+    expect(copyright).toContain('Reserved Font Name "Dactyl"')
+  })
+
+  it('includes a U+00A0 no-break space matching the space advance', () => {
+    const font = buildFont(glyphData)
+    const space = font.glyphs.get(font.charToGlyphIndex(' '))
+    const nbsp = font.glyphs.get(font.charToGlyphIndex(' '))
+    expect(nbsp).toBeTruthy()
+    expect(nbsp.unicode).toBe(0x00a0)
+    expect(nbsp.advanceWidth).toBe(space.advanceWidth)
+  })
+
+  it('gives .notdef a real outline and no wider advance than the widest glyph', () => {
+    const font = buildFont(glyphData)
+    const notdef = font.glyphs.get(0)
+    expect(notdef.name).toBe('.notdef')
+    expect(notdef.path.commands.length).toBeGreaterThan(0)
+    // Widest character glyph here is 'B' at 520; .notdef must not exceed it, or
+    // hmtx and hhea.advanceWidthMax disagree.
+    expect(notdef.advanceWidth).toBe(520)
+  })
+})


### PR DESCRIPTION
Groundwork for publishing generated Dactyl fonts to freeware font sites: licensing + an exporter that produces fontbakery-clean OTFs.

## Licensing

- **`OFL.txt`** — SIL Open Font License 1.1 covering the fonts and the generator, copyright **Terry Spitz**, with **"Dactyl"** reserved as a Reserved Font Name.
- **`FONTLICENSE.md`** — explains the two-license split (fonts/generator under OFL; `proofs/` prose stays under CC BY-NC-SA) and how to make an RFN-free copy of `OFL.txt` if a family is later submitted to Google Fonts (Google refuses RFNs).
- **`README.md`** — new License section pointing at both.

## Exporter fixes (`web/src/fontExport.js`)

Made the exported OTF pass the fontbakery **Google Fonts** profile (236 checks) with **no FAILs**:

| Check | Was | Fix |
|-------|-----|-----|
| `opentype/name/empty_records`, `name/trailing_spaces` | FAIL | drop the whitespace-only name records opentype.js 1.3.4 emits for unset fields; populate designer/manufacturer/URLs; set an explicit unique id |
| `opentype/font_version` | FAIL | set font version 1.0 so `head.fontRevision` matches the `Version 1.000` name string |
| `mandatory_glyphs` | FAIL | give `.notdef` a hollow-box outline, capped at the widest glyph's advance so hmtx/hhea agree |
| `whitespace_glyphs` | FAIL | add U+00A0 no-break space matching the space advance |
| copyright | — | embed the full OFL notice, aligned with `OFL.txt` |

Remaining: one `gpos_kerning_info` **WARN** (Dactyl has no kerning — inherent, and Google Fonts accepts it) and three `ERROR`s that are environmental only (a proxy-blocked network check, plus two that need Google-Fonts *packaging* context — an `article/` dir and `METADATA.pb` — not applicable to a standalone file).

## QA tooling

- **`web/scripts/buildOtf.mjs`** — builds a Dactyl OTF headlessly through the same Fable + opentype.js pipeline the browser uses (`node scripts/buildOtf.mjs [outPath]`), so fonts can be QA'd offline with [fontbakery](https://fontbakery.readthedocs.io/).
- **`web/src/fontExport.test.js`** — new tests lock in the metadata guarantees (no empty name records, version consistency, nbspace width, `.notdef` outline/advance).

## Why OFL, not Creative Commons

CC was designed for creative works, not fonts, and a NonCommercial clause (as the proofs use) would make the fonts ineligible for Google Fonts and most freeware distributors. OFL is what the ecosystem expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194rmBCyBGqq2Mr21BvS7fe