### PR TITLE
Add per-glyph "randomise every glyph" mode to the Font tab

### DIFF
--- a/docs/ExplorerGuide.md
+++ b/docs/ExplorerGuide.md
@@ -25,7 +25,7 @@ The **sidebar** on the left holds all font axis controls.  The **top bar** holds
 ### Toolbar icons
 | Icon | Action |
 |------|--------|
-| ↺ Reset | Restore all axes to their default values |
+| ↺ Reset | Restore all axes to their default values (also clears per-glyph randomisation) |
 | 🎲 Randomize | Randomise all non-experimental axes |
 | 📖 Documentation | Open the README in a new tab |
 
@@ -50,6 +50,10 @@ Each axis shows a labelled slider (for numeric ranges) or a toggle switch (for b
 
 ### Font
 Renders the full character set (or whatever text is in the text box) using the current axis values.  Supports zoom via the +/−/↺ buttons or Ctrl+scroll.
+
+The **shuffle button** (🔀) in the top-right randomises *every glyph independently* — each character gets its own axis values, following the same rules as the sidebar 🎲 button but nudged around the current axes rather than the defaults (so the sliders still drive the overall look; `leading` is left alone as it is a line property, not a glyph one).
+
+The result is **stable**: clicking the button rolls a single seed, and every character's settings are derived from that seed plus its code point.  So a given letter looks the same everywhere it appears, and the variant font survives re-renders, sidebar tweaks and tab switches.  It also feeds the OTF export, the Proofs tab and the Visual Diffs font comparison.  Click again for a new set; the ✕ next to it (or the sidebar ↺ Reset) turns it off.
 
 The **download button** (⬇) in the top-right exports a custom OTF font file built from the current axes.
 

--- a/src/explorer/Api.fs
+++ b/src/explorer/Api.fs
@@ -60,6 +60,93 @@ let generateSvg (text: string) (axes: Axes) (autoscale: bool) (progress: (float 
 
     font.stringToSvg lines 0.0 0.0 autoscale "black" progress |> String.concat "\n"
 
+/// Build a char -> Font lookup from two parallel inputs: `chars.[i]` is rendered
+/// with `axesList.[i]`.  Characters not listed fall back to `fallback`.
+let private fontLookup (chars: string) (axesList: Axes array) (tweak: Axes -> Axes) (fallback: Font) =
+    let byChar =
+        Seq.init (min chars.Length axesList.Length) id
+        |> Seq.map (fun i -> chars.[i], Font(tweak axesList.[i]))
+        |> Map.ofSeq
+
+    fun ch ->
+        match Map.tryFind ch byChar with
+        | Some f -> f
+        | None -> fallback
+
+/// Render text with a different set of axes per character — the "randomise every
+/// glyph" mode.  `chars` and `axesList` are parallel arrays; every occurrence of
+/// `chars.[i]` is drawn with `axesList.[i]`, anything else uses `baseAxes`.
+///
+/// Line spacing and the baseline of each line come from `baseAxes` so that glyphs
+/// with different heights/thicknesses still sit on a common baseline; advance
+/// widths come from each glyph's own axes.
+let generateSvgPerGlyph
+    (text: string)
+    (baseAxes: Axes)
+    (chars: string)
+    (axesList: Axes array)
+    (autoscale: bool)
+    (progress: (float -> unit) option)
+    =
+    let baseFont = Font baseAxes
+    let fontFor = fontLookup chars axesList id baseFont
+
+    let lines =
+        if System.String.IsNullOrEmpty(text) then
+            []
+        else
+            text.Replace("\r\n", "\n").Split('\n') |> List.ofArray
+
+    let totalChars = lines |> List.sumBy (fun s -> s.Length)
+    let mutable charCount = 0
+
+    // SVG y of the baseline (glyph y=0) for line i, matching the placement
+    // Font.stringToSvgLineInternal would give it under baseAxes.
+    let baselineY i =
+        baseFont.charHeight * float (i + 1) + baseFont.metrics.D - baseFont.metrics.thickness
+
+    let svg, lineWidths =
+        List.unzip
+            [ for i in 0 .. lines.Length - 1 do
+                  let str = lines.[i]
+                  let fonts = [ for ch in str -> fontFor ch ]
+
+                  let widths =
+                      List.map2 (fun (f: Font) (ch: char) -> f.charWidth ch) fonts (List.ofSeq str)
+
+                  let offsetXs = List.scan (+) 0.0 widths
+
+                  let lineSvg =
+                      [ for c in 0 .. str.Length - 1 do
+                            let font = fonts.[c]
+                            charCount <- charCount + 1
+
+                            match progress with
+                            | Some p -> p (float charCount / float totalChars)
+                            | None -> ()
+
+                            // glyph coords are pre-shifted by their own thickness, so add
+                            // it back here to land every glyph on the shared baseline
+                            yield!
+                                font.charToSvg
+                                    str.[c]
+                                    offsetXs.[c]
+                                    (baselineY i + font.metrics.thickness)
+                                    "black" ]
+
+                  (lineSvg, List.sum widths) ]
+
+    let margin = 50.0
+
+    let w, h =
+        if autoscale then
+            (List.max (0.0 :: lineWidths)) + margin,
+            baseFont.charHeight * float lines.Length + margin
+        else
+            6000.0, 6000.0
+
+    toSvgDocument -margin -margin w h (List.collect id svg) |> String.concat "\n"
+
 let generateTweenSvg (text: string) (axes: Axes) =
     let font = Font axes
 
@@ -599,24 +686,31 @@ let solveSplineGrid () =
                                error = error |})
     results.ToArray()
 
-let generateFontGlyphData (axes: Axes) (progress: (float -> unit) option) =
-    let fontAxes = { axes with outline = true; filled = true }
-    let font = Font fontAxes
+/// Glyph outlines + advance widths for the exported/preview font, allowing a
+/// different set of axes per character (see `generateSvgPerGlyph`).  Pass empty
+/// `chars`/`axesList` for a uniform font.  The font-wide metrics (ascender,
+/// descender, unitsPerEm) always come from `axes` so per-glyph variation stays
+/// inside the em box rather than rescaling the font.
+let generateFontGlyphDataPerGlyph
+    (axes: Axes)
+    (chars: string)
+    (axesList: Axes array)
+    (progress: (float -> unit) option)
+    =
+    let asFontAxes (a: Axes) = { a with outline = true; filled = true }
+    let font = Font(asFontAxes axes)
     let metrics = FontMetrics(axes)
+    let fontFor = fontLookup chars axesList asFontAxes font
     // Exported/preview fonts need an actual space glyph (used to render proof
     // text, font comparisons, etc.), so make sure one is always included even
     // though allChars itself no longer contains a literal space character.
-    let chars = allChars.Replace("\n", "") + " "
+    let glyphChars = allChars.Replace("\n", "") + " "
 
-    // outlineFont has smooth=false so rendering the sampled Corner outline knots
-    // does not trigger O(n²) NelderMead; cached on the font instance.
-    let outlineFont = font.outlineFont
-
-    let totalChars = chars.Length
+    let totalChars = glyphChars.Length
     let mutable charCount = 0
 
     let glyphs =
-        chars
+        glyphChars
         |> Seq.map (fun c ->
             charCount <- charCount + 1
 
@@ -624,15 +718,19 @@ let generateFontGlyphData (axes: Axes) (progress: (float -> unit) option) =
             | Some p -> p (float charCount / float totalChars)
             | None -> ()
 
+            let charFont = fontFor c
+
             try
-                let outline = font.CharToOutline c
-                let svg, _, _ = outlineFont.elementToSvg outline
+                let outline = charFont.CharToOutline c
+                // outlineFont has smooth=false so rendering the sampled Corner outline knots
+                // does not trigger O(n²) NelderMead; cached on the font instance.
+                let svg, _, _ = charFont.outlineFont.elementToSvg outline
                 {| unicode = int c
-                   advanceWidth = font.charWidth c
+                   advanceWidth = charFont.charWidth c
                    pathData = String.concat " " svg |}
             with _ ->
                 {| unicode = int c
-                   advanceWidth = font.charWidth c
+                   advanceWidth = charFont.charWidth c
                    pathData = "" |})
         |> Array.ofSeq
 
@@ -641,6 +739,9 @@ let generateFontGlyphData (axes: Axes) (progress: (float -> unit) option) =
        ascender = metrics.T + thickness
        descender = metrics.D - thickness
        unitsPerEm = font.charHeight |}
