### PR TITLE
Fix touch scroll globally blocked by resize-handle listener; sidebar/progress-bar polish

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -840,7 +840,9 @@
         bottom: 0;
         width: 64px;
         min-width: 64px;
-        z-index: 1000;
+        /* Above .progress-bar-container (z-index: 1000) so the pane isn't
+           see-through to the progress bar when both overlap on mobile. */
+        z-index: 1010;
         padding: 24px 12px;
         transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.3s ease;
         overflow-x: hidden;
@@ -905,7 +907,7 @@
         width: 40px;
         height: 40px;
         padding: 0;
-        z-index: 1001;
+        z-index: 1011;
         border-radius: var(--radius-md);
         background: var(--panel-bg);
         color: var(--text-primary);
@@ -917,7 +919,8 @@
         position: absolute;
         inset: 0;
         background: rgba(0, 0, 0, 0.4);
-        z-index: 999;
+        /* Above .progress-bar-container (z-index: 1000) so it dims that too. */
+        z-index: 1005;
     }
 
     .main {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -150,6 +150,10 @@
     position: relative;
     cursor: pointer;
     margin: 0;
+    /* Sliders sit inside vertically-scrollable lists (e.g. the mobile
+       sidebar); without this, touch drags starting on the slider are
+       claimed for the (horizontal) thumb drag and can't scroll the list. */
+    touch-action: pan-y;
 }
 
 .modern-slider:focus {

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1694,6 +1694,13 @@ function App() {
     setGlyphSeed(newGlyphSeed())
   }
 
+  // Constant inputs — memoized so this isn't recomputed on every render
+  // (e.g. every slider tick), which was expensive enough to noticeably
+  // delay the browser's touch-scroll response when dragging a slider.
+  const sidebarTitleSvg = useMemo(
+    () => generateTweenSvg("Dactyl", { ...defaultAxes, weight: 35 }),
+    []
+  )
 
   return (
     <div className="container">
@@ -1709,7 +1716,7 @@ function App() {
         <div className="sidebar-backdrop" onClick={() => setMobileSidebarOpen(false)} />
       )}
       <div className={`sidebar${mobileSidebarOpen ? ' mobile-open' : ''}`}>
-        <div className="sidebar-title" dangerouslySetInnerHTML={{ __html: generateTweenSvg("Dactyl", { ...defaultAxes, weight: 35 }) }} />
+        <div className="sidebar-title" dangerouslySetInnerHTML={{ __html: sidebarTitleSvg }} />
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px', flex: '0 0 auto' }}>
           <h2 style={{ margin: 0 }}>Controls</h2>
           <div className="toolbar" style={{ display: 'flex', gap: '5px' }}>

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -540,6 +540,7 @@ function App() {
     }
     const onMouseMove = (e) => applyDelta(e.clientY)
     const onTouchMove = (e) => {
+      if (!resizingInputAreaRef.current) return
       applyDelta(e.touches[0].clientY)
       if (e.cancelable) e.preventDefault()
     }


### PR DESCRIPTION
## Summary

Follow-up to #222, which fixed *opening* the mobile sidebar. The user reported touch scrolling still didn't work — confirmed on real Chrome/Windows touch input, not just emulation — even after an initial `touch-action` attempt (kept below, it's still correct, just wasn't the actual cause).

**Root cause (the real bug):** in `web/src/App.jsx`, the input-area resize handle's `touchmove` listener is registered on `document` for the whole app's lifetime and called `e.preventDefault()` on **every** touchmove event anywhere on the page — not just while a resize drag was actually in progress. The `resizingInputAreaRef.current` guard only gated the resize logic inside `applyDelta`, not the `preventDefault()` call itself. Since this listener is `{ passive: false }`, it silently blocked native touch scrolling *everywhere on the page*, including the sidebar — no CSS change could have fixed that, since JS was unconditionally cancelling the browser's default scroll before touch-action was even relevant. Fixed by gating `preventDefault()` behind the same ref check.

I verified this directly and definitively: dispatched a real `TouchEvent` via the DOM API (not a browser-touch-gesture simulation, which proved unreliable in this sandbox — see below) while no resize drag was active, and checked `event.defaultPrevented`. Before the fix: `true` (bug reproduced). After the fix: `false` (bug gone). Confirmed against both builds side by side.

Also included, from earlier in this branch:
- `touch-action: pan-y` on `.modern-slider` — sliders fill most of the sidebar's vertical space; without this, a touch drag starting on a slider is claimed for the slider's horizontal drag instead of the list's scroll. Still correct and worth keeping even though it wasn't the main blocker.
- Sidebar/toggle/backdrop z-index raised above `.progress-bar-container` so the progress bar renders behind the pane instead of over it.

## Test plan

- [x] `dotnet fable src/explorer --outDir web/src/lib/fable && cd web && npm run build` — production build succeeds
- [x] `npm test` (Vitest) — 116/116 tests pass
- [x] Direct proof of the real fix: dispatched a `TouchEvent('touchmove')` via `dispatchEvent` in-page (no resize drag active) and confirmed `event.defaultPrevented` flips from `true` (pre-fix) to `false` (post-fix) — this doesn't depend on simulating a real scroll gesture, so it's not subject to the emulation issues below
- [x] Progress-bar z-index fix verified visually (mock progress bar + `elementFromPoint` at the overlap region resolves to the sidebar)
- [ ] End-to-end real-device confirmation that scrolling now works — I don't have a reliable way to simulate an actual touch-drag scroll gesture in this sandbox (both raw CDP `Input.dispatchTouchEvent` and Chrome's own mouse-emulates-touch mode were unreliable/hung here), so please confirm on your phone/touchscreen.