### PR TITLE
Fix broken internal documentation links on GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -39,13 +39,24 @@ jobs:
       - name: Convert Markdown to HTML
         uses: natescherer/markdown-to-html-with-github-style-action@v1.1.0
         with:
-          path: README.md
+          path: README.md,DEVELOPING.md,docs/ExplorerGuide.md,docs/DactylGlyphs.md,docs/DactylSpline.md,docs/suggestions.md,docs/FontPipeline.md,docs/growth-brainstorm.md,docs/TODO.md
           outputpath: web/dist
+          matchpathstructure: true
+      - name: Rewrite internal doc links from .md to .html
+        # The README and docs cross-link each other with .md paths (which work
+        # when browsing on GitHub). On GitHub Pages we serve the converted
+        # .html files, so rewrite relative .md links to .html in the generated
+        # HTML. Only relative links are touched (paths containing ':' such as
+        # https:// are skipped).
+        run: |
+          find web/dist -name '*.html' -exec \
+            sed -i -E 's@href="([^":]*)\.md("|#)@href="\1.html\2@g' {} +
       - name: copy static files
         run: |
           cp output/allGlyphs.html web/dist
           cp gallery.html web/dist
           cp -r png/ web/dist
+          cp docs/*.svg web/dist/docs/
       - name: Upload Artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Problem

The internal documentation links on https://terryspitz.github.io/dactyl-font/README.html don't work.

The `Deploy Pages` workflow converted **only** `README.md` to HTML and copied it into `web/dist`. The README's documentation links point at `docs/*.md` and `DEVELOPING.md`, none of which were converted or copied to the site — so every internal link 404'd. On top of that, `.md` links are served by GitHub Pages as raw text/downloads rather than rendered pages.

## Fix (in `.github/workflows/deploy-pages.yml`)

- **Convert the docs too:** `DEVELOPING.md` and all `docs/*.md` are now converted to HTML alongside `README.html`, using the action's `matchpathstructure: true` so `docs/` layout is preserved (`web/dist/docs/*.html`).
- **Copy doc assets:** `docs/*.svg` (embedded in `DactylGlyphs.md`) are copied into `web/dist/docs/` so images resolve.
- **Rewrite links:** a `sed` step rewrites relative `.md` links to `.html` in the generated HTML (handling `#anchor` fragments and cross-doc links). External `https://` links are left untouched, so the source Markdown keeps working `.md` links when browsed directly on GitHub.

The sed delimiter was tested against realistic generated-anchor forms (relative links, anchors, cross-links, and external links) to confirm only relative `.md` targets are rewritten.

## Verification

- `deploy-pages.yml` validated as well-formed YAML.
- Link-rewrite regex verified locally against sample HTML covering relative links, `#anchor` fragments, docs cross-links, and external `.html`/`.md` URLs — only relative `.md` targets were rewritten.

Full end-to-end confirmation happens when the workflow runs on merge to `main` (Pages deploy only triggers on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MaYdMv4dDj3YWRsbZVbZf

---
_Generated by [Claude Code](https://claude.ai/code/session_015MaYdMv4dDj3YWRsbZVbZf)_