### PR TITLE
Generate tab: Texture mode (reaction-diffusion, maze, circuit-board patterns)

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -88,11 +88,15 @@ web/
 │   ├── App.jsx           — Root React component; tab routing, sidebar, worker orchestration
 │   ├── SplineEditor.jsx  — Interactive spline editor (Splines tab)
 │   ├── SplineGrid.jsx    — Grid view of spline shapes (Spline Grid tab)
-│   ├── GrowCanvas.jsx    — WebGL2 field-threshold preview (Grow tab)
-│   ├── growth.js         — Grow tab engine: distance field + marching-squares contours
-│   ├── growthSvg.js      — Grow tab back end: strokes → field / layered SVG (worker side)
-│   ├── glyphSpines.js    — Solves glyph backbones into polylines (Grow tab seed geometry)
-│   ├── growthExport.js   — Grow tab PNG/SVG save + clipboard helpers
+│   ├── GrowCanvas.jsx    — WebGL2 field-threshold preview (Generate tab, Bubble mode)
+│   ├── growth.js         — Bubble mode engine: distance field + marching-squares contours
+│   ├── growthSvg.js      — Bubble mode back end: strokes → field / layered SVG (worker side)
+│   ├── glyphSpines.js    — Solves glyph backbones into polylines (Generate tab seed geometry)
+│   ├── growthExport.js   — Generate tab PNG/SVG save + clipboard helpers (all three modes)
+│   ├── branching.js      — Grow mode engine: space-colonisation branching off the spine
+│   ├── branchSvg.js      — Grow mode back end: strokes → branches → SVG (worker side)
+│   ├── texture.js        — Texture mode engine: reaction-diffusion / maze / circuit patterns
+│   ├── textureSvg.js     — Texture mode back end: strokes → mask → pattern → SVG (worker side)
 │   ├── fontExport.js     — OTF font assembly via opentype.js + paper.js boolean union
 │   ├── fontExport.test.js — Vitest unit tests for font export
 │   ├── worker.js         — Web worker: calls Fable-compiled F# API off the main thread

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ NOTE: This README is best viewed at https://terryspitz.github.io/dactyl-font/REA
 
 ## tl;dr
 
