### PR TITLE
Snap cursive axis slider to 0.5 steps

### DIFF
--- a/src/explorer/Api.fs
+++ b/src/explorer/Api.fs
@@ -27,6 +27,14 @@ let getControlDetails (name: string, control: Controls, category: string, descri
            step = 0.05
            category = category
            description = description |}
+    | SteppedFracRange(min, max, step) ->
+        {| name = name
+           type_ = "range"
+           min = min
+           max = max
+           step = step
+           category = category
+           description = description |}
     | Checkbox ->
         {| name = name
            type_ = "checkbox"

--- a/src/generator/Axes.fs
+++ b/src/generator/Axes.fs
@@ -4,6 +4,8 @@ module Axes
 type Controls =
     | Range of from: int * upto: int
     | FracRange of from: float * upto: float
+    /// Like FracRange but snaps to multiples of `step` (e.g. 0.5) instead of the default 0.05.
+    | SteppedFracRange of from: float * upto: float * step: float
     | Checkbox
 
 // Variable which define the font characteristics (named after Variable Font terminology)
@@ -108,7 +110,7 @@ type Axes =
           "leading", Range(-100, 200), "backbone", "Gap between lines"
           "monospace", FracRange(0.0, 1.0), "backbone", "Fraction to interpolate widths to monospace"
           "slant", FracRange(0.0, 1.0), "backbone", "Fraction to shear glyphs"
-          "cursive", FracRange(0.0, 1.0), "backbone", "Cursive a/g forms: 0=Roman (two-storey), 0.5=Auto (cursive when slanted), 1=Cursive (single-storey)"
+          "cursive", SteppedFracRange(0.0, 1.0, 0.5), "backbone", "Cursive a/g forms: 0=Roman (two-storey), 0.5=Auto (cursive when slanted), 1=Cursive (single-storey)"
           "roundedness", Range(0, 100), "backbone", "Roundedness"
           "weight", Range(1, 200), "outline", "Stroke width"
           "contrast", FracRange(-0.5, 0.5), "outline", "Make vertical lines thicker"


### PR DESCRIPTION
## Summary

- Adds a `SteppedFracRange of from * upto * step` variant to the `Controls` union in `Axes.fs`, alongside the existing `Range`, `FracRange`, and `Checkbox` cases. Unlike `FracRange` (fixed 0.05 step), this lets an individual axis declare its own snap increment.
- Switches the `cursive` axis definition from `FracRange(0.0, 1.0)` to `SteppedFracRange(0.0, 1.0, 0.5)`, so its slider only lands on the three meaningful values: 0 (Roman), 0.5 (Auto), 1 (Cursive).
- Updates `Api.fs`'s `getControlDetails` to map the new case's `step` straight through to the JS-friendly control definition.

No changes were needed in `App.jsx` or the diff/tween controls — they already read `min`/`max`/`step` off each control definition generically, so the browser's native `<input type="range" step=...>` snapping picks this up everywhere the cursive control is rendered.

This also gives a flexible pattern for any future axis that needs a non-default step: just use `SteppedFracRange(min, max, step)` in `Axes.controls` instead of `FracRange`.

## Test plan

- [x] `dotnet build src/generator/generator.fsproj` — builds clean
- [x] `dotnet fable src/explorer --outDir web/src/lib/fable` — compiles clean; verified generated `Api.js` emits `step: control.fields[2]` for the new case
- [x] `dotnet test src/generator/tests/generator.tests.fsproj` — 99 passed
- [x] `cd web && npm test -- --run` — 90 passed
- [x] `cd web && npm run build` — production build succeeds

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKQpERZDcQXqL34d1h9mT9)_