+
+let generateFontGlyphData (axes: Axes) (progress: (float -> unit) option) =
+    generateFontGlyphDataPerGlyph axes "" [||] progress
 
 let private knotToObj (k: Knot) : obj =
     // When x_fit/y_fit is true the solver treats the coordinate as a free variable (None).

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -385,7 +385,6 @@
     justify-content: space-between;
     align-items: center;
     margin-bottom: 0;
-    gap: 12px;
 }
 
 .tabs {
@@ -394,10 +393,6 @@
     border-radius: var(--radius-lg);
     padding: 4px;
     border: 1px solid var(--border-color);
-    /* when the window is too narrow, scroll the tabs rather than squeezing the
-       per-tab tools off the right-hand edge */
-    min-width: 0;
-    overflow-x: auto;
 }
 
 .tab-button {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -385,6 +385,7 @@
     justify-content: space-between;
     align-items: center;
     margin-bottom: 0;
+    gap: 12px;
 }
 
 .tabs {
@@ -393,6 +394,10 @@
     border-radius: var(--radius-lg);
     padding: 4px;
     border: 1px solid var(--border-color);
+    /* when the window is too narrow, scroll the tabs rather than squeezing the
+       per-tab tools off the right-hand edge */
+    min-width: 0;
+    overflow-x: auto;
 }
 
 .tab-button {
@@ -521,6 +526,13 @@
     background-color: var(--panel-bg);
     color: var(--text-primary);
     border-color: var(--border-light);
+}
+
+/* Toggled-on icon button (e.g. per-glyph randomisation is active) */
+.icon-button.active {
+    background-color: var(--accent-color);
+    border-color: var(--accent-color);
+    color: #fff;
 }
 
 .material-symbols-outlined {

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -9,6 +9,7 @@ import { buildCompareOverlaySvg } from './fontCompare'
 import FontCompareControls from './FontCompareControls'
 import FontCompareTextOverlay from './FontCompareTextOverlay'
 import { proofTexts, proofLabels, proofCases, classicBooks } from './proofs'
+import { randomizeAxes, buildGlyphAxes, newGlyphSeed } from './glyphRandom'
 import './App.css'
 
 // Special Visual Diffs option: compare the old spiro/spline2 engine vs the new dactyl spline
@@ -64,6 +65,11 @@ function App() {
     return getGlyphDefs(initialText, defaultAxes.alt_a_g)
   })
   const [axes, setAxes] = useState({ ...defaultAxes })
