### PR TITLE
Fix Deploy Pages failure: add H1 heading to docs/TODO.md

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,5 +1,5 @@
 
-**TODOs**
+# TODOs
 - Artistic axes (not yet implemented):
   - **pressure**: stroke width varies with curvature — tighter curves get thicker, straighter segments stay thin (mimics brush pressure). Tried (curvature-from-tangent-samples) but the result looked wrong/noisy; reverted. Needs a smoother curvature estimate.
   - **bounce**: per-glyph random vertical baseline displacement for hand-lettering feel


### PR DESCRIPTION
## Problem

After #193 merged, the `Deploy Pages` workflow started **failing** on `main` at the *Convert Markdown to HTML* step, so the site was never republished and the internal documentation links are still not live:

```
InvalidOperation: .../markdown-to-html-with-github-style-action/v1.1.0/src/steps/2_convert.ps1:28
  28 |  $Title = ($ContentArray | Where-Object {$_ -like "# *"}).Replace(…)
     |  You cannot call a method on a null-valued expression.
```

#193 added `docs/*.md` to the conversion list. The converter action derives each page's `<title>` from the file's first `# ` (H1) heading and throws when a file has none. `docs/TODO.md` started with bold text `**TODOs**` instead of a heading, which crashed the step and skipped the deploy entirely.

## Fix

Promote `docs/TODO.md`'s opening `**TODOs**` to an H1 heading (`# TODOs`). All other converted docs already have an H1, so this unblocks the deploy.

## Verification

- Confirmed the failing run's log points at the null-title crash and that every other doc in the conversion list (`README.md`, `DEVELOPING.md`, `docs/ExplorerGuide.md`, `docs/DactylGlyphs.md`, `docs/DactylSpline.md`, `docs/suggestions.md`, `docs/FontPipeline.md`, `docs/growth-brainstorm.md`) already begins with a `# ` heading — `TODO.md` was the only one missing it.
- Full end-to-end confirmation (links live) happens when `Deploy Pages` runs on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MaYdMv4dDj3YWRsbZVbZf

---
_Generated by [Claude Code](https://claude.ai/code/session_015MaYdMv4dDj3YWRsbZVbZf)_