### PR TITLE
Make the whole collapsed mobile sidebar tappable to open

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1715,7 +1715,10 @@ function App() {
       {mobileSidebarOpen && (
         <div className="sidebar-backdrop" onClick={() => setMobileSidebarOpen(false)} />
       )}
-      <div className={`sidebar${mobileSidebarOpen ? ' mobile-open' : ''}`}>
+      <div
+        className={`sidebar${mobileSidebarOpen ? ' mobile-open' : ''}`}
+        onClick={() => { if (!mobileSidebarOpen) setMobileSidebarOpen(true) }}
+      >
         <div className="sidebar-title" dangerouslySetInnerHTML={{ __html: sidebarTitleSvg }} />
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px', flex: '0 0 auto' }}>
           <h2 style={{ margin: 0 }}>Controls</h2>


### PR DESCRIPTION
## Summary

Follow-up to #224. After that fix, touch-scrolling and the toggle button itself both work correctly (verified: a real touch `tap()` on `.sidebar-toggle` does expand it), but the reported symptom was "when I touch the side panel it doesn't pop out" — which pointed at a discoverability problem rather than a broken handler.

The open/close control is a 40×40px button tucked in the top-left corner. Tapping anywhere else on the visible collapsed rail — the logo, a category icon, empty space — did nothing, which reads as "the panel doesn't respond to touch" even though the tiny button in the corner did work.

- Added a click handler on `.sidebar` itself that opens it when collapsed, so tapping anywhere on the visible rail reveals it — the common mobile-drawer pattern (tap the visible edge to open, use the X/backdrop to close).
- Only takes effect while collapsed (`if (!mobileSidebarOpen)`), so it never interferes with using controls once the panel is open.
- The dedicated toggle button and backdrop-tap-to-close are unchanged.

## Test plan

- [x] `dotnet fable src/explorer --outDir web/src/lib/fable && cd web && npm run build` — production build succeeds
- [x] `npm test` (Vitest) — 116/116 tests pass
- [x] Verified via Playwright with a touch-enabled context (`hasTouch: true`, iPhone 13 emulation):
  - Tapping the collapsed rail well away from the toggle button (e.g. over `.category-content`) now opens the sidebar (300px)
  - Toggle button still closes it
  - Backdrop tap still closes it
  - Clicking a slider while open does *not* close the panel (interaction with controls is unaffected)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNjLmwCcW2TkotH3egsRns)_