### PR TITLE
ci: keep apt off the visual-test happy path, and bound the job

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -18,6 +18,10 @@ permissions:
 jobs:
   visual-test:
     runs-on: ubuntu-latest
+    # Backstop: a healthy run takes ~2 minutes.  Without this, a hung step runs
+    # until GitHub's 6-hour job limit (see the apt stalls that motivated the
+    # step timeouts below) instead of failing fast and visibly.
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -50,10 +54,12 @@ jobs:
         run: cd web && npm ci
 
       - name: Install Playwright browsers
-        run: cd web && npx playwright install --with-deps chromium
-
-      - name: Install ImageMagick
-        run: sudo apt-get install -y imagemagick fonts-dejavu-core
+        # No --with-deps: that flag shells out to apt-get, which is where this
+        # job has hung (twice for over an hour, on two different runners).  The
+        # ubuntu-latest image already ships Chromium's system libraries, so the
+        # browser download alone is enough — and it normally takes ~20s.
+        timeout-minutes: 5
+        run: cd web && npx playwright install chromium
 
       - name: Build web app
         run: cd web && npm run build
@@ -86,6 +92,17 @@ jobs:
             git commit -m "Add new visual regression baselines"
             git push
           fi
+
+      - name: Install ImageMagick for diff GIFs
+        # Only the diff-GIF step below uses `convert` and the DejaVu font, and it
+        # only runs on failure — so installing these unconditionally put an
+        # apt-get on the happy path for nothing.  It is not worth failing an
+        # already-failing run over, hence continue-on-error: the PNGs still
+        # upload even if this cannot install.
+        if: failure()
+        continue-on-error: true
+        timeout-minutes: 10
+        run: sudo apt-get install -y imagemagick fonts-dejavu-core
 
       - name: Generate failure diff GIFs
         if: failure()


### PR DESCRIPTION
Follow-up to the CI stalls seen on #223. Touches `.github/workflows/visual-tests.yml` only — no source or snapshot changes.

## What happened

The `visual-test` job hung on **`Install Playwright browsers`** twice, on two different runners:

| attempt | runner | time on that step | outcome |
|---|---|---|---|
| 1 | 1000002693 | 69 min | cancelled |
| 2 | 1000002694 | 5h 32m | cancelled |
| 3 | 1000002698 | 26s | passed |

Every step after the stall was skipped, so no test ran and no artifacts were produced. And the attempt that *did* pass still took 37 minutes — **34½ of them inside `Install ImageMagick`**.

Both are apt. `playwright install --with-deps` shells out to `apt-get`, and the ImageMagick step calls it again; apt blocks indefinitely when it can't take the dpkg lock. The job had no `timeout-minutes`, so a stall burned runner time until GitHub's 6-hour limit instead of failing fast.

## Changes

Three, arranged so a **passing run makes no apt calls at all**:

- **Drop `--with-deps`** from the Playwright install. `ubuntu-latest` already ships Chromium's system libraries — and this is what the local test instructions in `CLAUDE.md` already tell contributors to run.
- **Install ImageMagick and DejaVu only on failure**, immediately before the diff-GIF step that is their sole consumer, rather than unconditionally near the top. `convert` and `DejaVu-Sans-Bold` are used by exactly one step, which is already `if: failure()`. Marked `continue-on-error` so a failed install can't mask the test failure that triggered it — the screenshots upload either way.
- **`timeout-minutes: 20`** on the job (healthy runs take ~2), plus tighter step-level bounds on the two steps that touch the network or apt.

Expected effect: a healthy run drops from ~37 min back to ~2 min, and a stalled one turns red in minutes with a legible reason instead of silently occupying a runner for hours.

## Risk

One change carries real risk, and it's worth naming: if `ubuntu-latest` turns out to be missing a library Chromium needs, **`Run visual tests` fails immediately and loudly**, and the fix is to restore `--with-deps` on that one step. The blast radius is a single red run with a clear error — and the new timeouts mean we find out in minutes rather than hours.

## Testing

YAML parsed and the step graph verified — `Install ImageMagick for diff GIFs` sits immediately before `Generate failure diff GIFs`, both `if: failure()`, with the diff/upload steps still downstream. The workflow itself can only be exercised by running it, which this PR will do on open.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6MGGU92XpRUv3kyofXLpX)_