### PR TITLE
Vary repeated characters in per-glyph SVG rendering

### DIFF
--- a/src/explorer/Api.fs
+++ b/src/explorer/Api.fs
@@ -92,9 +92,13 @@ let private fontLookup (chars: string) (axesList: Axes array) (tweak: Axes -> Ax
         | Some f -> f
         | None -> fallback
 
-/// Render text with a different set of axes per character — the "randomise every
-/// glyph" mode.  `chars` and `axesList` are parallel arrays; every occurrence of
-/// `chars.[i]` is drawn with `axesList.[i]`, anything else uses `baseAxes`.
+/// Render text with a different set of axes per character occurrence — the
+/// "randomise every glyph" mode.  `axesList.[i]` is drawn at the i'th
+/// character position of `text` once newlines are stripped (matching how the
+/// text below is split into lines and concatenated back together), so unlike
+/// generateFontGlyphDataPerGlyph's per-code-point lookup, repeated characters
+/// can each get their own axes.  Positions past the end of `axesList` (or an
+/// empty array) fall back to `baseAxes`.
 ///
 /// Line spacing and the baseline of each line come from `baseAxes` so that glyphs
 /// with different heights/thicknesses still sit on a common baseline; advance
@@ -102,13 +106,13 @@ let private fontLookup (chars: string) (axesList: Axes array) (tweak: Axes -> Ax
 let generateSvgPerGlyph
     (text: string)
     (baseAxes: Axes)
-    (chars: string)
     (axesList: Axes array)
     (autoscale: bool)
     (progress: (float -> unit) option)
     =
     let baseFont = Font baseAxes
-    let fontFor = fontLookup chars axesList id baseFont
+    let fonts = axesList |> Array.map Font
+    let fontAt i = if i >= 0 && i < fonts.Length then fonts.[i] else baseFont
 
     let lines =
         if System.String.IsNullOrEmpty(text) then
@@ -118,6 +122,7 @@ let generateSvgPerGlyph
 
     let totalChars = lines |> List.sumBy (fun s -> s.Length)
     let mutable charCount = 0
+    let mutable pos = 0
 
     // SVG y of the baseline (glyph y=0) for line i, matching the placement
     // Font.stringToSvgLineInternal would give it under baseAxes.
@@ -128,16 +133,20 @@ let generateSvgPerGlyph
         List.unzip
             [ for i in 0 .. lines.Length - 1 do
                   let str = lines.[i]
-                  let fonts = [ for ch in str -> fontFor ch ]
+                  let fontsForLine =
+                      [ for _ in str do
+                            let f = fontAt pos
+                            pos <- pos + 1
+                            yield f ]
 
                   let widths =
-                      List.map2 (fun (f: Font) (ch: char) -> f.charWidth ch) fonts (List.ofSeq str)
+                      List.map2 (fun (f: Font) (ch: char) -> f.charWidth ch) fontsForLine (List.ofSeq str)
 
                   let offsetXs = List.scan (+) 0.0 widths
 
                   let lineSvg =
                       [ for c in 0 .. str.Length - 1 do
-                            let font = fonts.[c]
+                            let font = fontsForLine.[c]
                             charCount <- charCount + 1
 
                             match progress with

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -15,7 +15,7 @@ import { buildCompareOverlaySvg } from './fontCompare'
 import FontCompareControls from './FontCompareControls'
 import FontCompareTextOverlay from './FontCompareTextOverlay'
 import { proofTexts, proofLabels, proofCases, classicBooks } from './proofs'
-import { randomizeAxes, buildGlyphAxes, newGlyphSeed } from './glyphRandom'
+import { randomizeAxes, buildGlyphAxes, buildPerGlyphTextAxes, newGlyphSeed } from './glyphRandom'
 import './App.css'
 
 // Special Visual Diffs option: compare the old spiro/spline2 engine vs the new dactyl spline
@@ -563,15 +563,19 @@ function App() {
     return (!isNaN(idx) && idx >= 0 && idx < classicBooks.length) ? classicBooks[idx] : null
   })
 
-  // Per-glyph random axes, as the parallel (chars, axesList) arrays the F# API
-  // takes.  Two variants so the whole-font one (export / proofs / comparisons)
-  // doesn't churn every time the typed text changes.
+  // Per-glyph random axes for the two rendering paths (see glyphRandom.js):
+  //  - perGlyphFontAxes: per-character (chars, axesList), for anything backed
+  //    by a real font (export / embedded proof preview / comparisons), where
+  //    a code point can only have one glyph shape.
+  //  - perGlyphTextAxes: per-occurrence axesList for direct SVG rendering
+  //    (Font tab preview, Font/Proofs SVG export), so repeated characters
+  //    like "555555" can each render differently.
   const perGlyphFontAxes = useMemo(
     () => glyphSeed === null ? null : buildGlyphAxes(allChars.replace(/\n/g, '') + ' ', glyphSeed, axes, controlDefinitions),
     [glyphSeed, axes]
   )
   const perGlyphTextAxes = useMemo(
-    () => glyphSeed === null ? null : buildGlyphAxes(text || '', glyphSeed, axes, controlDefinitions),
+    () => glyphSeed === null ? null : buildPerGlyphTextAxes(text || '', glyphSeed, axes, controlDefinitions),
     [glyphSeed, axes, text]
   )
   const perGlyphFontArgs = perGlyphFontAxes ? [perGlyphFontAxes.chars, perGlyphFontAxes.axesList] : []
@@ -609,7 +613,7 @@ function App() {
     }
     worker.onerror = (err) => { worker.terminate(); reject(err) }
     worker.postMessage(perGlyphTextAxes
-      ? { id: 0, type: 'fontPerGlyph', args: [text, axes, perGlyphTextAxes.chars, perGlyphTextAxes.axesList, true] }
+      ? { id: 0, type: 'fontPerGlyph', args: [text, axes, perGlyphTextAxes, true] }
       : { id: 0, type: 'font', args: [text, axes, true] })
   })
 
@@ -627,8 +631,8 @@ function App() {
     }
     worker.onerror = (err) => { worker.terminate(); reject(err) }
     if (glyphSeed !== null) {
-      const pga = buildGlyphAxes(proofsText, glyphSeed, axes, controlDefinitions)
-      worker.postMessage({ id: 0, type: 'fontPerGlyph', args: [proofsText, axes, pga.chars, pga.axesList, true] })
+      const axesList = buildPerGlyphTextAxes(proofsText, glyphSeed, axes, controlDefinitions)
+      worker.postMessage({ id: 0, type: 'fontPerGlyph', args: [proofsText, axes, axesList, true] })
     } else {
       worker.postMessage({ id: 0, type: 'font', args: [proofsText, axes, true] })
     }
@@ -1001,7 +1005,7 @@ function App() {
       }
       if (perGlyphTextAxes) {
         typeReq = 'fontPerGlyph'
-        args = [text, axes, perGlyphTextAxes.chars, perGlyphTextAxes.axesList, false]
+        args = [text, axes, perGlyphTextAxes, false]
       } else {
         typeReq = 'font'
         args = [text, axes, false]

--- a/web/src/glyphRandom.js
+++ b/web/src/glyphRandom.js
@@ -1,11 +1,23 @@
 // Axis randomisation, shared by the sidebar "Randomize" button and the Font
 // tab's "randomise every glyph" mode.
 //
-// Per-glyph mode is driven by a single integer seed: each character's axes are
-// derived deterministically from (seed, code point).  That keeps the variant
-// font *stable* — re-renders, tab switches, sidebar tweaks and OTF export all
-// reproduce the same glyphs, and every occurrence of a letter looks the same.
-// A new set only appears when a new seed is rolled (or randomisation is reset).
+// Per-glyph mode is driven by a single integer seed. There are two flavours:
+//
+//  - Per-character (buildGlyphAxes): axes are derived from (seed, code point)
+//    alone, so every occurrence of a letter looks the same. Required for OTF
+//    export and the embedded-font proof preview, where a code point can only
+//    have one glyph shape.
+//  - Per-occurrence (buildPerGlyphTextAxes): axes are derived from (seed, code
+//    point, nth occurrence of that character so far), so a repeated run like
+//    "555555" renders with a different roll per character. Only valid for
+//    direct SVG rendering (no real font involved), and only for the specific
+//    text being drawn — the nth occurrence shifts if an earlier occurrence of
+//    the same character is inserted/removed, though unrelated edits don't
+//    disturb it.
+//
+// Either way, re-renders, tab switches and sidebar tweaks reproduce the same
+// glyphs; a new set only appears when a new seed is rolled (or randomisation
+// is reset).
 
 // Only touch a fraction of axes, and bias sampled values toward the centre
 // (nudge, don't reroll) so extreme/rare effects don't stack up.
@@ -31,13 +43,16 @@ export function mulberry32(seed) {
   }
 }
 
-/// Mix a seed with a character code into a well-distributed 32-bit PRNG seed,
-/// so adjacent code points (e.g. 'a' and 'b') get unrelated settings.
-export function glyphSeedFor(seed, codePoint) {
+/// Mix a seed with a character code (and, for per-occurrence mode, which
+/// occurrence of that character this is) into a well-distributed 32-bit PRNG
+/// seed, so adjacent code points (e.g. 'a' and 'b') — and repeated instances
+/// of the same code point — get unrelated settings. `occurrence` defaults to
+/// 0, which reproduces the plain per-character seed exactly.
+export function glyphSeedFor(seed, codePoint, occurrence = 0) {
   let h = ((seed | 0) ^ 0x9e3779b9) >>> 0
   h = Math.imul(h ^ codePoint, 0x85ebca6b)
   h ^= h >>> 13
-  h = Math.imul(h, 0xc2b2ae35)
+  h = Math.imul(h ^ occurrence, 0xc2b2ae35)
   return (h ^ (h >>> 16)) >>> 0
 }
 
@@ -72,20 +87,41 @@ export function randomizeAxes(base, centre, controls, rand, skippedAxes = []) {
   return next
 }
 
-/// Axes for a single character under the per-glyph random seed.
-export function glyphAxes(char, seed, axes, controls) {
-  const rand = mulberry32(glyphSeedFor(seed, char.codePointAt(0)))
+/// Axes for a single character under the per-glyph random seed. `occurrence`
+/// distinguishes repeats of the same character within one render (see
+/// buildPerGlyphTextAxes); omit it for the stable per-character roll used by
+/// font export.
+export function glyphAxes(char, seed, axes, controls, occurrence = 0) {
+  const rand = mulberry32(glyphSeedFor(seed, char.codePointAt(0), occurrence))
   return randomizeAxes(axes, axes, controls, rand, PER_GLYPH_SKIPPED_AXES)
 }
 
-/// Build the parallel (chars, axesList) arrays the F# API expects.  Duplicate
-/// characters collapse to one entry, so a letter always renders identically.
+/// Build the parallel (chars, axesList) arrays the F# API expects for
+/// per-character rendering (OTF export, embedded-font proof preview).
+/// Duplicate characters collapse to one entry, so a letter always renders
+/// identically — required since a real font has one glyph per code point.
 export function buildGlyphAxes(chars, seed, axes, controls) {
   const distinct = [...new Set(Array.from(chars))].filter(c => c !== '\n' && c !== '\r')
   return {
     chars: distinct.join(''),
     axesList: distinct.map(c => glyphAxes(c, seed, axes, controls)),
   }
+}
+
+/// Build a positional axesList for direct SVG rendering of `text`: one entry
+/// per character, in order, aligned with how the F# side splits the text into
+/// lines (text.Replace("\r\n","\n").Split('\n'), lines concatenated back to
+/// back). Unlike buildGlyphAxes this is *not* deduplicated by character — the
+/// nth occurrence of a character gets its own roll — so repeated characters
+/// like "555555" can each render differently.
+export function buildPerGlyphTextAxes(text, seed, axes, controls) {
+  const flat = text.replace(/\r\n/g, '\n').split('\n').join('')
+  const occurrence = new Map()
+  return Array.from(flat).map(c => {
+    const n = occurrence.get(c) ?? 0
+    occurrence.set(c, n + 1)
+    return glyphAxes(c, seed, axes, controls, n)
+  })
 }
 
 /// A fresh seed for the "randomise every glyph" button.

--- a/web/src/glyphRandom.test.js
+++ b/web/src/glyphRandom.test.js
@@ -5,6 +5,7 @@ import {
   randomizeAxes,
   glyphAxes,
   buildGlyphAxes,
+  buildPerGlyphTextAxes,
   PER_GLYPH_SKIPPED_AXES,
 } from './glyphRandom'
 
@@ -59,6 +60,15 @@ describe('glyphSeedFor', () => {
     const a = glyphSeedFor(1, 97)
     const b = glyphSeedFor(2, 97)
     expect(a).not.toBe(b)
+  })
+
+  it('defaults occurrence to 0, matching the plain (seed, codePoint) form', () => {
+    expect(glyphSeedFor(1, 97, 0)).toBe(glyphSeedFor(1, 97))
+  })
+
+  it('separates occurrences of the same character', () => {
+    const seeds = new Set(Array.from({ length: 10 }, (_, n) => glyphSeedFor(1, 97, n)))
+    expect(seeds.size).toBe(10)
   })
 })
 
@@ -152,5 +162,35 @@ describe('buildGlyphAxes', () => {
     const b = buildGlyphAxes('cba', 7, axes, controls)
     const byChar = o => Object.fromEntries(o.chars.split('').map((c, i) => [c, o.axesList[i]]))
     expect(byChar(a)).toEqual(byChar(b))
+  })
+})
+
+describe('buildPerGlyphTextAxes', () => {
+  it('keeps repeated characters as separate, potentially different entries', () => {
+    const axesList = buildPerGlyphTextAxes('555555', 7, axes, controls)
+    expect(axesList).toHaveLength(6)
+    // not asking for all-distinct (rolls can coincide), just real variety
+    expect(new Set(axesList.map(a => JSON.stringify(a))).size).toBeGreaterThan(1)
+  })
+
+  it('gives each occurrence the same axes as glyphAxes with that occurrence index', () => {
+    const axesList = buildPerGlyphTextAxes('555555', 7, axes, controls)
+    axesList.forEach((a, i) => {
+      expect(a).toEqual(glyphAxes('5', 7, axes, controls, i))
+    })
+  })
+
+  it('drops newlines but keeps position alignment otherwise', () => {
+    const axesList = buildPerGlyphTextAxes('ab\ncd', 7, axes, controls)
+    expect(axesList).toHaveLength(4)
+    expect(axesList[0]).toEqual(glyphAxes('a', 7, axes, controls, 0))
+    expect(axesList[1]).toEqual(glyphAxes('b', 7, axes, controls, 0))
+    expect(axesList[2]).toEqual(glyphAxes('c', 7, axes, controls, 0))
+    expect(axesList[3]).toEqual(glyphAxes('d', 7, axes, controls, 0))
+  })
+
+  it('is stable for the same seed and text', () => {
+    expect(buildPerGlyphTextAxes('555555', 7, axes, controls))
+      .toEqual(buildPerGlyphTextAxes('555555', 7, axes, controls))
   })
 })

