### PR TITLE
Hide mobile sidebar entirely instead of showing a shrunken rail

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -833,68 +833,31 @@
 
 /* Mobile Portrait Overrides */
 @media (max-width: 768px) {
+    /* No shrunken icon-rail on mobile — the pane is fully off-screen until
+       opened via .sidebar-toggle, which is simpler than the old
+       hover-driven "shrunken rail" (hover has no touch equivalent, so it
+       needed extra state/CSS just to reveal contents on tap). */
     .sidebar {
         position: absolute;
         left: 0;
         top: 0;
         bottom: 0;
-        width: 64px;
-        min-width: 64px;
+        width: 300px;
+        min-width: 0;
+        max-width: 85vw;
         /* Above .progress-bar-container (z-index: 1000) so the pane isn't
            see-through to the progress bar when both overlap on mobile. */
         z-index: 1010;
-        padding: 24px 12px;
-        transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.3s ease;
-        overflow-x: hidden;
+        padding: 24px;
+        transform: translateX(-100%);
+        transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.3s ease;
         border-right: 1px solid var(--border-color);
         background: var(--sidebar-bg);
     }
 
-    /* Expansion is driven by the .mobile-open class (toggled on tap via
-       .sidebar-toggle), not :hover/:focus-within — touch devices have no
-       hover, so a hover-only rule left the pane permanently collapsed and
-       its contents unreachable/unscrollable on mobile. */
     .sidebar.mobile-open {
-        width: 300px;
+        transform: translateX(0);
         box-shadow: 10px 0 30px rgba(0, 0, 0, 0.5);
-    }
-
-    /* Hide text labels in shrunken sidebar */
-    .sidebar h2,
-    .sidebar .sidebar-title,
-    .sidebar .category-header .category-title,
-    .sidebar .control-group label,
-    .sidebar .value-display,
-    .sidebar .category-header span:not(.material-symbols-outlined) {
-        opacity: 0;
-        white-space: nowrap;
-        transition: opacity 0.2s ease;
-        pointer-events: none;
-    }
-
-    .sidebar.mobile-open h2,
-    .sidebar.mobile-open .sidebar-title,
-    .sidebar.mobile-open .category-header .category-title,
-    .sidebar.mobile-open .control-group label,
-    .sidebar.mobile-open .value-display,
-    .sidebar.mobile-open .category-header span {
-        opacity: 1;
-        pointer-events: auto;
-    }
-
-    /* Keep icons visible and centered */
-    .sidebar .category-header {
-        justify-content: center;
-        padding: 0;
-    }
-
-    .sidebar.mobile-open .category-header {
-        justify-content: flex-start;
-        padding-left: 0;
-    }
-
-    .sidebar .material-symbols-outlined {
-        font-size: 24px;
     }
 
     .sidebar-toggle {
@@ -924,7 +887,6 @@
     }
 
     .main {
-        margin-left: 64px;
         padding: 16px;
     }
 
@@ -947,6 +909,9 @@
         flex-direction: column;
         align-items: flex-start;
         gap: 12px;
+        /* Clear the floating .sidebar-toggle button (top:12px, left:12px,
+           40x40px) so it doesn't sit on top of the first row of content. */
+        padding-left: 56px;
     }
 
     .tabs {

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1715,10 +1715,7 @@ function App() {
       {mobileSidebarOpen && (
         <div className="sidebar-backdrop" onClick={() => setMobileSidebarOpen(false)} />
       )}
-      <div
-        className={`sidebar${mobileSidebarOpen ? ' mobile-open' : ''}`}
-        onClick={() => { if (!mobileSidebarOpen) setMobileSidebarOpen(true) }}
-      >
+      <div className={`sidebar${mobileSidebarOpen ? ' mobile-open' : ''}`}>
         <div className="sidebar-title" dangerouslySetInnerHTML={{ __html: sidebarTitleSvg }} />
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px', flex: '0 0 auto' }}>
           <h2 style={{ margin: 0 }}>Controls</h2>


### PR DESCRIPTION
## Summary

Now that the sidebar has a dedicated open/close button (`.sidebar-toggle`, top-left), the always-visible 64px "shrunken" icon rail on mobile is no longer needed — it was a leftover from the old hover-driven design, where something had to stay visible to hover/tap in the first place.

- `.sidebar` on mobile is now fully off-screen (`transform: translateX(-100%)`) until opened, then slides in at full width (`translateX(0)`), instead of living at a permanent 64px width that expanded to 300px.
- Removed the CSS that faked the "shrunken" state: hiding labels/text via opacity, centering icons, the width transition — none of it is needed now that the pane is either fully hidden or fully shown.
- Removed `.main`'s `margin-left: 64px` (no more rail reserving space) and instead gave `.top-bar` enough `padding-left` to clear the floating toggle button so it doesn't sit on top of the tabs.
- Dropped the "tap the rail to open" click handler added in #226 — there's no rail left to tap; the button is the only way in now, which is exactly what was asked for.

## Test plan

- [x] `dotnet fable src/explorer --outDir web/src/lib/fable && cd web && npm run build` — production build succeeds
- [x] `npm test` (Vitest) — 116/116 tests pass
- [x] Verified via Playwright (iPhone 13 emulation, touch-enabled context):
  - Closed: sidebar bounding box is `{ x: -300, width: 300 }` — fully off-screen, no rail visible (screenshot: only the "menu" button shows, clear of the tabs)
  - Tapping where the old rail used to be no longer does anything (transform unchanged)
  - Tapping `.sidebar-toggle` slides it to `{ x: 0 }` — full width, all content visible

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNjLmwCcW2TkotH3egsRns)_