+  // "Randomise every glyph": null = off, otherwise the seed that every
+  // character's axes are derived from.  Holding a seed (rather than a big map of
+  // per-glyph axes) is what makes the variant font stable — it only changes when
+  // the button is clicked again or Reset clears it.
+  const [glyphSeed, setGlyphSeed] = useState(null)
   const [activeTab, setActiveTab] = useState('font')
   // Visual Diffs config: which axis to diff and the two values to compare.
   // SPLINE_ENGINE is a special compound option (old spiro/spline2 vs new dactyl spline).
@@ -379,6 +385,19 @@ function App() {
     return (!isNaN(idx) && idx >= 0 && idx < classicBooks.length) ? classicBooks[idx] : null
   })
 
+  // Per-glyph random axes, as the parallel (chars, axesList) arrays the F# API
+  // takes.  Two variants so the whole-font one (export / proofs / comparisons)
+  // doesn't churn every time the typed text changes.
+  const perGlyphFontAxes = useMemo(
+    () => glyphSeed === null ? null : buildGlyphAxes(allChars.replace(/\n/g, '') + ' ', glyphSeed, axes, controlDefinitions),
+    [glyphSeed, axes]
+  )
+  const perGlyphTextAxes = useMemo(
+    () => glyphSeed === null ? null : buildGlyphAxes(text || '', glyphSeed, axes, controlDefinitions),
+    [glyphSeed, axes, text]
+  )
+  const perGlyphFontArgs = perGlyphFontAxes ? [perGlyphFontAxes.chars, perGlyphFontAxes.axesList] : []
+
   const handleDownloadFont = () => {
     setDownloadingFont(true)
     const worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' })
@@ -393,7 +412,7 @@ function App() {
         downloadFont(result, axes, defaultAxes)
       }
     }
-    worker.postMessage({ id: 1, type: 'fontData', args: [axes] })
+    worker.postMessage({ id: 1, type: 'fontData', args: [axes, ...perGlyphFontArgs] })
   }
 
   const renderIdRef = useRef(0)
@@ -480,8 +499,13 @@ function App() {
         worker.terminate()
         return
       }
-      typeReq = 'font'
-      args = [text, axes, false]
+      if (perGlyphTextAxes) {
+        typeReq = 'fontPerGlyph'
+        args = [text, axes, perGlyphTextAxes.chars, perGlyphTextAxes.axesList, false]
+      } else {
+        typeReq = 'font'
+        args = [text, axes, false]
+      }
     } else if (activeTab === 'glyphs') {
       typeReq = 'glyphsFromDefs'
       args = [glyphsDefsText, { ...axes, filled: glyphsFilled }]
@@ -543,7 +567,7 @@ function App() {
       clearTimeout(timer)
       worker.terminate()
     }
-  }, [text, axes, activeTab, glyphsDefsText, glyphsFilled, diffConfig, compareMode, growParams])
+  }, [text, axes, activeTab, glyphsDefsText, glyphsFilled, diffConfig, compareMode, growParams, perGlyphTextAxes])
 
   // Close the Grow download-format menu on outside click / Escape.
   useEffect(() => {
@@ -587,13 +611,13 @@ function App() {
       setShowProgress(false)
     }
 
-    worker.postMessage({ id, type: 'fontPreview', args: [axes] })
+    worker.postMessage({ id, type: 'fontPreview', args: [axes, ...perGlyphFontArgs] })
 
     return () => {
       clearTimeout(timer)
       worker.terminate()
     }
-  }, [axes, activeTab])
+  }, [axes, activeTab, perGlyphFontAxes])
 
   // Dedicated effect for the Grow tab GPU path: rebuild the growth field only
   // when text/axes change.  growParams are shader uniforms and don't re-trigger.
