### PR TITLE
Mark interior joints on 6, 9, Y, D glyphs

### DIFF
--- a/src/generator/GlyphStringDefs.fs
+++ b/src/generator/GlyphStringDefs.fs
@@ -71,13 +71,13 @@ let glyphMap =
           '3', "tol~t(c)~(th)r~hc-hllr hllr-hc~(bh)r~b(c)~bol"
           '4', "br3l-tr3l-bhl-bhr"
           '5', "tr-tl-hl hl~ttb(c)~(bbt)r~b(c)~bol"
-          '6', "tor~t(c)~(h)l~bbtl~b(c)~bbtr~ttbc~bbtlN"
+          '6', "tor~t(c)~(h)l~bbtl~b(c)~bbtr~ttbc~bbtlNj"
           '7', "tl-tr-bcl"
           //  two loops:
           //  '8', "hc~thl~tc~thr~ hc~bhl~bc~bhr~"
           // figure of eight:
           '8', "hc~(th)l~t(c)~(th)r~hc~(bh)l~b(c)~(bh)r~"
-          '9', "bol~b(c)~(h)r~ttbr~t(c)~ttbl~bbtc~ttbrS"
+          '9', "bol~b(c)~(h)r~ttbr~t(c)~ttbl~bbtc~ttbrSj"
 
           'A', "bl-tc-br bhlcj-bhrcj"
           'a', "xr-br xor~x(c)~(xb)l~b(c)~bor"
@@ -85,7 +85,7 @@ let glyphMap =
           'b', "tl-bl bol~b(c)~(xb)r~x(c)~xol"
           'C', "tor~t(c)~(h)l~b(c)~bor"
           'c', "xor~x(c)~(xb)l~b(c)~bor"
-          'D', "tl-bl-blo~(h)r~tlo-tl"
+          'D', "tl-bl-blo~(h)r~tlo-tlj"
           'd', "tr-br xor~x(c)~(xb)l~b(c)~bor"
           'E', "tr-tl-bl-br hl-hr"
           'e', "xbl-xbrN~x(c)~xblS~b(c)~bor5c"
@@ -127,7 +127,7 @@ let glyphMap =
           'w', "xl-bl3w-xlw-blw3-xw"
           'X', "tl-br tr-bl"
           'x', "xl-br xr-bl"
-          'Y', "tl-hc-tr hc-bc"
+          'Y', "tl-hc-tr hcj-bc"
           'y', "xl-xbl~b(c)~xbr-xr xr-br~d(c)~dol"
           'Z', "tl-tr-bl-br"
           'z', "xl-xr-bl-br" ]


### PR DESCRIPTION
## Summary

Adds the explicit `j` interior-joint marker to four glyphs, at the endpoints that land in the **middle of another stroke** rather than at a free terminal:

| Glyph | Point | Where |
|-------|-------|-------|
| `6` | `bbtlN` → `bbtlNj` | curl end tucked into the counter |
| `9` | `ttbrS` → `ttbrSj` | curl end tucked into the counter |
| `Y` | `hc` → `hcj` (stem stroke) | stem top where it meets the diagonals |
| `D` | `tl` → `tlj` (return point) | top-left corner where the bowl returns to the stem |

At an interior joint you don't want the stroke end decorated like a free terminal — a serif/flare/bulb poking out of the middle of the letter looks wrong. The `j` marker suppresses that cap and forces a clean cardinal-aligned corner instead (see `Font.isExplicitJoint` / the joint branch of `Font.cap`, and `docs/DactylGlyphs.md` §"Explicit Joints").

Only `src/generator/GlyphStringDefs.fs` changes (4 lines).

## Verification

- **F# unit tests**: all 98 pass (`dotnet test src/generator/tests`).
- **Rendered before/after** with serifs enabled (`serif = 30`) for each glyph. In every case the old definition produced a spurious serif stub at the interior join; the new definition renders a clean corner/terminal. The default sans (no-serif) rendering is unchanged and free of NaN artifacts.

Before (left) / after (right), serifs on — spurious serif stubs at the joins are removed:

- **D**: serif stub at the top-left corner → clean corner
- **Y**: serif nub at the stem/V junction → clean junction
- **9** / **6**: serif stub on the inner curl terminal → clean tucked terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Y3mL5mvygK3raj4T2rT9m

---
_Generated by [Claude Code](https://claude.ai/code/session_019Y3mL5mvygK3raj4T2rT9m)_