### PR TITLE
Fix left pane not scrolling/opening on mobile

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -33,6 +33,13 @@
     color: var(--text-primary);
 }
 
+/* Mobile-only controls; hidden on desktop where the sidebar is always
+   fully visible. Shown again inside the max-width:768px media query. */
+.sidebar-toggle,
+.sidebar-backdrop {
+    display: none;
+}
+
 .sidebar-title {
     width: 100%;
     margin-bottom: -10px;
@@ -837,15 +844,19 @@
         background: var(--sidebar-bg);
     }
 
-    .sidebar:hover, .sidebar:focus-within {
+    /* Expansion is driven by the .mobile-open class (toggled on tap via
+       .sidebar-toggle), not :hover/:focus-within — touch devices have no
+       hover, so a hover-only rule left the pane permanently collapsed and
+       its contents unreachable/unscrollable on mobile. */
+    .sidebar.mobile-open {
         width: 300px;
         box-shadow: 10px 0 30px rgba(0, 0, 0, 0.5);
     }
 
     /* Hide text labels in shrunken sidebar */
-    .sidebar h2, 
+    .sidebar h2,
     .sidebar .sidebar-title,
-    .sidebar .category-header .category-title, 
+    .sidebar .category-header .category-title,
     .sidebar .control-group label,
     .sidebar .value-display,
     .sidebar .category-header span:not(.material-symbols-outlined) {
@@ -855,12 +866,12 @@
         pointer-events: none;
     }
 
-    .sidebar:hover h2,
-    .sidebar:hover .sidebar-title,
-    .sidebar:hover .category-header .category-title,
-    .sidebar:hover .control-group label,
-    .sidebar:hover .value-display,
-    .sidebar:hover .category-header span {
+    .sidebar.mobile-open h2,
+    .sidebar.mobile-open .sidebar-title,
+    .sidebar.mobile-open .category-header .category-title,
+    .sidebar.mobile-open .control-group label,
+    .sidebar.mobile-open .value-display,
+    .sidebar.mobile-open .category-header span {
         opacity: 1;
         pointer-events: auto;
     }
@@ -871,13 +882,38 @@
         padding: 0;
     }
 
-    .sidebar:hover .category-header {
+    .sidebar.mobile-open .category-header {
         justify-content: flex-start;
         padding-left: 0;
     }
 
     .sidebar .material-symbols-outlined {
         font-size: 24px;
+    }
+
+    .sidebar-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: absolute;
+        top: 12px;
+        left: 12px;
+        width: 40px;
+        height: 40px;
+        padding: 0;
+        z-index: 1001;
+        border-radius: var(--radius-md);
+        background: var(--panel-bg);
+        color: var(--text-primary);
+        border: 1px solid var(--border-color);
+    }
+
+    .sidebar-backdrop {
+        display: block;
+        position: absolute;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.4);
+        z-index: 999;
     }
 
     .main {

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -455,6 +455,10 @@ function App() {
     setOpenCategories(prev => ({ ...prev, [cat]: !prev[cat] }))
   }
 
+  // On mobile the sidebar is collapsed to an icon rail; CSS :hover has no touch
+  // equivalent, so track an explicit open/closed state and toggle it by tap.
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
+
   const handleLegendMouseDown = (e) => {
     // Only drag on left click and not on interactive elements inside
     if (e.button !== 0 || e.target.tagName === 'INPUT' || e.target.tagName === 'A') return
@@ -1692,7 +1696,18 @@ function App() {
 
   return (
     <div className="container">
-      <div className="sidebar">
+      <button
+        className="sidebar-toggle"
+        onClick={() => setMobileSidebarOpen(open => !open)}
+        title={mobileSidebarOpen ? 'Close controls' : 'Open controls'}
+        aria-label={mobileSidebarOpen ? 'Close controls' : 'Open controls'}
+      >
+        <span className="material-symbols-outlined">{mobileSidebarOpen ? 'close' : 'menu'}</span>
+      </button>
+      {mobileSidebarOpen && (
+        <div className="sidebar-backdrop" onClick={() => setMobileSidebarOpen(false)} />
+      )}
+      <div className={`sidebar${mobileSidebarOpen ? ' mobile-open' : ''}`}>
         <div className="sidebar-title" dangerouslySetInnerHTML={{ __html: generateTweenSvg("Dactyl", { ...defaultAxes, weight: 35 }) }} />
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px', flex: '0 0 auto' }}>
           <h2 style={{ margin: 0 }}>Controls</h2>


### PR DESCRIPTION
## Summary

- The mobile sidebar (`.sidebar` in `web/src/App.css`, `< 768px`) only expanded from a 64px icon rail to 300px via CSS `:hover` / `:focus-within`. Touch devices have no `:hover`, and the `category-header` divs that could receive a tap weren't focusable elements, so `:focus-within` never fired either — the left pane stayed permanently collapsed on mobile, making its contents (and the scrollable `.controls-list` inside it) unreachable.
- Replaced the hover-only CSS trigger with an explicit tap-to-toggle: a `mobileSidebarOpen` React state in `web/src/App.jsx`, toggled by a new `.sidebar-toggle` button (hidden on desktop), with the expansion driven by a `.sidebar.mobile-open` class instead of `:hover`/`:focus-within`. Added a `.sidebar-backdrop` overlay so tapping outside the open pane closes it.
- Desktop layout/behavior is unchanged (the toggle button and backdrop are `display: none` outside the mobile media query).

## Test plan

- [x] `dotnet fable src/explorer --outDir web/src/lib/fable && cd web && npm run build` — production build succeeds
- [x] `npm test` (Vitest) — 116/116 tests pass
- [x] Manual check via Playwright against `vite preview` with an iPhone 13 emulated viewport: sidebar starts at 64px, `.sidebar-toggle` opens it to 300px, `.controls-list` scrollHeight (3033px) exceeds clientHeight (437px) and is confirmed scrollable
- [ ] Visual regression snapshots (`Visual Tests` CI workflow) — not run locally per project convention; will check CI

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNjLmwCcW2TkotH3egsRns)_