### PR TITLE
Add "Spacing Strings" preset to the proofs page

### DIFF
--- a/web/src/proofs.js
+++ b/web/src/proofs.js
@@ -26,11 +26,38 @@ const wrap = (s, width) => {
 
 const WRAP_WIDTH = 80
 
+// "Spacing Strings" technique: https://www.a-plus-type.com/writing/spacing-strings
+// A fixed set of control strings (n/o for lowercase, H/O for uppercase), followed
+// by two templated strings per glyph that sandwich it between straight (n/H) and
+// round (o/O) neighbours, doubled up for interior straight-to-straight and
+// round-to-round comparisons.
+const SPACING_CONTROL_STRINGS = [
+  'nnnnnnnn',
+  'nnnnononoooo',
+  'HHHOHOHOOO',
+  'HHnnHOHOnnOO',
+  'HHooHOHOooOO',
+  'nnHHnonoHHoo',
+  'nnOOnonoOOoo',
+]
+
+const spacingStringsForGlyph = (c) => [
+  `nn${c}nonouu${c}nono${c}oo`,
+  `HH${c}HOHO${c}OO`,
+]
+
+const spacingStringsText = [
+  ...SPACING_CONTROL_STRINGS,
+  '',
+  ...Array.from(alphabetChars.replace(/\n/g, '')).flatMap(spacingStringsForGlyph),
+].join('\n')
+
 export const proofTexts = {
   uppercase: wrap(stripComments(uppercase), WRAP_WIDTH),
   lowercase: wrap(stripComments(lowercase), WRAP_WIDTH),
   alphabet: alphabetChars,
   allGlyphs: allChars,
+  spacingStrings: spacingStringsText,
 }
 
 export const proofLabels = {
@@ -38,8 +65,9 @@ export const proofLabels = {
   lowercase: 'Lowercase',
   alphabet: 'Alphabet',
   allGlyphs: 'All glyphs',
+  spacingStrings: 'Spacing Strings',
 }
 
-export const proofCases = ['lowercase', 'uppercase', 'alphabet', 'allGlyphs']
+export const proofCases = ['lowercase', 'uppercase', 'alphabet', 'allGlyphs', 'spacingStrings']
 
 export { classicBooks } from './proofs/books'


### PR DESCRIPTION
## Summary

- Adds a new "Spacing Strings" preset to the Proofs tab, implementing the [spacing string technique](https://www.a-plus-type.com/writing/spacing-strings) from A+ Type.
- The site itself was blocked by this session's egress policy, so the exact strings (fixed control strings plus per-glyph templates) were supplied directly by the user.
- Text is generated in `web/src/proofs.js`: 7 fixed control strings (`nnnnnnnn`, `nnnnononoooo`, `HHHOHOHOOO`, etc.), followed by two templated lines per glyph — `nnXnonouuXnonoXoo` (lowercase context) and `HHXHOHOXOO` (uppercase context) — for every character in `alphabetChars` (a-z, A-Z, 0-9).

## Test plan

- [x] `dotnet fable src/explorer --outDir web/src/lib/fable && cd web && npm run build` — production build succeeds
- [x] `cd web && npm test` — all 89 Vitest unit tests pass
- [x] Verified via `vite preview` + headless Chromium screenshot that the new "Spacing Strings" chip appears on the Proofs tab, is selectable, and renders the expected control strings and per-glyph rows using the actual font glyphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q55L7xXhowyzSQUmvp1ukU


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q55L7xXhowyzSQUmvp1ukU)_