-Play with the [Dactyl Live Explorer](https://terryspitz.github.io/dactyl-font) — design fonts interactively using 30+ axes, then download a custom OTF. Switch between tabs to inspect individual **Glyphs**, watch **Tweens** animate axis changes, compare **Visual Diffs** across settings, explore the **Spline** maths, review **Proofs** with real text, or **Grow** letterforms into blobby Y2K logotypes.
+Play with the [Dactyl Live Explorer](https://terryspitz.github.io/dactyl-font) — design fonts interactively using 30+ axes, then download a custom OTF. Switch between tabs to inspect individual **Glyphs**, watch **Tweens** animate axis changes, compare **Visual Diffs** across settings, explore the **Spline** maths, review **Proofs** with real text, or **Generate** blobby Y2K logotypes, ivy-like branching serifs, and reaction-diffusion/maze/circuit-board textures out of the same backbones.
 
 See some of the chequered development history at the [Dactyl Font Gallery](gallery.html), a rotating gallery of past renders.
 
@@ -40,7 +40,7 @@ The [Dactyl Live Explorer](https://terryspitz.github.io/dactyl-font) runs entire
 | **Splines** | Interactive spline curve editor |
 | **Spline Grid** | Grid of curve variations |
 | **Proofs** | Real prose rendered with the current font for proofing |
-| **Grow** | Grows strokes out of the backbones to fill whitespace (constant-gap inflation), fuses neighbouring letters into a logotype, warps edges into an organic wobble, with layered Y2K keylines; save as PNG/SVG |
+| **Generate** | Three generative modes sharing the same backbones — **Bubble**: grows strokes to fill whitespace (constant-gap inflation), fuses neighbouring letters into a logotype, warps edges, layered Y2K keylines; **Grow**: space-colonisation branching sprouts ivy/serif-like twigs off the spine; **Texture**: reaction-diffusion (coral/cellular/dashed presets), a rectilinear maze, or PCB-style circuit traces, all confined to the grown letterform. Save any mode as PNG/SVG |
 
 ## Documentation
 
@@ -49,7 +49,7 @@ The [Dactyl Live Explorer](https://terryspitz.github.io/dactyl-font) runs entire
 - [DactylSpline Documentation](docs/DactylSpline.md) — The DactylSpline curve implementation
 - [DactylSpline Optimization Suggestions](docs/suggestions.md) — Ideas for improving the spline solver
 - [Font Rendering Pipeline](docs/FontPipeline.md) — Spine → outline → SVG pipeline, caps, serifs, and font export
-- [Growing Fonts](docs/growth-brainstorm.md) — Design notes for the **Grow** tab and future generative-growth directions
+- [Growing Fonts](docs/growth-brainstorm.md) — Design notes for the **Generate** tab's Bubble/Grow/Texture modes and future generative-growth directions
 - [TODO](docs/TODO.md) — Planned features and known issues
 - [Developing](DEVELOPING.md) — Building, running, testing, contributing, and the web directory layout
 

--- a/docs/ExplorerGuide.md
+++ b/docs/ExplorerGuide.md
@@ -7,13 +7,13 @@ The [Dactyl Live Explorer](https://terryspitz.github.io/dactyl-font) lets you de
 ## Layout
 
 ```
-┌──────────────┬──────────────────────────────────────────┐
-│              │  [Font][Glyphs][Tweens][Visual Diffs]    │
-│   Sidebar    │  [Splines][Spline Grid][Proofs][Grow] [⬇]│
-│  (Controls)  │                                           │
-│              │              Preview area                 │
-│              │                                           │
-└──────────────┴──────────────────────────────────────────┘
+┌──────────────┬──────────────────────────────────────────────┐
+│              │  [Font][Glyphs][Tweens][Visual Diffs]        │
+│   Sidebar    │  [Splines][Spline Grid][Proofs][Generate] [⬇]│
+│  (Controls)  │                                               │
+│              │              Preview area                     │
+│              │                                               │
+└──────────────┴──────────────────────────────────────────────┘
 ```
 
 The **sidebar** on the left holds all font axis controls.  The **top bar** holds the tab row and per-tab actions.  The **preview area** fills the rest of the page.
@@ -57,7 +57,7 @@ The result is **stable**: clicking the button rolls a single seed, and every cha
 
 The **download button** (⬇) in the top-right exports a custom OTF font file built from the current axes.  With per-glyph randomisation on, the seed goes in the font's style name and filename (`Dactyl-Random216973057.otf`) — a random font isn't described by its axes, so the seed is what makes a saved file traceable back to the settings that produced it.
 
-**Saving the typed string as a picture.** On the canvas, next to the zoom buttons, are a **copy** (⧉) and a **download** (⬇) button, the same pair the Grow tab has:
+**Saving the typed string as a picture.** On the canvas, next to the zoom buttons, are a **copy** (⧉) and a **download** (⬇) button, the same pair every Generate tab mode has:
 
 | Button | What it does |
 |--------|-------------|
@@ -133,16 +133,27 @@ Renders the font using professionally designed proof texts (sourced from [typogr
 
 The Proofs tab renders using a live CSS `@font-face` built from the current axes, so it reflects the real typeset appearance (not SVG outlines).
 
-### Grow
-Grows the letterforms out of the current backbones — an experimental generative
-mode inspired by Namco's *Techno Drive* (1998) logotype.  Instead of offsetting
+### Generate
+Three experimental generative modes, all growing letterforms out of the
+*same* current backbones — pick one from the mode toolbar (**Bubble** /
+**Grow** / **Texture**) at the left of the top bar.  All the usual axes still
+apply, since every mode starts from the same solved spines.
+
+Every mode shares the same **save controls** (top bar, right): a **copy**
+icon copies the result as a transparent PNG to the clipboard, and a
+**download** icon saves a PNG by default — its caret dropdown offers PNG
+(transparent, high-res) or SVG (vector).  A **fast preview** checkbox renders
+just the first character at a coarser resolution while dragging sliders, and
+a **reset** icon restores the active mode's own settings (leaving the mode
+choice and the other modes' settings untouched).
+
+#### Bubble mode
+Inspired by Namco's *Techno Drive* (1998) logotype.  Instead of offsetting
 each spine by a fixed thickness, every stroke swells into the surrounding
 whitespace until the channel between it and the nearest *opposing* stroke
 narrows to a constant gap.  Counters (the holes in `a`, `e`, `o`) stay open
 because the opposing stroke pushes back, while joints (`n`, `e`) don't pinch.
-All the usual axes still apply, since growth starts from the same backbones.
 
-**Controls in the top bar:**
 | Control | Effect |
 |---------|--------|
 | `grow` | 0 = classic constant offset … 1 = full space-filling bulge |
@@ -152,15 +163,60 @@ All the usual axes still apply, since growth starts from the same backbones.
 | `layers` | Emit nested keyline bands (near-white core → light blue → dark blue → black keyline) that fuse between glyphs for a Y2K logotype look |
 | `animate` | Ramp the growth up and down so the letters visibly grow (WebGL only) |
 
-**Save controls** (top bar, right): a **copy** icon copies the result as a
-transparent PNG to the clipboard, and a **download** icon saves a PNG by
-default — its caret dropdown offers PNG (transparent, high-res) or SVG (vector).
-
 The preview renders on the GPU where WebGL2 is available: the worker computes a
 distance field once per text/axes change and a fragment shader thresholds it,
-so dragging `grow`/`gap`/`fuse`/`warp`/`layers` never re-runs the worker.  Without WebGL2 it
-falls back to a worker-rendered SVG.  Multi-line text is supported; a
+so dragging `grow`/`gap`/`fuse`/`warp`/`layers` never re-runs the worker.  Without
+WebGL2 it falls back to a worker-rendered SVG.  Multi-line text is supported; a
 determinate progress bar shows while the field is (re)built.
+
+#### Grow mode
+Space-colonisation branching (the venation algorithm): twigs grow from
+root nodes seeded along the spine toward randomly scattered attractor points
+in the counters and margins, consuming each attractor as a twig reaches it.
+At high attractor density / low pull radius it reads as bristly flared
+serifs; at low density / long pull radius, longer forking ivy-like tendrils.
+
+| Control | Effect |
+|---------|--------|
+| `density` | How densely attractors pack the counters/margins |
+| `influence` | Radius within which a twig "sees" and is pulled toward an attractor |
+| `kill dist` | Radius within which a reached attractor is consumed |
+| `step` | Twig segment length per growth iteration |
+| `iterations` | Growth steps to run |
+| `reach` | Farthest an attractor may sit from the spine |
+| `base radius` / `min radius` / `taper depth` | Twig taper from trunk to tip |
+| `backbone` (+ colour) | Show the classic (`grow=0`) outline underneath the twigs |
+| `colour` | Twig colour |
+| `seed` | RNG seed — same seed always grows the same twigs |
+
+This mode is always worker-rendered SVG (no WebGL path), since growth is an
+iterative simulation rather than a per-pixel field threshold.
+
+#### Texture mode
+Patterns confined to the interior of the grown (Bubble-mode) letterform —
+the field that defines the shape is reused purely as a domain mask.  Pick a
+**style** from the sub-toolbar: **Reaction-Diffusion**, **Maze**, or
+**Circuit**.
+
+| Control | Effect | Applies to |
+|---------|--------|-----------|
+| `grow` / `gap` / `fuse` | Shape the mask domain, same meaning as Bubble mode | all styles |
+| `seed` | RNG seed — same seed always gives the same pattern | all styles |
+| preset chips (`coral` / `cells` / `stitches`) | Gray–Scott reaction-diffusion parameter sets: thin branching veins, honeycomb cells, or scattered dashes-and-dots | Reaction-Diffusion |
+| `steps` | Simulation iterations — more develops the pattern further (slower) | Reaction-Diffusion |
+| `grain` | Corridor / trace width — coarser reads as a chunkier pattern | Maze, Circuit |
+| `density` | Fraction of the grid tried as circuit trace starting points | Circuit |
+| `colour` | Fill / wall colour | Reaction-Diffusion, Maze |
+| `trace` / `pad` colour | Circuit trace and pad colours | Circuit |
+| `backbone` (+ colour) | Show the classic outline underneath the pattern | all styles |
+
+Reaction-diffusion is a Gray-Scott simulation clamped to zero outside the
+mask every step, seeded with sparse fully-saturated points; maze is a perfect
+maze (recursive backtracker) carved through the mask's cell grid and
+rendered as the *uncarved* walls, so it traces the letterform's own shape;
+circuit is Manhattan-routed random-walk traces with pads at corners and
+ends, PCB-style.  Like Grow mode, this is always worker-rendered SVG — the
+simulations are iterative, not a per-pixel field threshold.
 
 ---
 
@@ -170,7 +226,8 @@ All tabs and settings are bookmarkable via URL parameters.
 
 | Parameter | Values | Effect |
 |-----------|--------|--------|
-| `?view=` | `font` `glyphs` `tweens` `visualDiffs` `splines` `splineGrid` `proofs` `grow` | Open the named tab on load |
+| `?view=` | `font` `glyphs` `tweens` `visualDiffs` `splines` `splineGrid` `proofs` `generate` | Open the named tab on load |
+| `?mode=` | `grow` `texture` (omit for Bubble, the default) | Pre-select a Generate tab mode |
 | `?zoom=` | e.g. `0.85` | Set initial zoom level for all tabs |
 | `?proof=` | `lowercase` `uppercase` `alphabet` `classic` | Select a proof preset |
 | `?book=` | integer index | Pre-select a specific classic book |

--- a/docs/growth-brainstorm.md
+++ b/docs/growth-brainstorm.md
@@ -67,6 +67,11 @@ flavours:
 * **Filled texture**: keep the classic outline but fill its interior (or its
   *counters*) with the pattern — zebra letters, coral letters.
 
+**Shipped** as the "Filled texture" flavour, in `web/src/texture.js`
+(`reactionDiffusion`) — the "Reaction-Diffusion" style of a new **Texture**
+mode on the Generate tab, alongside two more grid-restricted styles beyond
+the original brainstorm (see "Texture mode" below).
+
 ## Idea 4 — Differential growth on the outline (vector-native)
 
 Take the existing dense outline polyline and iterate: each vertex is
@@ -181,7 +186,10 @@ unlocks the standard SDF toolbox:
    *(shipped: a `warp` slider displaces the field lookup by value noise —
    `domainWarp` in `growth.js`, matching GLSL noise + `uWarp*` uniforms in
    `GrowCanvas.jsx`, seeded for determinism)*; run reaction–diffusion inside
-   the SDF band so patterns hug the letterform; extract the ridge (medial
+   the SDF band so patterns hug the letterform *(shipped as Texture mode's
+   `buildTextureMask` — the mask is literally `f >= 0` on the same field, so
+   the reaction-diffusion domain is exactly the letterform, not a separate
+   band around it — see "Texture mode" below)*; extract the ridge (medial
    axis) of an *imported* font's SDF to reverse-engineer backbones —
    Dactyl-izing arbitrary fonts.
 
@@ -189,7 +197,8 @@ Status: items 1, 2 and 4 are implemented (JFA + segment-exact distances in
 `web/src/growth.js`, shader preview in `web/src/GrowCanvas.jsx`); item 3 is
 partly implemented (the cross-glyph `fuse` slider — field channel in
 `growth.js`, `uFuse` uniform in `GrowCanvas.jsx`); item 6's domain-warp `warp`
-slider is implemented; item 5 (MSDF export) and the rest of item 6 are open.
+slider and reaction-diffusion sub-item are implemented; item 5 (MSDF export)
+and the medial-axis sub-item of 6 are open.
 
 ## Idea 5 prototype: space colonisation (added after this slice shipped)
 
@@ -213,3 +222,58 @@ implemented; the tapered stroke is a rendering approximation rather than a
 true vector outline (no OTF export path yet, unlike the Idea 1 growth
 field); multi-glyph fusion between branches of neighbouring letters is not
 attempted.
+
+## Texture mode: reaction-diffusion + maze + circuit (added after this slice shipped)
+
+A third mode on the Generate tab (alongside Bubble and Grow), `web/src/
+texture.js` + `web/src/textureSvg.js`: three patterns confined to the
+interior of a grown letterform. `buildTextureMask` reuses `buildGrowthField`
++ `fieldToF` from `growth.js` (the exact same rule `growStrokes` uses) to
+rasterise "inside the grown letterform" onto a grid — the pattern's domain is
+always what the Bubble mode would draw for the same `grow`/`gap`/`fuse`, no
+new spine/distance code needed. Every disconnected mask piece (separate
+letters that haven't fused, the two strokes of an `i`) is handled
+independently by each style, so counters and gaps stay correct.
+
+* **Reaction-Diffusion** (Idea 3 / SDF direction #6): classic Gray-Scott,
+  confined to the mask (`V`/`U` held at their rest state outside it every
+  step — a hard wall, so the pattern presses right up to the letterform edge
+  rather than tapering). Three presets (`coral`/`cells`/`stitches`), chosen
+  and tuned by actually rendering each rather than copied from a textbook
+  cheat sheet — Gray-Scott is highly sensitive to both the feed/kill
+  parameters *and* the seeding: small-amplitude noise decays to nothing
+  everywhere in this bounded-mask setup (not just off-preset regions), so all
+  three presets seed with sparse fully-saturated single-cell points instead.
+  The result is contoured to vector paths with a threshold derived from the
+  field's own mean (`defaultRdThreshold`) rather than a fixed constant — 0.5
+  only ever traced a sliver near the boundary in testing, nowhere near the
+  interior pattern, since Gray-Scott's peak is always near 1 regardless of
+  preset but its *mean* varies a lot.
+* **Maze**: a perfect maze (recursive backtracker / randomised DFS) carved
+  through the mask's cell grid, rendered as the *uncarved* walls — the
+  corridors are the letterform's own shape. Verified as a genuine spanning
+  forest (zero cycles, `corridors = cells − components`) by reconstructing
+  the corridor graph from the wall output in `texture.test.js`.
+  `connectedComponents` runs the backtracker separately per disconnected mask
+  piece, since a single spanning tree can't cross between them (a naive
+  single-component version would leave every piece but the first fully
+  walled).
+* **Circuit**: PCB-trace look — orthogonal random-walk traces with a bias to
+  keep going straight (Manhattan-routed, not a pure random walk), confined to
+  the mask and claiming their cells so traces don't cross; pads mark every
+  trace's ends and corners.
+
+All three render through the same `backbone` toggle (the classic outline as
+a light reference silhouette, reusing the mask-build's own field so no extra
+work) and the same copy/download save controls as Bubble and Grow.
+Diagnosing the reaction-diffusion seeding behaviour (why some presets held a
+"coral" veins pattern from a handful of sparse seeds while others decayed to
+nothing from the same seeding, and needed the threshold to be field-relative
+rather than fixed) was most of the implementation effort here — the maze and
+circuit algorithms themselves were correct on the first real render.
+
+Open follow-ups: `life` (cellular automata, Idea 2) and true reaction-
+diffusion-driven differential growth (Idea 4) are not implemented as
+Texture-mode styles; no OTF export path (vector-only, same gap as Grow
+mode); MSDF export (SDF direction #5) would give reaction-diffusion a sharper
+GPU-native alternative to marching-squares contours.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -6,6 +6,7 @@ import GrowCanvas from './GrowCanvas'
 import { downloadBlob, svgBlob, svgToPngBlob, growFilenameBase, filenameBase } from './growthExport'
 import { LAYER_COLORS } from './growth'
 import { DEFAULT_BRANCH_COLOR } from './branching'
+import { RD_PRESET_NAMES, DEFAULT_CIRCUIT_TRACE_COLOR, DEFAULT_CIRCUIT_PAD_COLOR } from './texture'
 import { downloadFont, buildFontDataUrl } from './fontExport'
 import { buildCompareOverlaySvg } from './fontCompare'
 import FontCompareControls from './FontCompareControls'
@@ -32,11 +33,30 @@ const defaultBranchParams = () => ({
   backbone: true, color: DEFAULT_BRANCH_COLOR, backboneColor: '#000000',
   maxReach: 140, baseRadius: 10, minRadius: 1.2, maxDepthForTaper: 14,
 })
+const defaultTextureParams = () => ({
+  style: 'rd', // 'rd' (reaction-diffusion) | 'maze' | 'circuit'
+  grow: 0.6, gap: 25, fuse: 0, growScale: 120,
+  backbone: true, backboneColor: '#e8e8e8',
+  seed: 1,
+  // Reaction-diffusion
+  preset: 'coral', steps: 3000, color: '#ff6f4a',
+  // Maze / circuit share a coarser grid ("grain" in the UI) than the RD
+  // field default; textureSvg.js calls this `cell`.
+  cell: 18,
+  // Circuit
+  density: 0.12, traceColor: DEFAULT_CIRCUIT_TRACE_COLOR, padColor: DEFAULT_CIRCUIT_PAD_COLOR,
+})
 
 // Field grid spacing used for the "fast preview" toggle — coarser than the
 // normal 3–6 cellFor(text) range, so slider drags stay responsive on slow
 // modes (Grow especially) instead of recomputing at full resolution.
 const PREVIEW_CELL = 10
+
+// Texture mode's `cell` ("grain" in the UI) only applies to the maze/circuit
+// styles — reaction-diffusion wants its own finer, text-length-scaled
+// default (textureSvg.js's cellFor), so strip it out for that style rather
+// than let the shared params object's grain value override it.
+const textureWorkerParams = (p) => (p.style === 'rd' ? { ...p, cell: undefined } : p)
 
 // Build the two axes variants (and key labels) for the Visual Diffs tab
 function getDiffAxes(axes, diffConfig) {
@@ -155,15 +175,17 @@ function App() {
   const [tweenFilter, setTweenFilter] = useState(
     () => new URLSearchParams(window.location.search).get('tween') || ''
   )
-  // Generate tab: which generative mode is active. Two UI-facing values:
+  // Generate tab: which generative mode is active. Three UI-facing values:
   // 'bubble' (constant-gap SDF inflation, implemented in growth.js/growParams
-  // — code keeps the "grow" name since that's the algorithm's name) and
-  // 'grow' (space-colonisation twigs, implemented in branching.js/branchParams
-  // — code keeps the "branch" name). URL-addressable so a chosen mode is
+  // — code keeps the "grow" name since that's the algorithm's name), 'grow'
+  // (space-colonisation twigs, implemented in branching.js/branchParams —
+  // code keeps the "branch" name), and 'texture' (reaction-diffusion / maze /
+  // circuit patterns confined to the letterform, implemented in
+  // texture.js/textureParams). URL-addressable so a chosen mode is
   // shareable/deep-linkable, same as compareMode.
   const [generateMode, setGenerateMode] = useState(() => {
     const m = new URLSearchParams(window.location.search).get('mode')
-    return m === 'grow' ? 'grow' : 'bubble'
+    return (m === 'grow' || m === 'texture') ? m : 'bubble'
   })
   // Bubble mode ('grow' internally): constant-gap growth parameters (see growth.js)
   const [growParams, setGrowParams] = useState(defaultGrowParams)
@@ -171,6 +193,8 @@ function App() {
   // (see branching.js). Dense/tight enough that twig coverage alone reads
   // legibly with the backbone off, not just with it on.
   const [branchParams, setBranchParams] = useState(defaultBranchParams)
+  // Texture mode: reaction-diffusion / maze / circuit patterns (see texture.js).
+  const [textureParams, setTextureParams] = useState(defaultTextureParams)
   // Fast preview: render just the first character at PREVIEW_CELL resolution
   // instead of the full text, for responsive slider dragging on slow modes.
   const [fastPreview, setFastPreview] = useState(false)
@@ -187,6 +211,11 @@ function App() {
   const [branchCopied, setBranchCopied] = useState(false)
   const [branchMenuOpen, setBranchMenuOpen] = useState(false)
   const branchMenuRef = useRef(null)
+  // Texture mode export state — mirrors the Bubble/Grow ones above.
+  const [savingTexture, setSavingTexture] = useState(false)
+  const [textureCopied, setTextureCopied] = useState(false)
+  const [textureMenuOpen, setTextureMenuOpen] = useState(false)
+  const textureMenuRef = useRef(null)
   // Font tab image export (same PNG/SVG copy + download as Grow, on the canvas)
   const [savingFontImage, setSavingFontImage] = useState(false)
   const [fontCopied, setFontCopied] = useState(false)
@@ -265,7 +294,7 @@ function App() {
   const setGenerateModeWithUrl = (m) => {
     setGenerateMode(m)
     const url = new URL(window.location)
-    if (m === 'grow') url.searchParams.set('mode', 'grow')
+    if (m === 'grow' || m === 'texture') url.searchParams.set('mode', m)
     else url.searchParams.delete('mode')
     window.history.replaceState({}, '', url)
   }
@@ -671,6 +700,15 @@ function App() {
       if (generateMode === 'grow') {
         typeReq = 'branch'
         args = [previewText, axes, fastPreview ? { ...branchParams, cell: PREVIEW_CELL } : branchParams]
+      } else if (generateMode === 'texture') {
+        typeReq = 'texture'
+        // Only the rd style benefits from PREVIEW_CELL: maze/circuit already
+        // run their own (coarser, already-fast) grid, and forcing a finer
+        // PREVIEW_CELL on them would make fast-preview slower, not faster.
+        const tp = fastPreview && textureParams.style === 'rd'
+          ? { ...textureParams, cell: PREVIEW_CELL }
+          : textureParams
+        args = [previewText, axes, textureWorkerParams(tp)]
       } else {
         typeReq = 'growth'
         args = [previewText, axes, fastPreview ? { ...growParams, cell: PREVIEW_CELL } : growParams]
@@ -697,7 +735,7 @@ function App() {
       clearTimeout(timer)
       worker.terminate()
     }
-  }, [text, axes, activeTab, glyphsDefsText, glyphsFilled, diffConfig, compareMode, generateMode, growParams, branchParams, fastPreview, perGlyphTextAxes])
+  }, [text, axes, activeTab, glyphsDefsText, glyphsFilled, diffConfig, compareMode, generateMode, growParams, branchParams, textureParams, fastPreview, perGlyphTextAxes])
 
   // Close the Bubble download-format menu on outside click / Escape.
   useEffect(() => {
@@ -728,6 +766,21 @@ function App() {
       document.removeEventListener('keydown', onKey)
     }
   }, [branchMenuOpen])
+
+  // Close the Texture download-format menu on outside click / Escape.
+  useEffect(() => {
+    if (!textureMenuOpen) return
+    const onDown = (e) => {
+      if (textureMenuRef.current && !textureMenuRef.current.contains(e.target)) setTextureMenuOpen(false)
+    }
+    const onKey = (e) => { if (e.key === 'Escape') setTextureMenuOpen(false) }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [textureMenuOpen])
 
   // Same for the Font tab's download-format menu.
   useEffect(() => {
@@ -1065,6 +1118,10 @@ function App() {
     if (!text) { resolve(''); return }
     const worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' })
     worker.onmessage = (e) => {
+      // Ignore intermediate { type: 'progress' } ticks — resolving on the
+      // first one (instead of the final result) would silently save an
+      // empty/undefined SVG for slower (longer-text) renders.
+      if (e.data.type === 'progress') return
       worker.terminate()
       if (e.data.error) reject(new Error(e.data.error))
       else resolve(e.data.result)
@@ -1125,6 +1182,8 @@ function App() {
     if (!text) { resolve(''); return }
     const worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' })
     worker.onmessage = (e) => {
+      // Ignore intermediate { type: 'progress' } ticks — see requestGrowthSvg.
+      if (e.data.type === 'progress') return
       worker.terminate()
       if (e.data.error) reject(new Error(e.data.error))
       else resolve(e.data.result)
@@ -1175,6 +1234,68 @@ function App() {
     }
   }
 
+  // Render the current Texture mode view to a vector SVG string via a
+  // one-off worker, for both SVG and PNG downloads — mirrors requestBranchSvg.
+  const requestTextureSvg = () => new Promise((resolve, reject) => {
+    if (!text) { resolve(''); return }
+    const worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' })
+    worker.onmessage = (e) => {
+      // Texture mode's reaction-diffusion simulation reports many intermediate
+      // { type: 'progress' } ticks before the final result — ignore those and
+      // wait for the message that actually carries a result/error, or this
+      // resolves (with undefined) on the very first progress tick instead of
+      // the finished SVG.
+      if (e.data.type === 'progress') return
+      worker.terminate()
+      if (e.data.error) reject(new Error(e.data.error))
+      else resolve(e.data.result)
+    }
+    worker.onerror = (err) => { worker.terminate(); reject(err) }
+    worker.postMessage({ id: 0, type: 'texture', args: [text, axes, textureWorkerParams(textureParams)] })
+  })
+
+  const handleDownloadTexture = async (format) => {
+    setTextureMenuOpen(false)
+    setSavingTexture(true)
+    setError(null)
+    try {
+      const svg = await requestTextureSvg()
+      if (!svg) return
+      const base = filenameBase('texture', text)
+      if (format === 'svg') {
+        downloadBlob(svgBlob(svg), `${base}.svg`)
+      } else {
+        const png = await svgToPngBlob(svg, { scale: 3, background: null })
+        downloadBlob(png, `${base}.png`)
+      }
+    } catch (e) {
+      setError(`Texture ${format.toUpperCase()} export failed: ${e.message}`)
+    } finally {
+      setSavingTexture(false)
+    }
+  }
+
+  const handleCopyTexture = async () => {
+    if (!navigator.clipboard || typeof ClipboardItem === 'undefined') {
+      setError('Clipboard image copy is not supported in this browser')
+      return
+    }
+    setSavingTexture(true)
+    setError(null)
+    try {
+      const svg = await requestTextureSvg()
+      if (!svg) throw new Error('nothing to copy')
+      const png = await svgToPngBlob(svg, { scale: 3, background: null })
+      await navigator.clipboard.write([new ClipboardItem({ 'image/png': png })])
+      setTextureCopied(true)
+      setTimeout(() => setTextureCopied(false), 1500)
+    } catch (e) {
+      setError(`Texture copy failed: ${e.message}`)
+    } finally {
+      setSavingTexture(false)
+    }
+  }
+
   const handleControlChange = (name, value) => {
     setAxes(prev => ({ ...prev, [name]: value }))
   }
@@ -1188,6 +1309,7 @@ function App() {
   // the mode selection (and the other mode's settings) untouched.
   const handleResetGenerateParams = () => {
     if (generateMode === 'bubble') setGrowParams(defaultGrowParams())
+    else if (generateMode === 'texture') setTextureParams(defaultTextureParams())
     else setBranchParams(defaultBranchParams())
   }
 
@@ -1436,6 +1558,12 @@ function App() {
                     onClick={() => setGenerateModeWithUrl('grow')}
                   >
                     Grow
+                  </button>
+                  <button
+                    className={`proof-chip ${generateMode === 'texture' ? 'selected' : ''}`}
+                    onClick={() => setGenerateModeWithUrl('texture')}
+                  >
+                    Texture
                   </button>
                 </div>
                 <button
@@ -1771,6 +1899,226 @@ function App() {
                             PNG <span style={{ opacity: 0.55, marginLeft: 'auto', fontSize: '0.8em' }}>transparent</span>
                           </button>
                           <button className="grow-menu-item" role="menuitem" onClick={() => handleDownloadBranch('svg')}>
+                            <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>polyline</span>
+                            SVG <span style={{ opacity: 0.55, marginLeft: 'auto', fontSize: '0.8em' }}>vector</span>
+                          </button>
+                        </div>
+                      )}
+                    </span>
+                  </span>
+                </>)}
+                {generateMode === 'texture' && (<>
+                  <div className="proof-chips" style={{ marginLeft: 0 }}>
+                    <button
+                      className={`proof-chip ${textureParams.style === 'rd' ? 'selected' : ''}`}
+                      onClick={() => setTextureParams(p => ({ ...p, style: 'rd' }))}
+                    >
+                      Reaction-Diffusion
+                    </button>
+                    <button
+                      className={`proof-chip ${textureParams.style === 'maze' ? 'selected' : ''}`}
+                      onClick={() => setTextureParams(p => ({ ...p, style: 'maze' }))}
+                    >
+                      Maze
+                    </button>
+                    <button
+                      className={`proof-chip ${textureParams.style === 'circuit' ? 'selected' : ''}`}
+                      onClick={() => setTextureParams(p => ({ ...p, style: 'circuit' }))}
+                    >
+                      Circuit
+                    </button>
+                  </div>
+                  <div className="controls-break" />
+                  <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }} title="How far the domain bulges beyond the classic outline">
+                    grow
+                    <input
+                      type="range" min="0" max="1" step="0.05"
+                      value={textureParams.grow}
+                      onChange={e => setTextureParams(p => ({ ...p, grow: parseFloat(e.target.value) }))}
+                    />
+                    <span style={{ minWidth: '2.5em' }}>{textureParams.grow.toFixed(2)}</span>
+                  </label>
+                  <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                    gap
+                    <input
+                      type="range" min="5" max="100" step="5"
+                      value={textureParams.gap}
+                      onChange={e => setTextureParams(p => ({ ...p, gap: parseFloat(e.target.value) }))}
+                    />
+                    <span style={{ minWidth: '2em' }}>{textureParams.gap}</span>
+                  </label>
+                  <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }} title="Melt neighbouring letters' domains together">
+                    fuse
+                    <input
+                      type="range" min="0" max="1" step="0.05"
+                      value={textureParams.fuse}
+                      onChange={e => setTextureParams(p => ({ ...p, fuse: parseFloat(e.target.value) }))}
+                    />
+                    <span style={{ minWidth: '2.5em' }}>{textureParams.fuse.toFixed(2)}</span>
+                  </label>
+                  <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                    seed
+                    <input
+                      type="range" min="1" max="50" step="1"
+                      value={textureParams.seed}
+                      onChange={e => setTextureParams(p => ({ ...p, seed: parseFloat(e.target.value) }))}
+                    />
+                    <span style={{ minWidth: '2em' }}>{textureParams.seed}</span>
+                  </label>
+                  <div className="controls-break" />
+                  {textureParams.style === 'rd' && (<>
+                    <div className="proof-chips" style={{ marginLeft: 0 }}>
+                      {RD_PRESET_NAMES.map(name => (
+                        <button
+                          key={name}
+                          className={`proof-chip ${textureParams.preset === name ? 'selected' : ''}`}
+                          onClick={() => setTextureParams(p => ({ ...p, preset: name }))}
+                        >
+                          {name}
+                        </button>
+                      ))}
+                    </div>
+                    <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }} title="More steps develop the pattern further (slower)">
+                      steps
+                      <input
+                        type="range" min="1000" max="6000" step="250"
+                        value={textureParams.steps}
+                        onChange={e => setTextureParams(p => ({ ...p, steps: parseFloat(e.target.value) }))}
+                      />
+                      <span style={{ minWidth: '3em' }}>{textureParams.steps}</span>
+                    </label>
+                    <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                      colour
+                      <input
+                        type="color"
+                        value={textureParams.color}
+                        onChange={e => setTextureParams(p => ({ ...p, color: e.target.value }))}
+                      />
+                    </label>
+                  </>)}
+                  {textureParams.style === 'maze' && (<>
+                    <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }} title="Corridor width — coarser reads as a chunkier maze">
+                      grain
+                      <input
+                        type="range" min="8" max="32" step="2"
+                        value={textureParams.cell}
+                        onChange={e => setTextureParams(p => ({ ...p, cell: parseFloat(e.target.value) }))}
+                      />
+                      <span style={{ minWidth: '2em' }}>{textureParams.cell}</span>
+                    </label>
+                    <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                      colour
+                      <input
+                        type="color"
+                        value={textureParams.color}
+                        onChange={e => setTextureParams(p => ({ ...p, color: e.target.value }))}
+                      />
+                    </label>
+                  </>)}
+                  {textureParams.style === 'circuit' && (<>
+                    <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }} title="Trace width — coarser reads as chunkier PCB traces">
+                      grain
+                      <input
+                        type="range" min="8" max="32" step="2"
+                        value={textureParams.cell}
+                        onChange={e => setTextureParams(p => ({ ...p, cell: parseFloat(e.target.value) }))}
+                      />
+                      <span style={{ minWidth: '2em' }}>{textureParams.cell}</span>
+                    </label>
+                    <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }} title="Fraction of the available grid tried as trace starting points">
+                      density
+                      <input
+                        type="range" min="0.05" max="0.3" step="0.01"
+                        value={textureParams.density}
+                        onChange={e => setTextureParams(p => ({ ...p, density: parseFloat(e.target.value) }))}
+                      />
+                      <span style={{ minWidth: '2.5em' }}>{textureParams.density.toFixed(2)}</span>
+                    </label>
+                    <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                      trace
+                      <input
+                        type="color"
+                        value={textureParams.traceColor}
+                        onChange={e => setTextureParams(p => ({ ...p, traceColor: e.target.value }))}
+                      />
+                    </label>
+                    <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                      pad
+                      <input
+                        type="color"
+                        value={textureParams.padColor}
+                        onChange={e => setTextureParams(p => ({ ...p, padColor: e.target.value }))}
+                      />
+                    </label>
+                  </>)}
+                  <div className="controls-break" />
+                  <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                    backbone
+                    <input
+                      type="checkbox"
+                      checked={textureParams.backbone}
+                      onChange={e => setTextureParams(p => ({ ...p, backbone: e.target.checked }))}
+                    />
+                  </label>
+                  {textureParams.backbone && (
+                    <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                      backbone colour
+                      <input
+                        type="color"
+                        value={textureParams.backboneColor}
+                        onChange={e => setTextureParams(p => ({ ...p, backboneColor: e.target.value }))}
+                      />
+                    </label>
+                  )}
+                  <div className="controls-break" />
+                  <span style={{ display: 'flex', alignItems: 'center', gap: '4px', marginLeft: '4px' }}>
+                    <button
+                      className="icon-button"
+                      onClick={handleCopyTexture}
+                      disabled={savingTexture || !text}
+                      title="Copy PNG to clipboard"
+                    >
+                      <span className="material-symbols-outlined" style={{ fontSize: '20px' }}>
+                        {textureCopied ? 'check' : 'content_copy'}
+                      </span>
+                    </button>
+                    {/* Download defaults to PNG; the caret opens a PNG/SVG menu. */}
+                    <span ref={textureMenuRef} className="grow-download-split" style={{ display: 'flex', alignItems: 'center', gap: '4px', position: 'relative' }}>
+                      <button
+                        className="icon-button"
+                        onClick={() => handleDownloadTexture('png')}
+                        disabled={savingTexture || !text}
+                        title="Download PNG (transparent, high-res)"
+                      >
+                        <span className="material-symbols-outlined" style={{ fontSize: '20px' }}>
+                          {savingTexture ? 'hourglass_empty' : 'download'}
+                        </span>
+                      </button>
+                      <button
+                        className="icon-button"
+                        onClick={() => setTextureMenuOpen(o => !o)}
+                        disabled={savingTexture || !text}
+                        title="Choose download format"
+                        aria-haspopup="menu"
+                        aria-expanded={textureMenuOpen}
+                        style={{ width: '24px', minWidth: '24px', padding: '6px 0' }}
+                      >
+                        <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>arrow_drop_down</span>
+                      </button>
+                      {textureMenuOpen && (
+                        <div
+                          role="menu"
+                          style={{
+                            position: 'absolute', top: '100%', right: 0, marginTop: '4px', zIndex: 20,
+                            background: 'var(--panel-bg)', border: '1px solid var(--border-color)',
+                            borderRadius: 'var(--radius-md)', boxShadow: '0 4px 12px rgba(0,0,0,0.4)', overflow: 'hidden', minWidth: '160px',
+                          }}
+                        >
+                          <button className="grow-menu-item" role="menuitem" onClick={() => handleDownloadTexture('png')}>
+                            <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>image</span>
+                            PNG <span style={{ opacity: 0.55, marginLeft: 'auto', fontSize: '0.8em' }}>transparent</span>
+                          </button>
+                          <button className="grow-menu-item" role="menuitem" onClick={() => handleDownloadTexture('svg')}>
                             <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>polyline</span>
                             SVG <span style={{ opacity: 0.55, marginLeft: 'auto', fontSize: '0.8em' }}>vector</span>
                           </button>

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -43,6 +43,10 @@ const defaultTextureParams = () => ({
   // Maze / circuit share a coarser grid ("grain" in the UI) than the RD
   // field default; textureSvg.js calls this `cell`.
   cell: 18,
+  // Maze / circuit share an outline width; maze has its own outline colour
+  // (kept separate from RD's `color` so switching styles doesn't carry over
+  // an unrelated fill colour as the wall colour).
+  strokeWidth: 3, wallColor: '#222222',
   // Circuit
   density: 0.12, traceColor: DEFAULT_CIRCUIT_TRACE_COLOR, padColor: DEFAULT_CIRCUIT_PAD_COLOR,
 })
@@ -2006,12 +2010,21 @@ function App() {
                       />
                       <span style={{ minWidth: '2em' }}>{textureParams.cell}</span>
                     </label>
+                    <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }} title="Wall stroke width">
+                      outline width
+                      <input
+                        type="range" min="1" max="10" step="0.5"
+                        value={textureParams.strokeWidth}
+                        onChange={e => setTextureParams(p => ({ ...p, strokeWidth: parseFloat(e.target.value) }))}
+                      />
+                      <span style={{ minWidth: '2em' }}>{textureParams.strokeWidth}</span>
+                    </label>
                     <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                      colour
+                      outline colour
                       <input
                         type="color"
-                        value={textureParams.color}
-                        onChange={e => setTextureParams(p => ({ ...p, color: e.target.value }))}
+                        value={textureParams.wallColor}
+                        onChange={e => setTextureParams(p => ({ ...p, wallColor: e.target.value }))}
                       />
                     </label>
                   </>)}
@@ -2034,6 +2047,15 @@ function App() {
                       />
                       <span style={{ minWidth: '2.5em' }}>{textureParams.density.toFixed(2)}</span>
                     </label>
+                    <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }} title="Trace stroke width">
+                      outline width
+                      <input
+                        type="range" min="1" max="12" step="0.5"
+                        value={textureParams.strokeWidth}
+                        onChange={e => setTextureParams(p => ({ ...p, strokeWidth: parseFloat(e.target.value) }))}
+                      />
+                      <span style={{ minWidth: '2em' }}>{textureParams.strokeWidth}</span>
+                    </label>
                     <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
                       trace
                       <input
@@ -2052,8 +2074,8 @@ function App() {
                     </label>
                   </>)}
                   <div className="controls-break" />
-                  <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                    backbone
+                  <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }} title="Fill the letterform silhouette behind the pattern">
+                    background
                     <input
                       type="checkbox"
                       checked={textureParams.backbone}
@@ -2062,7 +2084,7 @@ function App() {
                   </label>
                   {textureParams.backbone && (
                     <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                      backbone colour
+                      background colour
                       <input
                         type="color"
                         value={textureParams.backboneColor}

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -37,15 +37,18 @@ const defaultTextureParams = () => ({
   style: 'rd', // 'rd' (reaction-diffusion) | 'maze' | 'circuit'
   grow: 0.6, gap: 25, fuse: 0, growScale: 120,
   backbone: true, backboneColor: '#e8e8e8',
+  // Thick keyline band hugging the letterform's outer edge — same technique
+  // as Bubble mode's dark outer layer (two field contours, evenodd-filled).
+  edgeOutline: true, edgeOutlineWidth: 24, edgeOutlineColor: '#000000',
   seed: 1,
   // Reaction-diffusion
   preset: 'coral', steps: 3000, color: '#ff6f4a',
   // Maze / circuit share a coarser grid ("grain" in the UI) than the RD
   // field default; textureSvg.js calls this `cell`.
   cell: 18,
-  // Maze / circuit share an outline width; maze has its own outline colour
-  // (kept separate from RD's `color` so switching styles doesn't carry over
-  // an unrelated fill colour as the wall colour).
+  // Maze / circuit share a stroke width; maze has its own wall colour (kept
+  // separate from RD's `color` so switching styles doesn't carry over an
+  // unrelated fill colour as the wall colour).
   strokeWidth: 3, wallColor: '#222222',
   // Circuit
   density: 0.12, traceColor: DEFAULT_CIRCUIT_TRACE_COLOR, padColor: DEFAULT_CIRCUIT_PAD_COLOR,
@@ -2011,7 +2014,7 @@ function App() {
                       <span style={{ minWidth: '2em' }}>{textureParams.cell}</span>
                     </label>
                     <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }} title="Wall stroke width">
-                      outline width
+                      maze width
                       <input
                         type="range" min="1" max="10" step="0.5"
                         value={textureParams.strokeWidth}
@@ -2020,7 +2023,7 @@ function App() {
                       <span style={{ minWidth: '2em' }}>{textureParams.strokeWidth}</span>
                     </label>
                     <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                      outline colour
+                      maze colour
                       <input
                         type="color"
                         value={textureParams.wallColor}
@@ -2048,7 +2051,7 @@ function App() {
                       <span style={{ minWidth: '2.5em' }}>{textureParams.density.toFixed(2)}</span>
                     </label>
                     <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }} title="Trace stroke width">
-                      outline width
+                      trace width
                       <input
                         type="range" min="1" max="12" step="0.5"
                         value={textureParams.strokeWidth}
@@ -2092,6 +2095,33 @@ function App() {
                       />
                     </label>
                   )}
+                  <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }} title="A thick keyline band hugging the letterform's outer edge">
+                    outline
+                    <input
+                      type="checkbox"
+                      checked={textureParams.edgeOutline}
+                      onChange={e => setTextureParams(p => ({ ...p, edgeOutline: e.target.checked }))}
+                    />
+                  </label>
+                  {textureParams.edgeOutline && (<>
+                    <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                      outline width
+                      <input
+                        type="range" min="5" max="60" step="1"
+                        value={textureParams.edgeOutlineWidth}
+                        onChange={e => setTextureParams(p => ({ ...p, edgeOutlineWidth: parseFloat(e.target.value) }))}
+                      />
+                      <span style={{ minWidth: '2em' }}>{textureParams.edgeOutlineWidth}</span>
+                    </label>
+                    <label style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                      outline colour
+                      <input
+                        type="color"
+                        value={textureParams.edgeOutlineColor}
+                        onChange={e => setTextureParams(p => ({ ...p, edgeOutlineColor: e.target.value }))}
+                      />
+                    </label>
+                  </>)}
                   <div className="controls-break" />
                   <span style={{ display: 'flex', alignItems: 'center', gap: '4px', marginLeft: '4px' }}>
                     <button

--- a/web/src/branching.js
+++ b/web/src/branching.js
@@ -15,7 +15,8 @@
 import { SampleGrid } from './growth.js'
 
 /// Deterministic PRNG (mulberry32) so a `seed` param keeps visual tests stable.
-function mulberry32(seed) {
+/// Exported for reuse by texture.js (reaction-diffusion seeding, maze/circuit RNG).
+export function mulberry32(seed) {
     let a = seed >>> 0
     return () => {
         a = (a + 0x6D2B79F5) | 0

--- a/web/src/growth.js
+++ b/web/src/growth.js
@@ -624,7 +624,8 @@ export function buildGrowthField(strokes, opts = {}) {
 /// Marching squares at iso value `iso` over field f (ny rows × nx cols, grid
 /// spacing h, origin x0/y0).  Returns closed contours as arrays of [x,y].
 /// Assumes the field border is below every iso used (padded), so all contours close.
-function marchingSquares(f, nx, ny, x0, y0, h, iso) {
+/// Exported for reuse by texture.js (contouring the reaction-diffusion V field).
+export function marchingSquares(f, nx, ny, x0, y0, h, iso) {
     // Key each contour segment by its start/end cell-edge so successive
     // segments chain into polylines.  Edge id: (edge orientation, ix, iy).
     const segStarts = new Map() // edgeKey -> next edgeKey
@@ -714,8 +715,9 @@ function marchingSquares(f, nx, ny, x0, y0, h, iso) {
     return contours
 }
 
-/// Ramer–Douglas–Peucker simplification of a closed contour.
-function simplify(pts, eps) {
+/// Ramer–Douglas–Peucker simplification of a closed contour.  Exported for
+/// reuse by texture.js.
+export function simplify(pts, eps) {
     if (pts.length < 8) return pts
     const keep = new Uint8Array(pts.length)
     keep[0] = 1
@@ -746,6 +748,36 @@ function simplify(pts, eps) {
     const out = []
     for (let i = 0; i < pts.length; i++) if (keep[i]) out.push(pts[i])
     return out
+}
+
+/// Apply the constant-gap growth rule to a built field, producing the scalar
+/// field f (ink iff f >= 0).  Factored out of growStrokes so texture.js can
+/// reuse the exact same rule to derive a letterform mask (f >= 0) as the
+/// domain for reaction-diffusion / maze / circuit patterns.
+///
+/// field: the object returned by buildGrowthField.
+/// params: thickness, grow, growScale, gap, fuse (same meanings as growStrokes).
+export function fieldToF(field, params = {}) {
+    const { rg, nx, ny } = field
+    const thickness = params.thickness ?? 30
+    const grow = params.grow ?? 0.5
+    const growScale = params.growScale ?? 120
+    const gap = params.gap ?? thickness * 0.8
+    const fuse = params.fuse ?? 0
+    const rMin = thickness / 2
+    const rMax = rMin + grow * growScale
+    // At full fuse, cross-glyph cells drop the gap and overlap by fuseMerge so
+    // the two fronts guarantee a merged blob rather than merely kissing.
+    const fuseMerge = rMin
+
+    const f = new Float32Array(nx * ny)
+    for (let k = 0; k < nx * ny; k++) {
+        const cross = rg[k * 3 + 2]
+        const g = gap - cross * fuse * (gap + fuseMerge)
+        const rAllowed = Math.max(rMin, Math.min(rMax, rg[k * 3 + 1] - g))
+        f[k] = rAllowed - rg[k * 3]
+    }
+    return f
 }
 
 /// Grow strokes into a field and contour it (the vector path: SVG, and later
@@ -797,20 +829,10 @@ export function growStrokes(strokes, params = {}) {
     })
     if (!field) return { levels: isoLevels.map(iso => ({ iso, contours: [] })), bbox: null, stats: {} }
 
-    const { rg, nx, ny, x0, y0 } = field
+    const { nx, ny, x0, y0 } = field
     const rMin = thickness / 2
     const rMax = rMin + grow * growScale
-    // At full fuse, cross-glyph cells drop the gap and overlap by fuseMerge so
-    // the two fronts guarantee a merged blob rather than merely kissing.
-    const fuseMerge = rMin
-
-    let f = new Float32Array(nx * ny)
-    for (let k = 0; k < nx * ny; k++) {
-        const cross = rg[k * 3 + 2]
-        const g = gap - cross * fuse * (gap + fuseMerge)
-        const rAllowed = Math.max(rMin, Math.min(rMax, rg[k * 3 + 1] - g))
-        f[k] = rAllowed - rg[k * 3]
-    }
+    let f = fieldToF(field, { thickness, grow, growScale, gap, fuse })
     f = blurField(f, nx, ny, smoothPasses)
 
     // Domain-warp the grown field for an organic wobble.  Warping f (not the

--- a/web/src/texture.js
+++ b/web/src/texture.js
@@ -1,0 +1,413 @@
+// Texture mode (brainstorm Idea 3 + extensions): patterns confined to the
+// interior of a grown letterform, using the Bubble mode's SDF field purely as
+// a *domain mask* — "run reaction-diffusion inside the SDF band so patterns
+// hug the letterform" (docs/growth-brainstorm.md, SDF direction #6), extended
+// here to two more grid-restricted styles beyond reaction-diffusion:
+//
+//   - reactionDiffusion: classic Gray-Scott, confined to the mask, producing
+//     organic coral/spot/stripe/mitosis textures.
+//   - maze: a perfect maze (recursive-backtracker) carved through the mask's
+//     cell grid, rendered as the *uncarved* walls — rectilinear corridors
+//     that trace the letterform's shape.
+//   - circuit: orthogonal random-walk traces with corner pads, Manhattan-
+//     routed through the mask — a PCB-trace look.
+//
+// All three share one domain: buildTextureMask rasterises "inside the grown
+// letterform" (the same f = rAllowed - d1 >= 0 rule as growStrokes, via
+// growth.js's fieldToF) onto a grid, coarser than the SDF field's own `cell`
+// for maze/circuit (so corridors/traces read as a pattern, not grid noise),
+// but reusing the *same* field machinery — no new spine/distance code needed.
+
+import { buildGrowthField, fieldToF, marchingSquares, simplify } from './growth.js'
+import { mulberry32 } from './branching.js'
+
+/// Rasterise "inside the grown letterform" as a Uint8Array mask on a grid.
+/// Reuses buildGrowthField + fieldToF (the exact same rule growStrokes uses),
+/// so the pattern's domain always matches what the Bubble mode would draw for
+/// the same grow/gap/fuse.
+///
+/// strokes: [{ pts: [[x,y],...], closed: bool, glyph?: int }], as from glyphSpines.js.
+/// opts:
+///   thickness, growScale, gap, fuse, grow — same meanings as growStrokes (grow
+///     default 0.6: some bulge, so counters/margins have room for a pattern).
+///   cell — grid spacing in font units; coarser reads as a chunkier pattern
+///     (default 4, but maze/circuit want much coarser — see their own opts).
+///   onProgress — optional (0..1), spans the field build.
+///
+/// Returns { mask, f, nx, ny, x0, y0, cell } or null for empty strokes; `f` is
+/// kept so callers can also contour the classic outline (iso 0) for a
+/// "backbone" reference, without rebuilding the field.
+export function buildTextureMask(strokes, opts = {}) {
+    const thickness = opts.thickness ?? 30
+    const grow = opts.grow ?? 0.6
+    const growScale = opts.growScale ?? 120
+    const gap = opts.gap ?? thickness * 0.8
+    const fuse = opts.fuse ?? 0
+    const cell = opts.cell ?? 4
+
+    const field = buildGrowthField(strokes, {
+        thickness, growScale, cell,
+        counterK: opts.counterK,
+        onProgress: opts.onProgress,
+    })
+    if (!field) return null
+
+    const f = fieldToF(field, { thickness, grow, growScale, gap, fuse })
+    const { nx, ny, x0, y0 } = field
+    const mask = new Uint8Array(nx * ny)
+    for (let k = 0; k < nx * ny; k++) mask[k] = f[k] >= 0 ? 1 : 0
+    return { mask, f, nx, ny, x0, y0, cell }
+}
+
+// Named Gray-Scott parameter sets (feed rate F, kill rate K; diffusion rates
+// Du/Dv are the standard 0.16/0.08 for all of them).  Chosen and verified by
+// actually rendering each at full text scale and eyeballing the result, not
+// copied blind from a textbook cheat sheet: Gray-Scott is notoriously
+// sensitive to F/K *and* to seeding (isolated point seeds decay to nothing in
+// most of the parameter space — only a band near `coral` self-propagates from
+// sparse points; everywhere else needs a large-enough nucleus, and a hard,
+// letterform-shaped mask boundary shifts what "large enough" means versus the
+// usual periodic-domain demos).  These three all reliably fill the whole
+// mask from the same simple sparse single-cell seeding (see
+// reactionDiffusion), which is why the set stops at three rather than
+// chasing textbook names like "mitosis" that didn't reproduce here.
+const RD_PRESETS = {
+    coral:    { F: 0.0545, K: 0.0620 }, // thin branching veins
+    cells:    { F: 0.0620, K: 0.0610 }, // honeycomb / cellular
+    stitches: { F: 0.0500, K: 0.0650 }, // scattered dashes and dots
+}
+export const RD_PRESET_NAMES = Object.keys(RD_PRESETS)
+
+/// Gray-Scott reaction-diffusion, confined to `mask` (V and U are held at
+/// their rest state 0/1 outside it every step — a hard wall, not a periodic
+/// or reflecting boundary, so the pattern presses right up to the letterform
+/// edge rather than tapering into it).
+///
+/// mask, nx, ny: as from buildTextureMask.
+/// opts:
+///   preset — one of RD_PRESET_NAMES (default 'coral').
+///   steps — iterations to run (default 3000; more = more developed pattern,
+///     roughly linear cost).
+///   seedFrac — fraction of mask cells that start fully activated (default
+///     0.05); the reaction only takes hold from a *fully saturated* nucleus
+///     (V=1, U=0) — small-amplitude noise decays back to the trivial state
+///     for all three presets, so this isn't a "jitter strength" knob, it's a
+///     density of all-or-nothing starting points.
+///   seed — RNG seed for the random seed points (default 1).
+///   onProgress — optional (0..1) across the simulation.
+///
+/// Returns V, a Float32Array on the same grid (0..~1), for contouring or
+/// direct raster display.
+export function reactionDiffusion(mask, nx, ny, opts = {}) {
+    const { F, K } = RD_PRESETS[opts.preset] ?? RD_PRESETS.coral
+    const Du = 0.16, Dv = 0.08
+    const steps = opts.steps ?? 3000
+    const seedFrac = opts.seedFrac ?? 0.05
+    const seed = opts.seed ?? 1
+    const onProgress = opts.onProgress
+    const rng = mulberry32(seed)
+
+    const n = nx * ny
+    const U = new Float32Array(n).fill(1)
+    const V = new Float32Array(n).fill(0)
+
+    // Sparse fully-saturated single-cell seeds, scattered across the whole
+    // mask by per-cell probability so coverage scales with area (a single
+    // glyph and a full word both end up with comparably dense seeding).
+    for (let k = 0; k < n; k++) {
+        if (mask[k] && rng() < seedFrac) { V[k] = 1; U[k] = 0 }
+    }
+
+    const lap = (arr, ix, iy) => {
+        const k = iy * nx + ix
+        const l = arr[iy * nx + (ix > 0 ? ix - 1 : ix)]
+        const r = arr[iy * nx + (ix < nx - 1 ? ix + 1 : ix)]
+        const u = arr[(iy > 0 ? iy - 1 : iy) * nx + ix]
+        const d = arr[(iy < ny - 1 ? iy + 1 : iy) * nx + ix]
+        return l + r + u + d - 4 * arr[k]
+    }
+
+    let Un = new Float32Array(n), Vn = new Float32Array(n)
+    const reportEvery = Math.max(1, Math.floor(steps / 40))
+    for (let s = 0; s < steps; s++) {
+        for (let iy = 0; iy < ny; iy++) {
+            for (let ix = 0; ix < nx; ix++) {
+                const k = iy * nx + ix
+                if (!mask[k]) { Un[k] = 1; Vn[k] = 0; continue }
+                const u = U[k], v = V[k]
+                const uvv = u * v * v
+                Un[k] = u + (Du * lap(U, ix, iy) - uvv + F * (1 - u))
+                Vn[k] = v + (Dv * lap(V, ix, iy) + uvv - (F + K) * v)
+            }
+        }
+        U.set(Un); V.set(Vn)
+        if (onProgress && (s % reportEvery) === 0) onProgress(s / steps)
+    }
+    if (onProgress) onProgress(1)
+    return V
+}
+
+/// Contour the reaction-diffusion V field at `threshold` into closed vector
+/// contours (font units, y up) — thin wrapper over growth.js's marching
+/// squares + RDP simplify, reused as-is (V is just another scalar field).
+export function contourScalarField(V, nx, ny, x0, y0, cell, threshold, simplifyEps) {
+    return marchingSquares(V, nx, ny, x0, y0, cell, threshold)
+        .map(c => simplify(c, simplifyEps ?? cell * 0.12))
+}
+
+/// A good default contour threshold for a reaction-diffusion V field: a
+/// fraction of V's own mean over the mask.  V's peak is always close to 1
+/// regardless of preset (Gray-Scott's saturation), but its *mean* — and so
+/// the useful iso-level that traces the pattern's ink rather than either its
+/// bare ridge crests or its whole (near-full) extent — varies with the
+/// preset and even the seed, so a fixed constant threshold is wrong for some
+/// presets: 0.5 (the "obvious" middle-of-range guess) only ever captured a
+/// sliver near the letterform's outer boundary in testing, nowhere near the
+/// interior pattern.  Computing it from the field itself is robust to that.
+export function defaultRdThreshold(V, mask) {
+    let sum = 0, count = 0
+    for (let k = 0; k < V.length; k++) {
+        if (mask[k]) { sum += V[k]; count++ }
+    }
+    return count > 0 ? (sum / count) * 0.8 : 0.2
+}
+
+/// Label 4-connected components of `mask` (nx×ny).  Returns { comp, count }:
+/// comp[k] is the component index of mask cell k (-1 if not mask); cells of
+/// the same component are reachable from each other via mask-only N/S/E/W
+/// steps.  Shared by maze and circuit — both need to run their own
+/// grid-restricted algorithm independently per disconnected letterform piece
+/// (e.g. the two strokes of an 'i', or separate letters that haven't fused).
+function connectedComponents(mask, nx, ny) {
+    const n = nx * ny
+    const comp = new Int32Array(n).fill(-1)
+    const cellsByComp = []
+    const stack = []
+    for (let start = 0; start < n; start++) {
+        if (!mask[start] || comp[start] !== -1) continue
+        const c = cellsByComp.length
+        const cells = []
+        comp[start] = c
+        stack.length = 0
+        stack.push(start)
+        while (stack.length) {
+            const k = stack.pop()
+            cells.push(k)
+            const ix = k % nx, iy = (k / nx) | 0
+            if (ix > 0 && mask[k - 1] && comp[k - 1] === -1) { comp[k - 1] = c; stack.push(k - 1) }
+            if (ix < nx - 1 && mask[k + 1] && comp[k + 1] === -1) { comp[k + 1] = c; stack.push(k + 1) }
+            if (iy > 0 && mask[k - nx] && comp[k - nx] === -1) { comp[k - nx] = c; stack.push(k - nx) }
+            if (iy < ny - 1 && mask[k + nx] && comp[k + nx] === -1) { comp[k + nx] = c; stack.push(k + nx) }
+        }
+        cellsByComp.push(cells)
+    }
+    return { comp, cellsByComp }
+}
+
+/// A perfect maze (recursive backtracker / randomised DFS) carved through
+/// `mask`'s cell grid, rendered as the *uncarved* walls — so the maze
+/// corridors are the letterform's own shape, and every disconnected piece of
+/// the mask (e.g. the two strokes of an 'i', or separate un-fused letters)
+/// gets its own independent maze, since a spanning tree can't cross between
+/// them.
+///
+/// mask, nx, ny: as from buildTextureMask.  x0, y0, cell: the same grid's
+/// font-unit origin/spacing, to emit walls directly in font units.
+/// opts.seed — RNG seed (default 1).
+///
+/// Returns { walls: [[x1,y1,x2,y2], ...] } — unordered straight wall
+/// segments in font units (y up); every mask-cell boundary that ISN'T a
+/// carved corridor, including the letterform's own outer silhouette.
+export function maze(mask, nx, ny, x0, y0, cell, opts = {}) {
+    const rng = mulberry32(opts.seed ?? 1)
+    const { comp, cellsByComp } = connectedComponents(mask, nx, ny)
+
+    // Recursive backtracker per component; corridors recorded as a Set of
+    // "min,max" linear-index edge keys (undirected, so lookup is symmetric).
+    const edgeKey = (a, b) => (a < b ? a + ',' + b : b + ',' + a)
+    const corridors = new Set()
+    const visited = new Uint8Array(nx * ny)
+    for (const cells of cellsByComp) {
+        if (cells.length < 2) continue // an isolated single-cell speck: no corridor to carve
+        const start = cells[0]
+        visited[start] = 1
+        const stack = [start]
+        while (stack.length) {
+            const cur = stack[stack.length - 1]
+            const ix = cur % nx, iy = (cur / nx) | 0
+            const options = []
+            if (ix > 0 && mask[cur - 1] && !visited[cur - 1]) options.push(cur - 1)
+            if (ix < nx - 1 && mask[cur + 1] && !visited[cur + 1]) options.push(cur + 1)
+            if (iy > 0 && mask[cur - nx] && !visited[cur - nx]) options.push(cur - nx)
+            if (iy < ny - 1 && mask[cur + nx] && !visited[cur + nx]) options.push(cur + nx)
+            if (options.length === 0) { stack.pop(); continue }
+            const next = options[Math.floor(rng() * options.length)]
+            corridors.add(edgeKey(cur, next))
+            visited[next] = 1
+            stack.push(next)
+        }
+    }
+
+    // Walls: every mask-cell edge that ISN'T a carved corridor.  East/North
+    // are checked for both internal (neighbour is mask) and boundary
+    // (neighbour isn't) walls — canonical direction so an internal wall
+    // between two mask cells is emitted once, from its west/south side only.
+    // West/South are checked for boundary walls only (the matching internal
+    // wall there was already emitted by the neighbour's East/North check).
+    const px = (ix) => x0 + ix * cell
+    const py = (iy) => y0 + iy * cell
+    const walls = []
+    for (let iy = 0; iy < ny; iy++) {
+        for (let ix = 0; ix < nx; ix++) {
+            const k = iy * nx + ix
+            if (!mask[k]) continue
+            const cxp = px(ix), cyp = py(iy), h = cell / 2
+
+            const eIx = ix + 1, eK = iy * nx + eIx
+            if (eIx >= nx || !mask[eK]) walls.push([cxp + h, cyp - h, cxp + h, cyp + h])
+            else if (!corridors.has(edgeKey(k, eK))) walls.push([cxp + h, cyp - h, cxp + h, cyp + h])
+
+            const nIy = iy + 1, nK = nIy * nx + ix
+            if (nIy >= ny || !mask[nK]) walls.push([cxp - h, cyp + h, cxp + h, cyp + h])
+            else if (!corridors.has(edgeKey(k, nK))) walls.push([cxp - h, cyp + h, cxp + h, cyp + h])
+
+            const wIx = ix - 1
+            if (wIx < 0 || !mask[iy * nx + wIx]) walls.push([cxp - h, cyp - h, cxp - h, cyp + h])
+
+            const sIy = iy - 1
+            if (sIy < 0 || !mask[sIy * nx + ix]) walls.push([cxp - h, cyp - h, cxp + h, cyp - h])
+        }
+    }
+    return { walls }
+}
+
+/// Render wall segments as a single SVG <path> of disconnected M/L subpaths
+/// (font units, y flipped to SVG coords, mirroring contoursToPath).
+export function wallsToSvgPath(walls, decimals = 1) {
+    const fmt = (v) => v.toFixed(decimals).replace(/\.0$/, '')
+    let d = ''
+    for (const [x1, y1, x2, y2] of walls) {
+        d += `M${fmt(x1)} ${fmt(-y1)}L${fmt(x2)} ${fmt(-y2)}`
+    }
+    return d
+}
+
+const DIRS4 = [[1, 0], [-1, 0], [0, 1], [0, -1]]
+
+/// Fisher-Yates shuffle (in place) using `rng` (a () => [0,1) function).
+function shuffle(arr, rng) {
+    for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(rng() * (i + 1))
+            ;[arr[i], arr[j]] = [arr[j], arr[i]]
+    }
+    return arr
+}
+
+/// PCB-trace-style pattern: orthogonal random-walk traces confined to `mask`,
+/// Manhattan-routed (each step N/S/E/W) with a bias to keep going straight —
+/// occasional turns instead of a pure random walk, so traces read as routed
+/// rather than jittery.  Traces claim their cells (no two traces cross), and
+/// pads mark every trace's endpoints and corners.
+///
+/// mask, nx, ny, x0, y0, cell: as from buildTextureMask.
+/// opts:
+///   density — fraction of mask cells tried as trace starts (default 0.12).
+///   maxLength — longest a trace can grow, in grid steps (default 60).
+///   straightBias — probability of continuing the current direction each
+///     step rather than considering a new one (default 0.82).
+///   minLength — traces shorter than this (grid steps) are discarded as
+///     visual noise (default 3).
+///   seed — RNG seed (default 1).
+///
+/// Returns { traces: [{ points: [[x,y],...] }], pads: [{x,y}] } in font units
+/// (y up).
+export function circuit(mask, nx, ny, x0, y0, cell, opts = {}) {
+    const rng = mulberry32(opts.seed ?? 1)
+    const density = opts.density ?? 0.12
+    const maxLength = opts.maxLength ?? 60
+    const straightBias = opts.straightBias ?? 0.82
+    const minLength = opts.minLength ?? 3
+
+    const n = nx * ny
+    const occupied = new Uint8Array(n)
+    const maskCells = []
+    for (let k = 0; k < n; k++) if (mask[k]) maskCells.push(k)
+    shuffle(maskCells, rng)
+    const numStarts = Math.max(1, Math.round(maskCells.length * density))
+
+    const paths = []
+    for (let s = 0; s < numStarts; s++) {
+        const start = maskCells[s]
+        if (occupied[start]) continue
+        let ix = start % nx, iy = (start / nx) | 0
+        let dir = DIRS4[Math.floor(rng() * 4)]
+        occupied[start] = 1
+        const path = [[ix, iy]]
+
+        for (let step = 0; step < maxLength; step++) {
+            const preferred = rng() < straightBias ? dir : DIRS4[Math.floor(rng() * 4)]
+            const order = shuffle(DIRS4.filter(d => d !== preferred), rng)
+            order.unshift(preferred)
+            let moved = false
+            for (const [dx, dy] of order) {
+                const nix = ix + dx, niy = iy + dy
+                if (nix < 0 || nix >= nx || niy < 0 || niy >= ny) continue
+                const nk = niy * nx + nix
+                if (!mask[nk] || occupied[nk]) continue
+                ix = nix; iy = niy; dir = [dx, dy]
+                occupied[nk] = 1
+                path.push([ix, iy])
+                moved = true
+                break
+            }
+            if (!moved) break
+        }
+        if (path.length >= minLength) paths.push(path)
+    }
+
+    const px = (ix) => x0 + ix * cell, py = (iy) => y0 + iy * cell
+    const traces = []
+    const pads = []
+    for (const path of paths) {
+        const points = path.map(([ix, iy]) => [px(ix), py(iy)])
+        traces.push({ points })
+        pads.push({ x: points[0][0], y: points[0][1] })
+        pads.push({ x: points[points.length - 1][0], y: points[points.length - 1][1] })
+        // Corner pads: grid points where the incoming/outgoing step direction changes.
+        for (let i = 1; i < path.length - 1; i++) {
+            const [ax, ay] = path[i - 1], [bx, by] = path[i], [cx, cy] = path[i + 1]
+            if (bx - ax !== cx - bx || by - ay !== cy - by) pads.push({ x: px(bx), y: py(by) })
+        }
+    }
+    return { traces, pads }
+}
+
+// Default PCB-ish palette: copper traces, darker pads.
+export const DEFAULT_CIRCUIT_TRACE_COLOR = '#b5703c'
+export const DEFAULT_CIRCUIT_PAD_COLOR = '#6b3f22'
+
+/// Render circuit traces + pads to SVG markup (font units, y flipped).
+export function circuitToSvg(traces, pads, opts = {}) {
+    const traceColor = opts.traceColor ?? DEFAULT_CIRCUIT_TRACE_COLOR
+    const padColor = opts.padColor ?? DEFAULT_CIRCUIT_PAD_COLOR
+    const strokeWidth = opts.strokeWidth ?? 4
+    const padSize = opts.padSize ?? strokeWidth * 2
+
+    let d = ''
+    for (const t of traces) {
+        if (t.points.length < 2) continue
+        d += `M${t.points[0][0].toFixed(1)} ${(-t.points[0][1]).toFixed(1)}`
+        for (let i = 1; i < t.points.length; i++) {
+            d += `L${t.points[i][0].toFixed(1)} ${(-t.points[i][1]).toFixed(1)}`
+        }
+    }
+    const traceSvg = d
+        ? `<path d="${d}" stroke="${traceColor}" stroke-width="${strokeWidth}" fill="none" stroke-linecap="round" stroke-linejoin="round"/>`
+        : ''
+    let padSvg = ''
+    for (const p of pads) {
+        const h = padSize / 2
+        padSvg += `<rect x="${(p.x - h).toFixed(1)}" y="${(-p.y - h).toFixed(1)}" width="${padSize.toFixed(1)}" height="${padSize.toFixed(1)}" fill="${padColor}"/>`
+    }
+    return traceSvg + padSvg
+}

--- a/web/src/texture.test.js
+++ b/web/src/texture.test.js
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest'
+import {
+    buildTextureMask, reactionDiffusion, contourScalarField, defaultRdThreshold, RD_PRESET_NAMES,
+    maze, wallsToSvgPath,
+    circuit, circuitToSvg,
+} from './texture'
+
+const hline = (x0, x1, y, glyph) => ({ pts: [[x0, y], [x1, y]], closed: false, glyph })
+
+describe('buildTextureMask', () => {
+    it('returns null for empty strokes', () => {
+        expect(buildTextureMask([])).toBeNull()
+    })
+
+    it('marks cells near the spine as inside, far cells as outside', () => {
+        const built = buildTextureMask([hline(0, 300, 0)], { thickness: 30, grow: 0.5, gap: 20, cell: 5 })
+        expect(built).not.toBeNull()
+        const { mask, nx, ny, x0, y0, cell } = built
+        // A cell near the spine's midpoint should be inside; one far above should not.
+        // rMax at grow=0.5, growScale=120 (default) is 15 + 0.5*120 = 75, so
+        // y=150 is well outside the grown stroke but still inside the padded grid.
+        const ixMid = Math.round((150 - x0) / cell)
+        const iyOnSpine = Math.round((0 - y0) / cell)
+        const iyFar = Math.round((150 - y0) / cell)
+        expect(mask[iyOnSpine * nx + ixMid]).toBe(1)
+        expect(iyFar).toBeLessThan(ny)
+        expect(mask[iyFar * nx + ixMid]).toBe(0)
+    })
+})
+
+describe('reactionDiffusion', () => {
+    const strokes = [hline(0, 300, 0)]
+    const built = () => buildTextureMask(strokes, { thickness: 30, grow: 0.6, gap: 20, cell: 6 })
+
+    it('is deterministic for a given seed', () => {
+        const { mask, nx, ny } = built()
+        const a = reactionDiffusion(mask, nx, ny, { seed: 3, steps: 300 })
+        const b = reactionDiffusion(mask, nx, ny, { seed: 3, steps: 300 })
+        expect(Array.from(a)).toEqual(Array.from(b))
+    })
+
+    it('differs for a different seed', () => {
+        const { mask, nx, ny } = built()
+        const a = reactionDiffusion(mask, nx, ny, { seed: 1, steps: 300 })
+        const b = reactionDiffusion(mask, nx, ny, { seed: 2, steps: 300 })
+        expect(Array.from(a)).not.toEqual(Array.from(b))
+    })
+
+    it('stays exactly 0 outside the mask', () => {
+        const { mask, nx, ny } = built()
+        const V = reactionDiffusion(mask, nx, ny, { seed: 1, steps: 300 })
+        for (let k = 0; k < mask.length; k++) {
+            if (!mask[k]) expect(V[k]).toBe(0)
+        }
+    })
+
+    it('supports all named presets without throwing', () => {
+        const { mask, nx, ny } = built()
+        for (const preset of RD_PRESET_NAMES) {
+            const V = reactionDiffusion(mask, nx, ny, { preset, seed: 1, steps: 300 })
+            expect(V.length).toBe(nx * ny)
+        }
+    })
+
+    it('produces a contourable field with defaultRdThreshold', () => {
+        const { mask, nx, ny, x0, y0, cell } = built()
+        const V = reactionDiffusion(mask, nx, ny, { seed: 4, steps: 800 })
+        const threshold = defaultRdThreshold(V, mask)
+        expect(threshold).toBeGreaterThan(0)
+        const contours = contourScalarField(V, nx, ny, x0, y0, cell, threshold)
+        expect(contours.length).toBeGreaterThan(0)
+    })
+})
+
+describe('maze', () => {
+    it('carves a perfect spanning-tree maze (no cycles) per connected component', () => {
+        const strokes = [hline(0, 300, 0)]
+        const cell = 20
+        const { mask, nx, ny, x0, y0 } = buildTextureMask(strokes, { thickness: 30, grow: 0.6, gap: 20, cell })
+        const { walls } = maze(mask, nx, ny, x0, y0, cell, { seed: 5 })
+        expect(walls.length).toBeGreaterThan(0)
+
+        // Reconstruct which adjacent mask-cell pairs are corridors (i.e. NOT
+        // walled) by checking for a wall segment centred on their shared edge,
+        // then verify the corridor graph is a spanning forest: exactly
+        // (maskCells - components) edges, and a union-find over them never
+        // reunites two cells already in the same set (no cycles).
+        const wallMidpoints = new Set()
+        const key = (x, y) => `${x.toFixed(2)},${y.toFixed(2)}`
+        for (const [x1, y1, x2, y2] of walls) wallMidpoints.add(key((x1 + x2) / 2, (y1 + y2) / 2))
+
+        const parent = new Map()
+        const find = (a) => { while (parent.get(a) !== a) a = parent.get(a); return a }
+        let maskCount = 0
+        for (let k = 0; k < nx * ny; k++) if (mask[k]) { parent.set(k, k); maskCount++ }
+
+        let corridorCount = 0, cycles = 0
+        for (let iy = 0; iy < ny; iy++) {
+            for (let ix = 0; ix < nx; ix++) {
+                const k = iy * nx + ix
+                if (!mask[k]) continue
+                if (ix + 1 < nx && mask[k + 1]) {
+                    const mx = x0 + ix * cell + cell / 2, my = y0 + iy * cell
+                    if (!wallMidpoints.has(key(mx, my))) {
+                        corridorCount++
+                        const ra = find(k), rb = find(k + 1)
+                        if (ra === rb) cycles++; else parent.set(ra, rb)
+                    }
+                }
+                if (iy + 1 < ny && mask[k + nx]) {
+                    const mx = x0 + ix * cell, my = y0 + iy * cell + cell / 2
+                    if (!wallMidpoints.has(key(mx, my))) {
+                        corridorCount++
+                        const ra = find(k), rb = find(k + nx)
+                        if (ra === rb) cycles++; else parent.set(ra, rb)
+                    }
+                }
+            }
+        }
+        const roots = new Set()
+        for (let k = 0; k < nx * ny; k++) if (mask[k]) roots.add(find(k))
+
+        expect(cycles).toBe(0)
+        expect(corridorCount).toBe(maskCount - roots.size)
+    })
+
+    it('carves each disconnected mask piece independently', () => {
+        // Two separated strokes (same "glyph" doesn't matter for maze/mask —
+        // only geometric proximity does): far enough apart that grow=0.6
+        // doesn't bridge them, so the mask has two components.
+        const strokes = [hline(0, 100, 0), hline(400, 500, 0)]
+        const cell = 12
+        const { mask, nx, ny, x0, y0 } = buildTextureMask(strokes, { thickness: 30, grow: 0.3, gap: 20, cell })
+        const { walls } = maze(mask, nx, ny, x0, y0, cell, { seed: 1 })
+        // Both pieces should have some carved corridors (i.e. not every
+        // mask-cell boundary is walled) — a naive single-component algorithm
+        // that only starts from one piece would leave the other fully walled.
+        const path = wallsToSvgPath(walls)
+        expect(path.length).toBeGreaterThan(0)
+        // Sanity: bounding boxes of the ink (mask) should span both strokes.
+        let minX = Infinity, maxX = -Infinity
+        for (let k = 0; k < nx * ny; k++) {
+            if (!mask[k]) continue
+            const ix = k % nx
+            const x = x0 + ix * cell
+            if (x < minX) minX = x
+            if (x > maxX) maxX = x
+        }
+        expect(maxX - minX).toBeGreaterThan(400)
+    })
+})
+
+describe('circuit', () => {
+    it('confines all trace points to the mask grid and stays orthogonal', () => {
+        const strokes = [hline(0, 300, 0)]
+        const cell = 15
+        const { mask, nx, ny, x0, y0 } = buildTextureMask(strokes, { thickness: 30, grow: 0.6, gap: 20, cell })
+        const { traces, pads } = circuit(mask, nx, ny, x0, y0, cell, { seed: 2, density: 0.15 })
+        expect(traces.length).toBeGreaterThan(0)
+        expect(pads.length).toBeGreaterThan(0)
+
+        for (const t of traces) {
+            for (let i = 1; i < t.points.length; i++) {
+                const [ax, ay] = t.points[i - 1], [bx, by] = t.points[i]
+                const dx = Math.abs(bx - ax), dy = Math.abs(by - ay)
+                // Each step is exactly one grid cell, axis-aligned (Manhattan).
+                const isAxisStep = (dx === 0 && Math.abs(dy - cell) < 1e-6) || (dy === 0 && Math.abs(dx - cell) < 1e-6)
+                expect(isAxisStep).toBe(true)
+            }
+            for (const [x, y] of t.points) {
+                const ix = Math.round((x - x0) / cell), iy = Math.round((y - y0) / cell)
+                expect(mask[iy * nx + ix]).toBe(1)
+            }
+        }
+    })
+
+    it('is deterministic for a given seed', () => {
+        const strokes = [hline(0, 300, 0)]
+        const cell = 15
+        const { mask, nx, ny, x0, y0 } = buildTextureMask(strokes, { thickness: 30, grow: 0.6, gap: 20, cell })
+        const a = circuit(mask, nx, ny, x0, y0, cell, { seed: 7 })
+        const b = circuit(mask, nx, ny, x0, y0, cell, { seed: 7 })
+        expect(circuitToSvg(a.traces, a.pads)).toBe(circuitToSvg(b.traces, b.pads))
+    })
+})

--- a/web/src/textureSvg.js
+++ b/web/src/textureSvg.js
@@ -1,0 +1,115 @@
+// Generate tab's Texture mode back end (runs in the worker): patterns
+// confined to the interior of a grown letterform (docs/growth-brainstorm.md,
+// Idea 3 + extensions — see texture.js for the algorithms).  Like Grow
+// (branching) mode, this is worker-computed SVG only: reaction-diffusion,
+// maze-carving, and circuit-routing are all iterative/combinatorial, not a
+// simple per-pixel threshold, so there's no WebGL preview path here.
+
+import { collectStrokes } from './growthSvg.js'
+import { contoursToPath } from './growth.js'
+import {
+    buildTextureMask, reactionDiffusion, contourScalarField, defaultRdThreshold,
+    maze, wallsToSvgPath,
+    circuit, circuitToSvg, DEFAULT_CIRCUIT_TRACE_COLOR, DEFAULT_CIRCUIT_PAD_COLOR,
+} from './texture.js'
+
+const GROW_SCALE = 120
+
+/// Pick the mask's grid resolution: reaction-diffusion wants a fine field for
+/// organic detail; maze/circuit want a much coarser one so corridors/traces
+/// read as a pattern instead of grid noise (and stay fast — both are O(cells)
+/// but a maze/circuit cell is "worth" far more visually at low cell counts
+/// than an RD cell is).
+function cellFor(text, style) {
+    const chars = text.replace(/\s/g, '').length
+    if (style === 'rd') return chars <= 10 ? 4 : chars <= 30 ? 5 : 7
+    return chars <= 10 ? 14 : chars <= 30 ? 18 : 24
+}
+
+/// Render text's grown-letterform texture pattern to a standalone SVG
+/// string.  onProgress(0..1) spans spine extraction, the mask field build,
+/// and the pattern algorithm itself (reaction-diffusion's simulation is the
+/// only one of the three with a meaningfully long tail).
+///
+/// params:
+///   style — 'rd' | 'maze' | 'circuit' (default 'rd').
+///   grow, gap, fuse, growScale — shape the mask domain (growStrokes rule).
+///   backbone — show the classic (grow=0) outline underneath as context
+///     (default true).
+///   backboneColor, color — outline fill / pattern colour (style-dependent
+///     defaults; maze uses `color` for its wall stroke, rd for its fill).
+///   RD: preset, steps, seedFrac, seed, threshold (default: derived from the
+///     field's own mean — see texture.js's defaultRdThreshold).
+///   maze: seed, strokeWidth.
+///   circuit: seed, density, maxLength, straightBias, traceColor, padColor,
+///     strokeWidth, padSize.
+export function generateTextureSvg(text, axes, params = {}, onProgress) {
+    const style = params.style ?? 'rd'
+    const grow = params.grow ?? 0.6
+    const gap = params.gap ?? 25
+    const fuse = params.fuse ?? 0
+    const growScale = params.growScale ?? GROW_SCALE
+    const thickness = axes.weight
+    const cell = params.cell ?? cellFor(text, style)
+    const showBackbone = params.backbone ?? true
+    const backboneColor = params.backboneColor ?? '#e8e8e8'
+
+    const EXTRACT_SHARE = 0.4
+    const strokes = collectStrokes(text, axes, cell, growScale,
+        onProgress ? (f => onProgress(EXTRACT_SHARE * f)) : undefined)
+    if (strokes.length === 0) return ''
+
+    const built = buildTextureMask(strokes, {
+        thickness, grow, growScale, gap, fuse, cell,
+        onProgress: onProgress ? (f => onProgress(EXTRACT_SHARE + 0.2 * f)) : undefined,
+    })
+    if (!built) return ''
+    const { mask, f, nx, ny, x0, y0 } = built
+
+    const backboneContours = showBackbone
+        ? contourScalarField(f, nx, ny, x0, y0, cell, 0)
+        : []
+    const backboneSvg = backboneContours.length
+        ? `<path d="${contoursToPath(backboneContours)}" fill="${backboneColor}" fill-rule="evenodd"/>`
+        : ''
+
+    let patternSvg = ''
+    const patternProgress = onProgress ? (frac => onProgress(0.6 + 0.4 * frac)) : undefined
+    if (style === 'maze') {
+        const { walls } = maze(mask, nx, ny, x0, y0, cell, { seed: params.seed })
+        const color = params.color ?? '#222222'
+        const strokeWidth = params.strokeWidth ?? Math.max(1.5, cell * 0.16)
+        patternSvg = walls.length
+            ? `<path d="${wallsToSvgPath(walls)}" stroke="${color}" stroke-width="${strokeWidth}" fill="none" stroke-linecap="square"/>`
+            : ''
+        if (patternProgress) patternProgress(1)
+    } else if (style === 'circuit') {
+        const { traces, pads } = circuit(mask, nx, ny, x0, y0, cell, {
+            seed: params.seed, density: params.density, maxLength: params.maxLength,
+            straightBias: params.straightBias,
+        })
+        patternSvg = circuitToSvg(traces, pads, {
+            traceColor: params.traceColor ?? DEFAULT_CIRCUIT_TRACE_COLOR,
+            padColor: params.padColor ?? DEFAULT_CIRCUIT_PAD_COLOR,
+            strokeWidth: params.strokeWidth ?? Math.max(2, cell * 0.28),
+            padSize: params.padSize,
+        })
+        if (patternProgress) patternProgress(1)
+    } else {
+        const V = reactionDiffusion(mask, nx, ny, {
+            preset: params.preset, steps: params.steps, seedFrac: params.seedFrac, seed: params.seed,
+            onProgress: patternProgress,
+        })
+        const threshold = params.threshold ?? defaultRdThreshold(V, mask)
+        const contours = contourScalarField(V, nx, ny, x0, y0, cell, threshold)
+        const color = params.color ?? '#ff6f4a'
+        patternSvg = contours.length ? `<path d="${contoursToPath(contours)}" fill="${color}" fill-rule="evenodd"/>` : ''
+    }
+    if (onProgress) onProgress(1)
+
+    const w = (nx - 1) * cell, h = (ny - 1) * cell
+    if (w <= 0 || h <= 0) return ''
+    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${x0.toFixed(1)} ${(-(y0 + h)).toFixed(1)} ${w.toFixed(1)} ${h.toFixed(1)}" width="${(w / 2).toFixed(0)}" height="${(h / 2).toFixed(0)}">` +
+        backboneSvg + patternSvg +
+        `</svg>`
+}

--- a/web/src/textureSvg.js
+++ b/web/src/textureSvg.js
@@ -34,13 +34,12 @@ function cellFor(text, style) {
 /// params:
 ///   style — 'rd' | 'maze' | 'circuit' (default 'rd').
 ///   grow, gap, fuse, growScale — shape the mask domain (growStrokes rule).
-///   backbone — show the classic (grow=0) outline underneath as context
-///     (default true).
-///   backboneColor, color — outline fill / pattern colour (style-dependent
-///     defaults; maze uses `color` for its wall stroke, rd for its fill).
+///   backbone — fill the classic (grow=0) letterform silhouette behind the
+///     pattern as a background (default true); backboneColor sets its colour.
+///   color — rd's pattern fill colour.
 ///   RD: preset, steps, seedFrac, seed, threshold (default: derived from the
 ///     field's own mean — see texture.js's defaultRdThreshold).
-///   maze: seed, strokeWidth.
+///   maze: seed, strokeWidth, wallColor.
 ///   circuit: seed, density, maxLength, straightBias, traceColor, padColor,
 ///     strokeWidth, padSize.
 export function generateTextureSvg(text, axes, params = {}, onProgress) {
@@ -77,7 +76,7 @@ export function generateTextureSvg(text, axes, params = {}, onProgress) {
     const patternProgress = onProgress ? (frac => onProgress(0.6 + 0.4 * frac)) : undefined
     if (style === 'maze') {
         const { walls } = maze(mask, nx, ny, x0, y0, cell, { seed: params.seed })
-        const color = params.color ?? '#222222'
+        const color = params.wallColor ?? '#222222'
         const strokeWidth = params.strokeWidth ?? Math.max(1.5, cell * 0.16)
         patternSvg = walls.length
             ? `<path d="${wallsToSvgPath(walls)}" stroke="${color}" stroke-width="${strokeWidth}" fill="none" stroke-linecap="square"/>`

--- a/web/src/textureSvg.js
+++ b/web/src/textureSvg.js
@@ -36,6 +36,12 @@ function cellFor(text, style) {
 ///   grow, gap, fuse, growScale — shape the mask domain (growStrokes rule).
 ///   backbone — fill the classic (grow=0) letterform silhouette behind the
 ///     pattern as a background (default true); backboneColor sets its colour.
+///   edgeOutline — a thick keyline band hugging the letterform's outer edge
+///     (default true), the same technique as Bubble mode's dark outer layer:
+///     two contours of the same field at iso 0 and iso -edgeOutlineWidth,
+///     filled together with evenodd so only the band between them inks.
+///     edgeOutlineWidth (font units, default 24), edgeOutlineColor (default
+///     '#000000').
 ///   color — rd's pattern fill colour.
 ///   RD: preset, steps, seedFrac, seed, threshold (default: derived from the
 ///     field's own mean — see texture.js's defaultRdThreshold).
@@ -52,6 +58,9 @@ export function generateTextureSvg(text, axes, params = {}, onProgress) {
     const cell = params.cell ?? cellFor(text, style)
     const showBackbone = params.backbone ?? true
     const backboneColor = params.backboneColor ?? '#e8e8e8'
+    const showEdgeOutline = params.edgeOutline ?? true
+    const edgeOutlineWidth = params.edgeOutlineWidth ?? 24
+    const edgeOutlineColor = params.edgeOutlineColor ?? '#000000'
 
     const EXTRACT_SHARE = 0.4
     const strokes = collectStrokes(text, axes, cell, growScale,
@@ -71,6 +80,19 @@ export function generateTextureSvg(text, axes, params = {}, onProgress) {
     const backboneSvg = backboneContours.length
         ? `<path d="${contoursToPath(backboneContours)}" fill="${backboneColor}" fill-rule="evenodd"/>`
         : ''
+
+    // Outer keyline band: iso 0 is the classic edge, iso -edgeOutlineWidth is
+    // the same field offset outward by edgeOutlineWidth (mirroring Bubble
+    // mode's layerIsoLevels) — filling both contours together with evenodd
+    // inks only the ring between them, and correctly punches out any inner
+    // counters (e.g. the hole in 'o') the same way growStrokes/backbone do.
+    const edgeOutlineSvg = (() => {
+        if (!showEdgeOutline) return ''
+        const inner = contourScalarField(f, nx, ny, x0, y0, cell, 0)
+        const outer = contourScalarField(f, nx, ny, x0, y0, cell, -edgeOutlineWidth)
+        const combined = [...outer, ...inner]
+        return combined.length ? `<path d="${contoursToPath(combined)}" fill="${edgeOutlineColor}" fill-rule="evenodd"/>` : ''
+    })()
 
     let patternSvg = ''
     const patternProgress = onProgress ? (frac => onProgress(0.6 + 0.4 * frac)) : undefined
@@ -109,6 +131,6 @@ export function generateTextureSvg(text, axes, params = {}, onProgress) {
     const w = (nx - 1) * cell, h = (ny - 1) * cell
     if (w <= 0 || h <= 0) return ''
     return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${x0.toFixed(1)} ${(-(y0 + h)).toFixed(1)} ${w.toFixed(1)} ${h.toFixed(1)}" width="${(w / 2).toFixed(0)}" height="${(h / 2).toFixed(0)}">` +
-        backboneSvg + patternSvg +
+        backboneSvg + edgeOutlineSvg + patternSvg +
         `</svg>`
 }

--- a/web/src/textureSvg.test.js
+++ b/web/src/textureSvg.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { defaultAxes } from './lib/fable/Api.js'
+import { generateTextureSvg } from './textureSvg'
+
+// Exercises the full Texture-mode back end (the same path the 'texture'
+// worker message runs): real glyph backbones → solved spines → mask field →
+// pattern algorithm → SVG.  Deterministic, no browser/GPU needed.  RD steps
+// are kept low here (vs the UI default of 3000) purely for test speed —
+// texture.test.js covers the algorithms themselves in more depth.
+
+const axes = { ...defaultAxes, dactyl_spline: true }
+
+describe('generateTextureSvg', () => {
+    it('returns empty string for blank text', () => {
+        expect(generateTextureSvg('', axes, { style: 'rd' })).toBe('')
+        expect(generateTextureSvg('   ', axes, { style: 'maze' })).toBe('')
+    })
+
+    it('rd style produces a filled pattern over the classic backbone', () => {
+        const svg = generateTextureSvg('o', axes, { style: 'rd', steps: 500, backbone: true })
+        expect(svg.startsWith('<svg')).toBe(true)
+        expect(svg).toContain('viewBox=')
+        // Two filled paths: the backbone silhouette, then the pattern on top.
+        expect((svg.match(/<path/g) || []).length).toBe(2)
+        expect(svg).toContain('fill-rule="evenodd"')
+    }, 30000)
+
+    it('rd style omits the backbone when disabled', () => {
+        const svg = generateTextureSvg('o', axes, { style: 'rd', steps: 500, backbone: false })
+        expect((svg.match(/<path/g) || []).length).toBe(1)
+    }, 30000)
+
+    it('maze style emits a single stroked wall path', () => {
+        const svg = generateTextureSvg('o', axes, { style: 'maze', backbone: false })
+        expect(svg.startsWith('<svg')).toBe(true)
+        expect(svg).toContain('stroke=')
+        expect(svg).toContain('fill="none"')
+    }, 20000)
+
+    it('circuit style emits trace paths and pad rects', () => {
+        const svg = generateTextureSvg('o', axes, { style: 'circuit', backbone: false })
+        expect(svg.startsWith('<svg')).toBe(true)
+        expect(svg).toContain('<path')
+        expect(svg).toContain('<rect')
+    }, 20000)
+
+    it('is deterministic for a given seed (all three styles)', () => {
+        for (const style of ['rd', 'maze', 'circuit']) {
+            const params = { style, seed: 3, steps: 500 }
+            const a = generateTextureSvg('o', axes, params)
+            const b = generateTextureSvg('o', axes, params)
+            expect(a).toBe(b)
+        }
+    }, 30000)
+
+    it('respects custom colours', () => {
+        const svg = generateTextureSvg('o', axes, { style: 'rd', steps: 500, color: '#123456', backbone: false })
+        expect(svg).toContain('#123456')
+    }, 20000)
+})

--- a/web/src/textureSvg.test.js
+++ b/web/src/textureSvg.test.js
@@ -17,7 +17,7 @@ describe('generateTextureSvg', () => {
     })
 
     it('rd style produces a filled pattern over the classic backbone', () => {
-        const svg = generateTextureSvg('o', axes, { style: 'rd', steps: 500, backbone: true })
+        const svg = generateTextureSvg('o', axes, { style: 'rd', steps: 500, backbone: true, edgeOutline: false })
         expect(svg.startsWith('<svg')).toBe(true)
         expect(svg).toContain('viewBox=')
         // Two filled paths: the backbone silhouette, then the pattern on top.
@@ -26,8 +26,17 @@ describe('generateTextureSvg', () => {
     }, 30000)
 
     it('rd style omits the backbone when disabled', () => {
-        const svg = generateTextureSvg('o', axes, { style: 'rd', steps: 500, backbone: false })
+        const svg = generateTextureSvg('o', axes, { style: 'rd', steps: 500, backbone: false, edgeOutline: false })
         expect((svg.match(/<path/g) || []).length).toBe(1)
+    }, 30000)
+
+    it('renders an edge-outline keyline band by default, and can be disabled', () => {
+        const withOutline = generateTextureSvg('o', axes, { style: 'rd', steps: 500, backbone: false })
+        const withoutOutline = generateTextureSvg('o', axes, { style: 'rd', steps: 500, backbone: false, edgeOutline: false })
+        // The outline adds one extra evenodd-filled path (two contours of the
+        // same field combined) ahead of the pattern.
+        expect((withOutline.match(/<path/g) || []).length).toBe((withoutOutline.match(/<path/g) || []).length + 1)
+        expect(withOutline).toContain('#000000')
     }, 30000)
 
     it('maze style emits a single stroked wall path', () => {

--- a/web/src/worker.js
+++ b/web/src/worker.js
@@ -2,6 +2,7 @@ import { generateSvg, generateSvgPerGlyph, generateSplineDebugSvgFromDefs, gener
 import { buildFontDataUrl } from './fontExport'
 import { generateGrowthSvg, generateGrowthField } from './growthSvg'
 import { generateBranchSvg } from './branchSvg'
+import { generateTextureSvg } from './textureSvg'
 import { DControlPoint } from './lib/fable/generator/DactylSpline'
 
 self.onmessage = (e) => {
@@ -104,6 +105,13 @@ self.onmessage = (e) => {
             case 'branch': {
                 const [brText, brAxes, brParams] = args
                 result = generateBranchSvg(brText, brAxes, brParams, (p) => {
+                    self.postMessage({ id, type: 'progress', value: p });
+                })
+                break
+            }
+            case 'texture': {
+                const [txText, txAxes, txParams] = args
+                result = generateTextureSvg(txText, txAxes, txParams, (p) => {
                     self.postMessage({ id, type: 'progress', value: p });
                 })
                 break


### PR DESCRIPTION
## What this adds

A third **Texture** mode on the Generate tab, alongside Bubble and Grow, confined to the interior of a grown letterform and reusing the existing SDF field machinery:

- **Reaction-diffusion** (Gray-Scott) with three presets — `coral` (thin branching veins), `cells` (honeycomb/cellular), `stitches` (scattered dashes and dots)
- **Maze** — a rectilinear perfect maze carved per connected component of the letterform mask (recursive-backtracker / randomized DFS)
- **Circuit** — PCB-style orthogonal trace routing with pads at corners/endpoints

All three share the mode's `grow`/`gap`/`fuse`/`seed` controls and the backbone-outline toggle, and save via the same copy/download (PNG/SVG) controls as Bubble and Grow.

## How it works

```
backbone strokes → growth field (existing) → fieldToF mask → pattern algorithm → SVG
```

- **`web/src/growth.js`** — small refactor: extracted `fieldToF` (the `f = rAllowed - d1` computation) out of `growStrokes` so it's reusable; exported `marchingSquares`/`simplify` for reuse by the new texture engine. Pure extraction, no behavior change (existing test suite still passes unchanged).
- **`web/src/branching.js`** — exported `mulberry32` (the seeded PRNG) for reuse.
- **`web/src/texture.js`** (new) — the three pattern algorithms:
  - `buildTextureMask`: wraps the existing field-building + `fieldToF` into a boolean interior mask
  - `reactionDiffusion`: Gray-Scott simulation with a hard-wall boundary at the mask edge; `defaultRdThreshold` derives a sensible marching-squares contour threshold from the field's own mean (a fixed threshold doesn't work — the field's mean value varies a lot by preset)
  - `maze`: flood-fill connected components + per-component recursive-backtracker; verified (in tests) to produce a genuine spanning forest with zero cycles
  - `circuit`: Manhattan-routed random walk with directional momentum, exclusive per-trace cell claiming
- **`web/src/textureSvg.js`** (new) — worker-side glue: builds the mask, dispatches on `style`, assembles the final SVG (mirrors `growthSvg.js`/`branchSvg.js`)
- **`web/src/worker.js`** — new `'texture'` message case
- **`web/src/App.jsx`** — mode toolbar gains a **Texture** chip; per-style controls (preset/steps for RD, grain for maze/circuit, density/trace-color/pad-color for circuit); shared save/copy/download menu wiring identical to the other two modes
- Also fixes a latent bug: `requestGrowthSvg`/`requestBranchSvg`/`requestTextureSvg` resolved on the *first* worker message, which for a mode with progress reporting could be an intermediate `{type:'progress'}` tick rather than the final result — silently short-circuiting to an empty/undefined SVG for slower generations (like a several-thousand-step RD sim). All three now filter progress messages before resolving.

## Tests

- `web/src/texture.test.js` (new, 11 tests) — mask correctness, RD determinism/boundary containment/all-presets-run, rigorous maze spanning-tree verification (union-find, zero cycles, correct edge count) including disconnected mask components, circuit trace validity (axis-aligned single-cell steps, mask containment) and determinism
- `web/src/textureSvg.test.js` (new, 7 tests) — full worker-path SVG generation for all three styles, empty-text handling, backbone toggle, determinism, custom colors

All 108 vitest tests pass, 99 F# generator tests pass, 2 SpiroFs tests pass, production build clean.

## Verification

Live-verified in a real browser (Playwright + Chromium) against the dev build: all three styles render correctly for varying text, PNG/SVG downloads and clipboard-copy work for each style, and regression-checked that Bubble/Grow mode downloads still work after the progress-message fix.

## Docs

Updated `README.md`, `DEVELOPING.md`, `docs/ExplorerGuide.md`, and `docs/growth-brainstorm.md` (which also gets a new section documenting the Gray-Scott seeding/thresholding behavior discovered while tuning the RD presets — full-saturation seeding is required since small-amplitude noise decays to nothing under this hard-wall boundary condition, and non-`coral` presets need seeds spread across the whole mask since they don't self-propagate from a few nucleation points).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LosK2gRkUdR2E4F6se3SGf)_