### PR TITLE
Re-add link to the png/ image gallery in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ NOTE: This README is best viewed at https://terryspitz.github.io/dactyl-font/REA
 
 Play with the [Dactyl Live Explorer](https://terryspitz.github.io/dactyl-font) — design fonts interactively using 30+ axes, then download a custom OTF. Switch between tabs to inspect individual **Glyphs**, watch **Tweens** animate axis changes, compare **Visual Diffs** across settings, explore the **Spline** maths, review **Proofs** with real text, or **Grow** letterforms into blobby Y2K logotypes.
 
+See a rotating gallery of past renders at the [Dactyl Font Gallery](gallery.html).
+
 ## What & Why
 
 Dactyl is a functional font generator written in F#, in service of ticking 'create a font' off my bucket list!

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ NOTE: This README is best viewed at https://terryspitz.github.io/dactyl-font/REA
 
 Play with the [Dactyl Live Explorer](https://terryspitz.github.io/dactyl-font) — design fonts interactively using 30+ axes, then download a custom OTF. Switch between tabs to inspect individual **Glyphs**, watch **Tweens** animate axis changes, compare **Visual Diffs** across settings, explore the **Spline** maths, review **Proofs** with real text, or **Grow** letterforms into blobby Y2K logotypes.
 
-See a rotating gallery of past renders at the [Dactyl Font Gallery](gallery.html).
+See some of the chequered development history at the [Dactyl Font Gallery](gallery.html), a rotating gallery of past renders.
 
 ## What & Why
 


### PR DESCRIPTION
## Summary

- The README's tl;dr used to link to [`gallery.html`](gallery.html), a rotating [Fotorama](https://fotorama.io/) gallery of the 176 images in `png/`.
- That link was dropped in a README rewrite (`b82eae9`, "Update README to reflect current feature set"), even though `gallery.html` and `png/` were never removed from the repo.
- This restores the link so the gallery is discoverable again from the README.

## Test plan

- [x] Verified `gallery.html` still exists and references images under `png/`, which are still present in the repo.
- [x] Rendered `README.md` locally to confirm the added line reads correctly and the link resolves to `gallery.html`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUMya95Zkh1Sv8k2LoXnxS)_