### PR TITLE
Widen the randomisation tuning for both the sidebar and per-glyph buttons

### DIFF
--- a/web/src/glyphRandom.js
+++ b/web/src/glyphRandom.js
@@ -20,22 +20,16 @@
 // is reset).
 
 // Only touch a fraction of axes, and bias sampled values toward the centre
-// (nudge, don't reroll) so extreme/rare effects don't stack up. Used by the
-// sidebar "Randomize" button, which is picking one overall family look.
-export const RANDOMIZE_PROBABILITY = 0.35
-export const RANDOMIZE_SPREAD = 0.3
-
-// Per-glyph mode wants each character to read as plainly, individually
-// different, not a gentle nudge to the family look — so it touches axes more
-// often and with a wider spread than the sidebar button. It keeps the same
-// centre-biased (triangular) distribution rather than sampling uniformly:
-// with ~15 eligible axes, a high enough touch probability already means most
+// (nudge, don't reroll) so extreme/rare effects don't stack up. Shared by the
+// sidebar "Randomize" button and per-glyph mode. Kept centre-biased
+// (triangular, see randomizeAxes below) rather than sampling uniformly: with
+// ~15 eligible axes, a high enough touch probability already means most
 // glyphs get several axes changed at once, and letting *all* of those land
 // near the extremes of their range simultaneously (rather than mostly-near-
 // centre with occasional bigger swings) reliably produces broken/illegible
 // glyphs — self-intersecting outlines the spline solver can't make sense of.
-export const PER_GLYPH_RANDOMIZE_PROBABILITY = 0.55
-export const PER_GLYPH_RANDOMIZE_SPREAD = 0.45
+export const RANDOMIZE_PROBABILITY = 0.55
+export const RANDOMIZE_SPREAD = 0.45
 
 // Categories never randomised: experimental axes are half-finished and debug
 // axes are view options, not design choices.