@@ -684,12 +708,12 @@ function App() {
       loadingRef.current = false
       setShowProgress(false)
     }
-    worker.postMessage({ id: ++renderIdRef.current, type: 'fontData', args: [axes] })
+    worker.postMessage({ id: ++renderIdRef.current, type: 'fontData', args: [axes, ...perGlyphFontArgs] })
     return () => {
       clearTimeout(timer)
       worker.terminate()
     }
-  }, [axes, activeTab, compareMode])
+  }, [axes, activeTab, compareMode, perGlyphFontAxes])
 
   // Vector overlay SVG (outline sources). Rebuilt when the font, alignment,
   // text or Dactyl outlines change.
@@ -934,6 +958,7 @@ function App() {
 
   const handleReset = () => {
     setAxes({ ...defaultAxes })
+    setGlyphSeed(null)
   }
 
   // "Debug" master checkbox in the glyphs floating tools: reflects/controls all
@@ -955,30 +980,16 @@ function App() {
     setGlyphsFilled(checked)
   }
 
-  // Only touch a fraction of axes per click, and bias sampled values toward
-  // the default (nudge, don't reroll) so extreme/rare effects don't stack up.
-  const RANDOMIZE_PROBABILITY = 0.35
-  const RANDOMIZE_SPREAD = 0.3
-
+  // Randomize around the *defaults* so repeated clicks don't compound.
   const handleRandom = () => {
-    const newAxes = { ...axes }
-    controlDefinitions.forEach(ctrl => {
-      if (ctrl.category === 'experimental' || ctrl.category === 'debug') return
-      // reset to default before re-randomizing, so clicks don't compound
-      newAxes[ctrl.name] = defaultAxes[ctrl.name]
-      if (Math.random() > RANDOMIZE_PROBABILITY) return
+    setAxes(randomizeAxes(axes, defaultAxes, controlDefinitions, Math.random))
+  }
 
-      if (ctrl.type_ === 'checkbox') {
-        newAxes[ctrl.name] = Math.random() > 0.5
-      } else {
-        const center = defaultAxes[ctrl.name] ?? (ctrl.min + ctrl.max) / 2
-        const range = ctrl.max - ctrl.min
-        // triangular distribution centered on 0: most draws land near `center`
-        const offset = (Math.random() - Math.random()) * range * RANDOMIZE_SPREAD
-        newAxes[ctrl.name] = Math.min(ctrl.max, Math.max(ctrl.min, center + offset))
-      }
-    })
-    setAxes(newAxes)
+  // "Randomise every glyph": roll a new seed. Everything downstream (font tab
+  // render, proofs, OTF export, font comparison) derives its per-glyph axes from
+  // it, so the variant font is stable until this is clicked again or Reset.
+  const handleRandomEveryGlyph = () => {
+    setGlyphSeed(newGlyphSeed())
   }
 
 
@@ -1272,16 +1283,36 @@ function App() {
             )
           })()}
           {activeTab === 'font' && (
-            <button
-              className="icon-button"
-              onClick={handleDownloadFont}
-              disabled={downloadingFont}
-              title="Download Font (OTF)"
-            >
-              <span className="material-symbols-outlined">
-                {downloadingFont ? 'hourglass_empty' : 'download'}
-              </span>
-            </button>
+            <div className="toolbar">
+              <button
+                className={`icon-button ${glyphSeed !== null ? 'active' : ''}`}
+                onClick={handleRandomEveryGlyph}
+                title={glyphSeed === null
+                  ? 'Randomise every glyph — give each character its own settings'
+                  : 'Randomise every glyph again (new set)'}
+              >
+                <span className="material-symbols-outlined">shuffle</span>
+              </button>
+              {glyphSeed !== null && (
+                <button
+                  className="icon-button"
+                  onClick={() => setGlyphSeed(null)}
+                  title="Turn off per-glyph randomisation"
+                >
+                  <span className="material-symbols-outlined">close</span>
+                </button>
+              )}
+              <button
+                className="icon-button"
+                onClick={handleDownloadFont}
+                disabled={downloadingFont}
+                title="Download Font (OTF)"
+              >
+                <span className="material-symbols-outlined">
+                  {downloadingFont ? 'hourglass_empty' : 'download'}
+                </span>
+              </button>
+            </div>
           )}
         </div>
 