--- a/web/src/worker.js
+++ b/web/src/worker.js
@@ -17,10 +17,11 @@ self.onmessage = (e) => {
                     self.postMessage({ id, type: 'progress', value: p });
                 })
                 break
-            // Same as 'font' but every character gets its own axes (see glyphRandom.js)
+            // Same as 'font' but every character occurrence gets its own axes
+            // (see glyphRandom.js's buildPerGlyphTextAxes)
             case 'fontPerGlyph': {
-                const [fText, fBaseAxes, fChars, fAxesList, fAutoscale] = args
-                result = generateSvgPerGlyph(fText, fBaseAxes, fChars, fAxesList, fAutoscale, (p) => {
+                const [fText, fBaseAxes, fAxesList, fAutoscale] = args
+                result = generateSvgPerGlyph(fText, fBaseAxes, fAxesList, fAutoscale, (p) => {
                     self.postMessage({ id, type: 'progress', value: p });
                 })
                 break


### PR DESCRIPTION
## Summary

- "Randomise every glyph" used to seed each character's axes from `(seed, code point)` alone, so every occurrence of a letter rendered identically — e.g. `555555` showed six copies of the same random roll.
- Direct SVG rendering (Font tab preview, Font/Proofs SVG export) doesn't need that constraint the way OTF export and the embedded-font Proofs preview do, since it isn't limited to one glyph shape per code point.
- Added an `occurrence` parameter to the seed mix (`glyphSeedFor`/`glyphAxes`) and a new `buildPerGlyphTextAxes` that gives each character occurrence its own roll, keyed by how many times that character has already appeared in the text.
- Changed `generateSvgPerGlyph` (F#) to take a positional `axesList` aligned to the flattened text instead of a char-keyed lookup, so repeats can render differently.
- `buildGlyphAxes` (distinct-char dedup) is unchanged and still backs OTF export and the embedded-font Proofs tab preview, where a code point can only have one glyph shape — those two paths still render every occurrence of a character identically, which is a fundamental limitation of real font formats, not something this PR attempts to work around.

## Test plan

- [x] `cd web && npm test` — 115 tests pass, including new coverage for `glyphSeedFor` occurrence separation and `buildPerGlyphTextAxes`
- [x] `dotnet test src/generator/tests/generator.tests.fsproj` — 107 tests pass
- [x] `dotnet fable src/explorer --outDir web/src/lib/fable && cd web && npm run build` — builds cleanly
- [x] Manually verified in a local `vite preview` build: typed `555555` into the Font tab with "Randomise every glyph" on, and each of the six `5`s renders with visibly different weight/serif/slant/roundedness

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpXVaZWdmrUMFBPFb7Tpzh)_