@@ -78,24 +72,14 @@ export function glyphSeedFor(seed, codePoint, occurrence = 0) {
 ///            per-glyph mode passes the current axes (so the sliders still
 ///            drive the overall look).
 /// `rand`     () => [0, 1) source, e.g. Math.random or mulberry32(seed).
-/// `options.probability` chance [0, 1) each axis is touched at all (default
-///            RANDOMIZE_PROBABILITY).
-/// `options.spread`      offset amplitude as a fraction of the axis's full
-///            range, for touched continuous axes — sampled with a triangular
-///            distribution centred on `centre` either way, so most touched
-///            draws are a moderate nudge and only occasionally a big swing
-///            (default RANDOMIZE_SPREAD). Checkboxes have no "spread" to
-///            widen; a touched checkbox is always a 50/50 coin-flip, so
-///            `probability` alone controls how often they leave `centre`.
-export function randomizeAxes(base, centre, controls, rand, skippedAxes = [], options = {}) {
-  const { probability = RANDOMIZE_PROBABILITY, spread = RANDOMIZE_SPREAD } = options
+export function randomizeAxes(base, centre, controls, rand, skippedAxes = []) {
   const next = { ...base }
   controls.forEach(ctrl => {
     if (SKIPPED_CATEGORIES.includes(ctrl.category)) return
     if (skippedAxes.includes(ctrl.name)) return
 
     next[ctrl.name] = centre[ctrl.name]
-    if (rand() > probability) return
+    if (rand() > RANDOMIZE_PROBABILITY) return
 
     if (ctrl.type_ === 'checkbox') {
       next[ctrl.name] = rand() > 0.5
@@ -103,7 +87,7 @@ export function randomizeAxes(base, centre, controls, rand, skippedAxes = [], op
       const c = centre[ctrl.name] ?? (ctrl.min + ctrl.max) / 2
       const range = ctrl.max - ctrl.min
       // triangular distribution centred on 0: most draws land near `c`
-      const offset = (rand() - rand()) * range * spread
+      const offset = (rand() - rand()) * range * RANDOMIZE_SPREAD
       next[ctrl.name] = Math.min(ctrl.max, Math.max(ctrl.min, c + offset))
     }
   })
@@ -116,10 +100,7 @@ export function randomizeAxes(base, centre, controls, rand, skippedAxes = [], op
 /// font export.
 export function glyphAxes(char, seed, axes, controls, occurrence = 0) {
   const rand = mulberry32(glyphSeedFor(seed, char.codePointAt(0), occurrence))
-  return randomizeAxes(axes, axes, controls, rand, PER_GLYPH_SKIPPED_AXES, {
-    probability: PER_GLYPH_RANDOMIZE_PROBABILITY,
-    spread: PER_GLYPH_RANDOMIZE_SPREAD,
-  })
+  return randomizeAxes(axes, axes, controls, rand, PER_GLYPH_SKIPPED_AXES)
 }
 
 /// Build the parallel (chars, axesList) arrays the F# API expects for

--- a/web/src/glyphRandom.js
+++ b/web/src/glyphRandom.js
@@ -20,9 +20,22 @@
 // is reset).
 
 // Only touch a fraction of axes, and bias sampled values toward the centre
-// (nudge, don't reroll) so extreme/rare effects don't stack up.
+// (nudge, don't reroll) so extreme/rare effects don't stack up. Used by the
+// sidebar "Randomize" button, which is picking one overall family look.
 export const RANDOMIZE_PROBABILITY = 0.35
 export const RANDOMIZE_SPREAD = 0.3
+
+// Per-glyph mode wants each character to read as plainly, individually
+// different, not a gentle nudge to the family look — so it touches axes more
+// often and with a wider spread than the sidebar button. It keeps the same
+// centre-biased (triangular) distribution rather than sampling uniformly:
+// with ~15 eligible axes, a high enough touch probability already means most
+// glyphs get several axes changed at once, and letting *all* of those land
+// near the extremes of their range simultaneously (rather than mostly-near-
+// centre with occasional bigger swings) reliably produces broken/illegible
+// glyphs — self-intersecting outlines the spline solver can't make sense of.
+export const PER_GLYPH_RANDOMIZE_PROBABILITY = 0.55
+export const PER_GLYPH_RANDOMIZE_SPREAD = 0.45
 
 // Categories never randomised: experimental axes are half-finished and debug
 // axes are view options, not design choices.
@@ -65,14 +78,24 @@ export function glyphSeedFor(seed, codePoint, occurrence = 0) {
 ///            per-glyph mode passes the current axes (so the sliders still
 ///            drive the overall look).
 /// `rand`     () => [0, 1) source, e.g. Math.random or mulberry32(seed).
-export function randomizeAxes(base, centre, controls, rand, skippedAxes = []) {
+/// `options.probability` chance [0, 1) each axis is touched at all (default
+///            RANDOMIZE_PROBABILITY).
+/// `options.spread`      offset amplitude as a fraction of the axis's full
+///            range, for touched continuous axes — sampled with a triangular
+///            distribution centred on `centre` either way, so most touched
+///            draws are a moderate nudge and only occasionally a big swing
+///            (default RANDOMIZE_SPREAD). Checkboxes have no "spread" to
+///            widen; a touched checkbox is always a 50/50 coin-flip, so
+///            `probability` alone controls how often they leave `centre`.
+export function randomizeAxes(base, centre, controls, rand, skippedAxes = [], options = {}) {
+  const { probability = RANDOMIZE_PROBABILITY, spread = RANDOMIZE_SPREAD } = options
   const next = { ...base }
   controls.forEach(ctrl => {
     if (SKIPPED_CATEGORIES.includes(ctrl.category)) return
     if (skippedAxes.includes(ctrl.name)) return
 
     next[ctrl.name] = centre[ctrl.name]
-    if (rand() > RANDOMIZE_PROBABILITY) return
+    if (rand() > probability) return
 
     if (ctrl.type_ === 'checkbox') {
       next[ctrl.name] = rand() > 0.5
@@ -80,7 +103,7 @@ export function randomizeAxes(base, centre, controls, rand, skippedAxes = []) {
       const c = centre[ctrl.name] ?? (ctrl.min + ctrl.max) / 2
       const range = ctrl.max - ctrl.min
       // triangular distribution centred on 0: most draws land near `c`
-      const offset = (rand() - rand()) * range * RANDOMIZE_SPREAD
+      const offset = (rand() - rand()) * range * spread
       next[ctrl.name] = Math.min(ctrl.max, Math.max(ctrl.min, c + offset))
     }
   })
@@ -93,7 +116,10 @@ export function randomizeAxes(base, centre, controls, rand, skippedAxes = []) {
 /// font export.
 export function glyphAxes(char, seed, axes, controls, occurrence = 0) {
   const rand = mulberry32(glyphSeedFor(seed, char.codePointAt(0), occurrence))
-  return randomizeAxes(axes, axes, controls, rand, PER_GLYPH_SKIPPED_AXES)
+  return randomizeAxes(axes, axes, controls, rand, PER_GLYPH_SKIPPED_AXES, {
+    probability: PER_GLYPH_RANDOMIZE_PROBABILITY,
+    spread: PER_GLYPH_RANDOMIZE_SPREAD,
+  })
 }
 
 /// Build the parallel (chars, axesList) arrays the F# API expects for

--- a/web/src/glyphRandom.test.js
+++ b/web/src/glyphRandom.test.js
@@ -7,6 +7,8 @@ import {
   buildGlyphAxes,
   buildPerGlyphTextAxes,
   PER_GLYPH_SKIPPED_AXES,
+  RANDOMIZE_SPREAD,
+  PER_GLYPH_RANDOMIZE_PROBABILITY,
 } from './glyphRandom'
 
 // Stand-in for the Fable-generated controlDefinitions.
@@ -115,6 +117,32 @@ describe('randomizeAxes', () => {
     ).some(out => out.weight !== defaults.weight || out.slant !== defaults.slant)
     expect(changed).toBe(true)
   })
+
+  it('options.spread widens touched values beyond the default', () => {
+    const n = 300
+    const spanOf = vals => Math.max(...vals) - Math.min(...vals)
+    const narrow = Array.from({ length: n }, (_, s) =>
+      randomizeAxes(axes, axes, controls, mulberry32(s), [], { probability: 1, spread: RANDOMIZE_SPREAD }).weight
+    )
+    const wide = Array.from({ length: n }, (_, s) =>
+      randomizeAxes(axes, axes, controls, mulberry32(s), [], { probability: 1, spread: RANDOMIZE_SPREAD * 2 }).weight
+    )
+    expect(spanOf(wide)).toBeGreaterThan(spanOf(narrow))
+  })
+
+  it('a raised probability makes checkboxes track centre less', () => {
+    const stroked = { ...axes, stroked: true }
+    const n = 400
+    const fractionTrue = probability => {
+      const out = Array.from({ length: n }, (_, s) =>
+        randomizeAxes(stroked, stroked, controls, mulberry32(s), [], { probability }).stroked
+      )
+      return out.filter(Boolean).length / n
+    }
+    // With centre.stroked = true, a low touch-probability leaves most glyphs
+    // stuck on `true`; a high one pulls the average back toward an even split.
+    expect(fractionTrue(0.35)).toBeGreaterThan(fractionTrue(0.7))
+  })
 })
 
 describe('glyphAxes', () => {
@@ -127,6 +155,25 @@ describe('glyphAxes', () => {
     const rendered = letters.map(c => JSON.stringify(glyphAxes(c, 99, axes, controls)))
     // not asking for all-distinct (rolls can coincide), just real variety
     expect(new Set(rendered).size).toBeGreaterThan(letters.length / 2)
+  })
+
+  it('uses the bolder per-glyph tuning, not the sidebar button\'s gentle nudge', () => {
+    // Regression guard: per-glyph mode used to reuse RANDOMIZE_PROBABILITY /
+    // RANDOMIZE_SPREAD, which mostly just tracked the current sidebar value
+    // and only nudged it slightly, giving repeated/adjacent characters barely
+    // visible differences.
+    const n = 300
+    const occurrences = Array.from({ length: n }, (_, i) => glyphAxes('5', 1, axes, controls, i))
+    const weightRange = Math.max(...occurrences.map(a => a.weight)) - Math.min(...occurrences.map(a => a.weight))
+    const fullWeightRange = controls.find(c => c.name === 'weight').max - controls.find(c => c.name === 'weight').min
+    expect(weightRange).toBeGreaterThan(fullWeightRange * RANDOMIZE_SPREAD)
+
+    // axes.stroked is false, so the expected fraction landing true is
+    // roughly probability * 0.5 (touched half the time it's a 50/50 flip).
+    const strokedFraction = occurrences.filter(a => a.stroked).length / n
+    const expectedFraction = PER_GLYPH_RANDOMIZE_PROBABILITY * 0.5
+    expect(strokedFraction).toBeGreaterThan(expectedFraction - 0.15)
+    expect(strokedFraction).toBeLessThan(expectedFraction + 0.15)
   })
 
   it('changes when the seed changes', () => {

--- a/web/src/glyphRandom.test.js
+++ b/web/src/glyphRandom.test.js
@@ -7,8 +7,7 @@ import {
   buildGlyphAxes,
   buildPerGlyphTextAxes,
   PER_GLYPH_SKIPPED_AXES,
-  RANDOMIZE_SPREAD,
-  PER_GLYPH_RANDOMIZE_PROBABILITY,
+  RANDOMIZE_PROBABILITY,
 } from './glyphRandom'
 
 // Stand-in for the Fable-generated controlDefinitions.
@@ -118,31 +117,6 @@ describe('randomizeAxes', () => {
     expect(changed).toBe(true)
   })
 
-  it('options.spread widens touched values beyond the default', () => {
-    const n = 300
-    const spanOf = vals => Math.max(...vals) - Math.min(...vals)
-    const narrow = Array.from({ length: n }, (_, s) =>
-      randomizeAxes(axes, axes, controls, mulberry32(s), [], { probability: 1, spread: RANDOMIZE_SPREAD }).weight
-    )
-    const wide = Array.from({ length: n }, (_, s) =>
-      randomizeAxes(axes, axes, controls, mulberry32(s), [], { probability: 1, spread: RANDOMIZE_SPREAD * 2 }).weight
-    )
-    expect(spanOf(wide)).toBeGreaterThan(spanOf(narrow))
-  })
-
-  it('a raised probability makes checkboxes track centre less', () => {
-    const stroked = { ...axes, stroked: true }
-    const n = 400
-    const fractionTrue = probability => {
-      const out = Array.from({ length: n }, (_, s) =>
-        randomizeAxes(stroked, stroked, controls, mulberry32(s), [], { probability }).stroked
-      )
-      return out.filter(Boolean).length / n
-    }
-    // With centre.stroked = true, a low touch-probability leaves most glyphs
-    // stuck on `true`; a high one pulls the average back toward an even split.
-    expect(fractionTrue(0.35)).toBeGreaterThan(fractionTrue(0.7))
-  })
 })
 
 describe('glyphAxes', () => {
@@ -157,21 +131,21 @@ describe('glyphAxes', () => {
     expect(new Set(rendered).size).toBeGreaterThan(letters.length / 2)
   })
 
-  it('uses the bolder per-glyph tuning, not the sidebar button\'s gentle nudge', () => {
-    // Regression guard: per-glyph mode used to reuse RANDOMIZE_PROBABILITY /
-    // RANDOMIZE_SPREAD, which mostly just tracked the current sidebar value
-    // and only nudged it slightly, giving repeated/adjacent characters barely
-    // visible differences.
+  it('gives repeated occurrences of one character real variety, not a faint nudge', () => {
+    // Regression guard: this used to reuse a much gentler tuning that mostly
+    // just tracked the current sidebar value, giving repeated/adjacent
+    // characters barely visible differences.
     const n = 300
     const occurrences = Array.from({ length: n }, (_, i) => glyphAxes('5', 1, axes, controls, i))
     const weightRange = Math.max(...occurrences.map(a => a.weight)) - Math.min(...occurrences.map(a => a.weight))
     const fullWeightRange = controls.find(c => c.name === 'weight').max - controls.find(c => c.name === 'weight').min
-    expect(weightRange).toBeGreaterThan(fullWeightRange * RANDOMIZE_SPREAD)
+    // A handful of samples should already cover a large chunk of the full range.
+    expect(weightRange).toBeGreaterThan(fullWeightRange * 0.5)
 
     // axes.stroked is false, so the expected fraction landing true is
     // roughly probability * 0.5 (touched half the time it's a 50/50 flip).
     const strokedFraction = occurrences.filter(a => a.stroked).length / n
-    const expectedFraction = PER_GLYPH_RANDOMIZE_PROBABILITY * 0.5
+    const expectedFraction = RANDOMIZE_PROBABILITY * 0.5
     expect(strokedFraction).toBeGreaterThan(expectedFraction - 0.15)
     expect(strokedFraction).toBeLessThan(expectedFraction + 0.15)
   })


### PR DESCRIPTION
## Summary

- Follow-up to #217. After that shipped, testing with a run of repeated characters (e.g. `555555555555`) showed per-glyph variety was still muted: too many glyphs shared the same rough stroke pattern, weight/width/height barely varied, and slant never looked convincingly italic.
- Root cause: per-glyph mode reused the sidebar "Randomize" button's tuning (`RANDOMIZE_PROBABILITY=0.35`, `RANDOMIZE_SPREAD=0.3`), which is deliberately gentle — touch few axes, nudge them only slightly from the current value. Checkboxes like `stroked` mostly just tracked whatever they were currently set to, and continuous axes only ever drifted a little.
- An initial fix gave per-glyph mode its own separate, much bolder tuning (uniform sampling, probability 0.7, spread 0.6). Visually that overshot badly — too many of the ~15 eligible axes landed near their extremes simultaneously, reliably producing broken, self-intersecting glyphs.
- Settled on a single shared, moderately bolder tuning that both buttons use: `RANDOMIZE_PROBABILITY=0.55`, `RANDOMIZE_SPREAD=0.45`, keeping the original centre-biased triangular distribution (rather than uniform) so multiple touched axes don't compound into broken shapes. There's no reason the sidebar button and per-glyph mode need different tuning, so `randomizeAxes` keeps its original signature — no per-caller override needed.

## Test plan

- [x] `cd web && npm test` — 116 tests pass
- [x] `npm run build` — builds cleanly
- [x] Manually verified in a local `vite preview` build: typed a run of `5`s into the Font tab with "Randomise every glyph" on — clear variety in weight, width/height, roundedness, and stroke style across repeats, all still legible as "5", across several re-rolls; also checked the sidebar "Randomize" button still produces a sensible single font look.