--- a/web/src/glyphRandom.js
+++ b/web/src/glyphRandom.js
@@ -1,0 +1,94 @@
+// Axis randomisation, shared by the sidebar "Randomize" button and the Font
+// tab's "randomise every glyph" mode.
+//
+// Per-glyph mode is driven by a single integer seed: each character's axes are
+// derived deterministically from (seed, code point).  That keeps the variant
+// font *stable* — re-renders, tab switches, sidebar tweaks and OTF export all
+// reproduce the same glyphs, and every occurrence of a letter looks the same.
+// A new set only appears when a new seed is rolled (or randomisation is reset).
+
+// Only touch a fraction of axes, and bias sampled values toward the centre
+// (nudge, don't reroll) so extreme/rare effects don't stack up.
+export const RANDOMIZE_PROBABILITY = 0.35
+export const RANDOMIZE_SPREAD = 0.3
+
+// Categories never randomised: experimental axes are half-finished and debug
+// axes are view options, not design choices.
+const SKIPPED_CATEGORIES = ['experimental', 'debug']
+
+// Line spacing is a paragraph property, not a glyph one — varying it per glyph
+// would just shunt whole lines around, so per-glyph mode leaves it alone.
+export const PER_GLYPH_SKIPPED_AXES = ['leading']
+
+/// Small, fast, seedable PRNG.  Returns a function yielding floats in [0, 1).
+export function mulberry32(seed) {
+  let a = seed >>> 0
+  return function () {
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/// Mix a seed with a character code into a well-distributed 32-bit PRNG seed,
+/// so adjacent code points (e.g. 'a' and 'b') get unrelated settings.
+export function glyphSeedFor(seed, codePoint) {
+  let h = ((seed | 0) ^ 0x9e3779b9) >>> 0
+  h = Math.imul(h ^ codePoint, 0x85ebca6b)
+  h ^= h >>> 13
+  h = Math.imul(h, 0xc2b2ae35)
+  return (h ^ (h >>> 16)) >>> 0
+}
+
+/// Randomise a set of axes.
+///
+/// `base`     axes to copy untouched values (skipped categories/axes) from.
+/// `centre`   axes that randomised values are sampled around, and that
+///            not-selected-this-roll axes are set to.  The sidebar button
+///            passes the *defaults* here (so repeated clicks don't compound);
+///            per-glyph mode passes the current axes (so the sliders still
+///            drive the overall look).
+/// `rand`     () => [0, 1) source, e.g. Math.random or mulberry32(seed).
+export function randomizeAxes(base, centre, controls, rand, skippedAxes = []) {
+  const next = { ...base }
+  controls.forEach(ctrl => {
+    if (SKIPPED_CATEGORIES.includes(ctrl.category)) return
+    if (skippedAxes.includes(ctrl.name)) return
+
+    next[ctrl.name] = centre[ctrl.name]
+    if (rand() > RANDOMIZE_PROBABILITY) return
+
+    if (ctrl.type_ === 'checkbox') {
+      next[ctrl.name] = rand() > 0.5
+    } else {
+      const c = centre[ctrl.name] ?? (ctrl.min + ctrl.max) / 2
+      const range = ctrl.max - ctrl.min
+      // triangular distribution centred on 0: most draws land near `c`
+      const offset = (rand() - rand()) * range * RANDOMIZE_SPREAD
+      next[ctrl.name] = Math.min(ctrl.max, Math.max(ctrl.min, c + offset))
+    }
+  })
+  return next
+}
+
+/// Axes for a single character under the per-glyph random seed.
+export function glyphAxes(char, seed, axes, controls) {
+  const rand = mulberry32(glyphSeedFor(seed, char.codePointAt(0)))
+  return randomizeAxes(axes, axes, controls, rand, PER_GLYPH_SKIPPED_AXES)
+}
+
+/// Build the parallel (chars, axesList) arrays the F# API expects.  Duplicate
+/// characters collapse to one entry, so a letter always renders identically.
+export function buildGlyphAxes(chars, seed, axes, controls) {
+  const distinct = [...new Set(Array.from(chars))].filter(c => c !== '\n' && c !== '\r')
+  return {
+    chars: distinct.join(''),
+    axesList: distinct.map(c => glyphAxes(c, seed, axes, controls)),
+  }
+}
+
+/// A fresh seed for the "randomise every glyph" button.
+export function newGlyphSeed() {
+  return Math.floor(Math.random() * 0x7fffffff)
+}

--- a/web/src/glyphRandom.test.js
+++ b/web/src/glyphRandom.test.js
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest'
+import {
+  mulberry32,
+  glyphSeedFor,
+  randomizeAxes,
+  glyphAxes,
+  buildGlyphAxes,
+  PER_GLYPH_SKIPPED_AXES,
+} from './glyphRandom'
+
+// Stand-in for the Fable-generated controlDefinitions.
+const controls = [
+  { name: 'thickness', type_: 'range', min: 1, max: 100, category: 'basic' },
+  { name: 'roundedness', type_: 'range', min: 0, max: 300, category: 'basic' },
+  { name: 'leading', type_: 'range', min: 0, max: 200, category: 'basic' },
+  { name: 'italic', type_: 'range', min: 0, max: 1, category: 'artistic' },
+  { name: 'serif', type_: 'range', min: 0, max: 70, category: 'artistic' },
+  { name: 'stroked', type_: 'checkbox', min: 0, max: 1, category: 'artistic' },
+  { name: 'wild', type_: 'range', min: 0, max: 1, category: 'experimental' },
+  { name: 'show_knots', type_: 'checkbox', min: 0, max: 1, category: 'debug' },
+]
+
+const axes = {
+  thickness: 30, roundedness: 100, leading: 50, italic: 0, serif: 0,
+  stroked: false, wild: 0.5, show_knots: true,
+}
+const defaults = { ...axes, wild: 0, show_knots: false }
+
+describe('mulberry32', () => {
+  it('is deterministic for a given seed', () => {
+    const a = mulberry32(12345)
+    const b = mulberry32(12345)
+    expect([a(), a(), a()]).toEqual([b(), b(), b()])
+  })
+
+  it('produces different streams for different seeds', () => {
+    expect(mulberry32(1)()).not.toBe(mulberry32(2)())
+  })
+
+  it('stays within [0, 1)', () => {
+    const r = mulberry32(7)
+    for (let i = 0; i < 500; i++) {
+      const v = r()
+      expect(v).toBeGreaterThanOrEqual(0)
+      expect(v).toBeLessThan(1)
+    }
+  })
+})
+
+describe('glyphSeedFor', () => {
+  it('separates adjacent code points', () => {
+    const seeds = 'abcdefghijklmnopqrstuvwxyz'
+      .split('')
+      .map(c => glyphSeedFor(42, c.codePointAt(0)))
+    expect(new Set(seeds).size).toBe(26)
+  })
+
+  it('separates adjacent seeds for the same character', () => {
+    const a = glyphSeedFor(1, 97)
+    const b = glyphSeedFor(2, 97)
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('randomizeAxes', () => {
+  it('never touches experimental or debug axes', () => {
+    const out = randomizeAxes(axes, defaults, controls, mulberry32(3))
+    expect(out.wild).toBe(axes.wild)
+    expect(out.show_knots).toBe(axes.show_knots)
+  })
+
+  it('keeps range values inside their control bounds', () => {
+    for (let seed = 0; seed < 200; seed++) {
+      const out = randomizeAxes(axes, defaults, controls, mulberry32(seed))
+      for (const c of controls) {
+        if (c.type_ !== 'range' || c.category === 'experimental' || c.category === 'debug') continue
+        expect(out[c.name]).toBeGreaterThanOrEqual(c.min)
+        expect(out[c.name]).toBeLessThanOrEqual(c.max)
+      }
+    }
+  })
+
+  it('resets untouched axes to the centre, so repeat rolls do not compound', () => {
+    // A roll from a drifted starting point lands in the same place as a roll
+    // from the centre, because every eligible axis is re-seeded from `centre`.
+    const drifted = { ...axes, thickness: 95, serif: 68, italic: 0.9 }
+    const a = randomizeAxes(drifted, defaults, controls, mulberry32(11))
+    const b = randomizeAxes(defaults, defaults, controls, mulberry32(11))
+    for (const c of controls) {
+      if (c.category === 'experimental' || c.category === 'debug') continue
+      expect(a[c.name]).toBe(b[c.name])
+    }
+  })
+
+  it('honours skippedAxes', () => {
+    for (let seed = 0; seed < 50; seed++) {
+      const out = randomizeAxes(axes, axes, controls, mulberry32(seed), ['leading'])
+      expect(out.leading).toBe(axes.leading)
+    }
+  })
+
+  it('does at least sometimes change something', () => {
+    const changed = Array.from({ length: 20 }, (_, s) =>
+      randomizeAxes(axes, defaults, controls, mulberry32(s))
+    ).some(out => out.thickness !== defaults.thickness || out.italic !== defaults.italic)
+    expect(changed).toBe(true)
+  })
+})
+
+describe('glyphAxes', () => {
+  it('is stable for the same (char, seed)', () => {
+    expect(glyphAxes('a', 99, axes, controls)).toEqual(glyphAxes('a', 99, axes, controls))
+  })
+
+  it('differs between characters under one seed', () => {
+    const letters = 'abcdefghijklmnopqrstuvwxyz'.split('')
+    const rendered = letters.map(c => JSON.stringify(glyphAxes(c, 99, axes, controls)))
+    // not asking for all-distinct (rolls can coincide), just real variety
+    expect(new Set(rendered).size).toBeGreaterThan(letters.length / 2)
+  })
+
+  it('changes when the seed changes', () => {
+    const before = 'abcdefghij'.split('').map(c => JSON.stringify(glyphAxes(c, 1, axes, controls)))
+    const after = 'abcdefghij'.split('').map(c => JSON.stringify(glyphAxes(c, 2, axes, controls)))
+    expect(after).not.toEqual(before)
+  })
+
+  it('centres on the current axes, so sidebar changes still show through', () => {
+    // `leading` is skipped, so it must track whatever the sidebar says.
+    expect(PER_GLYPH_SKIPPED_AXES).toContain('leading')
+    const out = glyphAxes('a', 5, { ...axes, leading: 123 }, controls)
+    expect(out.leading).toBe(123)
+  })
+})
+
+describe('buildGlyphAxes', () => {
+  it('collapses duplicates and drops newlines', () => {
+    const { chars, axesList } = buildGlyphAxes('aab\nba\r', 7, axes, controls)
+    expect(chars).toBe('ab')
+    expect(axesList).toHaveLength(2)
+  })
+
+  it('matches glyphAxes entry by entry', () => {
+    const { chars, axesList } = buildGlyphAxes('xyz', 7, axes, controls)
+    chars.split('').forEach((c, i) => {
+      expect(axesList[i]).toEqual(glyphAxes(c, 7, axes, controls))
+    })
+  })
+
+  it('gives the same result for the same seed regardless of input order', () => {
+    const a = buildGlyphAxes('abc', 7, axes, controls)
+    const b = buildGlyphAxes('cba', 7, axes, controls)
+    const byChar = o => Object.fromEntries(o.chars.split('').map((c, i) => [c, o.axesList[i]]))
+    expect(byChar(a)).toEqual(byChar(b))
+  })
+})

--- a/web/src/worker.js
+++ b/web/src/worker.js
@@ -1,4 +1,4 @@
-import { generateSvg, generateSplineDebugSvgFromDefs, generateTweenSvg, generateTweenDiffSvg, generateVisualDiffsSvg, controlDefinitions, solveSplineEditor, solveSplineGrid, solveAltSplines, getGuidePositions, getGlyphList, parseGlyphToControlPoints, generateFontGlyphData, getSplineOutlinePath } from './lib/fable/Api'
+import { generateSvg, generateSvgPerGlyph, generateSplineDebugSvgFromDefs, generateTweenSvg, generateTweenDiffSvg, generateVisualDiffsSvg, controlDefinitions, solveSplineEditor, solveSplineGrid, solveAltSplines, getGuidePositions, getGlyphList, parseGlyphToControlPoints, generateFontGlyphDataPerGlyph, getSplineOutlinePath } from './lib/fable/Api'
 import { buildFontDataUrl } from './fontExport'
 import { generateGrowthSvg, generateGrowthField } from './growthSvg'
 import { DControlPoint } from './lib/fable/generator/DactylSpline'
@@ -15,6 +15,14 @@ self.onmessage = (e) => {
                     self.postMessage({ id, type: 'progress', value: p });
                 })
                 break
+            // Same as 'font' but every character gets its own axes (see glyphRandom.js)
+            case 'fontPerGlyph': {
+                const [fText, fBaseAxes, fChars, fAxesList, fAutoscale] = args
+                result = generateSvgPerGlyph(fText, fBaseAxes, fChars, fAxesList, fAutoscale, (p) => {
+                    self.postMessage({ id, type: 'progress', value: p });
+                })
+                break
+            }
             case 'glyphsFromDefs':
                 result = generateSplineDebugSvgFromDefs(...args, (p) => {
                     self.postMessage({ id, type: 'progress', value: p });
@@ -92,16 +100,17 @@ self.onmessage = (e) => {
                 if (result) transfer = [result.rg.buffer]
                 break
             }
+            // chars/axesList are the optional per-glyph random overrides; empty = uniform font
             case 'fontData': {
-                const [fontAxes] = args
-                result = generateFontGlyphData(fontAxes, (p) => {
+                const [fontAxes, chars = '', axesList = []] = args
+                result = generateFontGlyphDataPerGlyph(fontAxes, chars, axesList, (p) => {
                     self.postMessage({ id, type: 'progress', value: p });
                 })
                 break
             }
             case 'fontPreview': {
-                const [fontAxes] = args
-                result = buildFontDataUrl(generateFontGlyphData(fontAxes, undefined), 'DactylPreview')
+                const [fontAxes, chars = '', axesList = []] = args
+                result = buildFontDataUrl(generateFontGlyphDataPerGlyph(fontAxes, chars, axesList, undefined), 'DactylPreview')
                 break
             }
             case 'splineOutline': {


### PR DESCRIPTION
A 🔀 shuffle button in the Font tab's top bar gives **every character its own randomised axes**, instead of one setting for the whole font.

### Stability

Driven by a single integer seed rather than a stored map of axes: each character's settings are derived from `(seed, code point)`. So

- a letter looks identical everywhere it appears,
- the variant font survives re-renders, tab switches and sidebar tweaks,
- clicking the button again rolls a new seed,
- the ✕ beside it — or the sidebar ↺ Reset — turns it off.

### Rules

Same rules as the existing sidebar 🎲 Randomize button (35% of axes touched per roll, triangular ±0.3·range nudge, `experimental` and `debug` categories skipped), with two deliberate differences:

- values are nudged around the **current** axes rather than the defaults, so the sidebar sliders still drive the overall look;
- `leading` is excluded, since it is a line property rather than a glyph one.

### Changes

- **`web/src/glyphRandom.js`** (new) — seeded PRNG (mulberry32 + a seed/code-point mixer), `randomizeAxes()` now shared with the sidebar Randomize button, and `buildGlyphAxes()` producing the char→axes map. Unit tests in `glyphRandom.test.js` cover determinism, bounds, exclusions and stability.
- **`src/explorer/Api.fs`** — `generateSvgPerGlyph` renders text with per-character `Font` instances, taking line spacing and a common baseline from the base axes so glyphs of differing height/thickness still line up, while advance widths come from each glyph's own axes. `generateFontGlyphDataPerGlyph` does the same for the exported/preview font, so the mode also reaches the OTF download, the Proofs tab and the Visual Diffs font comparison. Both are no-ops when given an empty char list, and `generateFontGlyphData` now delegates to the new function.
- **`web/src/worker.js`** — new `fontPerGlyph` message; `fontData`/`fontPreview` take optional per-glyph args.
- **`web/src/App.jsx`** — `glyphSeed` state, the toolbar buttons, and two memoised char→axes maps (one keyed on the typed text for the Font tab render, one on the full charset for export/proofs, so the proof font doesn't regenerate on every keystroke).
- **`web/src/App.css`** — one new rule, `.icon-button.active`, for the toggled-on state.
- **`docs/ExplorerGuide.md`** — documents the new button.

### Testing

- `npm test` — 73 passing, including 17 new tests for `glyphRandom.js`.
- `dotnet test src/generator/tests` — 98 passing.
- Verified `generateSvgPerGlyph` with an empty char map is **byte-identical** to `generateSvg`, and `generateFontGlyphData` output is unchanged, so the feature is inert when off.
- Rendered the Font tab and a per-glyph OTF export at several seeds and inspected the images: baselines align, no stray geometry, per-glyph variation is visible and repeatable.
- Ran `tabs.spec.js` and `font-compare.spec.js` against builds with and without this branch in the same environment and byte-compared the renders: identical on 9 of 10 tabs. The one difference is the `<canvas>`-based Splines tab, same dimensions, which also differs between two runs of *unchanged* code — antialiasing noise.

### Note on the second commit

The first push failed `visual-test` on the `grow` and `visualDiffs-compare-upload` snapshots, on size (`942x358` expected, `942x430` received). That came from a CSS tweak I had added alongside the feature — making `.tabs` shrinkable so the Font tab's extra button wouldn't push things off the right edge. Letting the tab row give up width meant the grow and font-compare control rows wrapped onto fewer lines, which shortened `.top-bar` and made `.preview-content` taller. The rendered content was unchanged in both (confirmed from the artifact's `-actual.png`s); only the frame was taller. `a261b14` reverts that tweak, so the top bar is exactly as it is on `main`.

Consequence worth knowing: the extra button means the top bar starts overflowing at a slightly wider window than before (~1180px rather than ~1090px, between the 768px mobile breakpoint and full width). That is the pre-existing narrow-window behaviour arriving one button's width sooner; happy to address it separately if it matters.