### PR TITLE
Rename the interior-joint marker from `j` to `J`

### DIFF
--- a/docs/DactylGlyphs.md
+++ b/docs/DactylGlyphs.md
@@ -117,12 +117,12 @@ whose end caps left a notch at the join.
 - *Example:* `5 = "tr-tl-hlK~ttb(c)~(bbt)r~b(c)~bol"` — the bar, stem and bowl
   are a single stroke; `hlK` is the acute join where the stem meets the bowl, and
   the bowl springs back out of it at whatever angle the solver likes.
-- *Example:* `m = "xl-bl xolj~x(llw)~xxblwK~x(rw)~xxbw-bw xxblwj-blw"` — both
+- *Example:* `m = "xl-bl xolJ~x(llw)~xxblwK~x(rw)~xxbw-bw xxblwJ-blw"` — both
   arches are one stroke, kinked over the middle leg, and the leg hangs off that
   kink as a joint.
 
 `K` works at any junction (line→curve, curve→line and curve→curve, where it gives
-a cusp) and composes with the other modifiers: `hlKj` is a corner that is also an
+a cusp) and composes with the other modifiers: `hlKJ` is a corner that is also an
 interior joint.
 
 A kink can be as sharp as the design wants — the outline builder does not need it
@@ -154,7 +154,7 @@ the other two are thickest. In `m` the two arches kink and the leg branches, so
 the leg's cap is buried under arch ink on both sides rather than sitting out in
 the thin crotch between the arches.
 
-### Explicit Joints (`j`)
+### Explicit Joints (`J`)
 Many letters are drawn as several separate strokes that **meet in the middle**
 of another stroke rather than at a free end — the crossbar of `A`, the leg of
 `R` springing off the bowl, the arches of `m` springing off the stem. At such
@@ -162,19 +162,19 @@ an **interior joint** you do *not* want the stroke end decorated like a free
 terminal: a serif, flare or end-bulb poking out of the middle of the letter
 looks wrong.
 
-Append a trailing **`j`** to the endpoint that lands on another stroke to
+Append a trailing **`J`** to the endpoint that lands on another stroke to
 declare it an interior joint. Its cap (serif / flare / bulb) is then suppressed
 and the join is cleanly aligned instead.
-- *Example:* in `R = "bl-tl-tlo~(th)r~hlo-hlj hcj-br"`, the bowl end `hlj` and
-  the leg top `hcj` are joints, while the leg foot `br` stays a real terminal
+- *Example:* in `R = "bl-tl-tlo~(th)r~hlo-hlJ hloJ-br"`, the bowl end `hlJ` and
+  the leg top `hloJ` are joints, while the leg foot `br` stays a real terminal
   that still receives a serif.
 
 The generator also has a geometric heuristic (the debug **`joints`** axis) that
 auto-detects joints where an endpoint lands on a *straight* segment of another
-stroke. The explicit `j` marker is more reliable: it also covers endpoints that
+stroke. The explicit `J` marker is more reliable: it also covers endpoints that
 land on **curves** (which the heuristic cannot see) or that sit just past a
 neighbouring stroke's last knot, and it applies regardless of the `joints`
-axis. Prefer marking joints explicitly with `j`.
+axis. Prefer marking joints explicitly with `J`.
 
 ---
 

--- a/src/generator/Font.fs
+++ b/src/generator/Font.fs
@@ -501,7 +501,7 @@ type Font(axes: Axes, ?showCombOpt: bool) =
         checkElem elem
 
     /// True when a knot exactly at (X,Y) was explicitly declared an interior
-    /// joint via the `j` marker in the glyph string. Unlike the geometric
+    /// joint via the `J` marker in the glyph string. Unlike the geometric
     /// heuristic above this handles joints landing on curves (e.g. R's leg, m's
     /// arches) and is always honoured, independent of the `joints` axis.
     member this.isExplicitJoint elem X Y =
@@ -645,7 +645,7 @@ type Font(axes: Axes, ?showCombOpt: bool) =
             //
             // e=0 makes the corners t*cos(theta) from the spine, which is <= t for
             // any angle, so a flat cut can never poke out. It relies on the joint
-            // knot already lying inside the covering ink; every `j` knot now sits
+            // knot already lying inside the covering ink; every `J` knot now sits
             // exactly on its covering spine, so that holds at all weights.
             //
             // joint_gap recession is NOT applied here: the caller trims the spine by

--- a/src/generator/GeneratorTypes.fs
+++ b/src/generator/GeneratorTypes.fs
@@ -81,7 +81,7 @@ type Knot =
       ty: SpiroPointType
       th_in: float option
       th_out: float option
-      // Explicitly-declared interior joint (via the `j` marker in the glyph
+      // Explicitly-declared interior joint (via the `J` marker in the glyph
       // string language). When true, an open-stroke endpoint at this knot
       // suppresses its cap (serif/flare/bulb) regardless of the geometric
       // joint heuristic — see Font.isJointRaw.

--- a/src/generator/GlyphStringDefs.fs
+++ b/src/generator/GlyphStringDefs.fs
@@ -15,10 +15,10 @@ let y_re = "[txhbd0-9]+|\([txhbd0-9]+\)"
 let offset_re = "[oe]"
 let x_re = "[lrcw0-9]+|\([lrcw0-9]+\)"
 let direction_re = "[NSEW]"
-// Explicit interior-joint marker: a trailing `j` on a point declares that an
+// Explicit interior-joint marker: a trailing `J` on a point declares that an
 // open-stroke endpoint landing here is a joint against another stroke, so its
 // cap (serif/flare/bulb) is suppressed. See Font.isJointRaw and DactylGlyphs.md.
-let joint_re = "j"
+let joint_re = "J"
 // Explicit corner (kink) marker: a trailing `K` forces the point to be a Corner,
 // breaking tangent continuity there while leaving both tangents free for the
 // solver. This is what lets a straight stem run directly into a curve that
@@ -102,15 +102,15 @@ let glyphMap =
           // One continuous stroke: the stem runs into the bowl at an acute kink (`K`),
           // rather than two overlapping strokes whose caps left a notch at the join.
           '5', "tr-tl-hlK~ttb(c)~(bbt)r~b(c)~bol"
-          '6', "tor~t(c)~(h)l~bbtl~b(c)~bbtr~ttbc~bbtlNj"
+          '6', "tor~t(c)~(h)l~bbtl~b(c)~bbtr~ttbc~bbtlNJ"
           '7', "tl-tr-bcl"
           //  two loops:
           //  '8', "hc~thl~tc~thr~ hc~bhl~bc~bhr~"
           // figure of eight:
           '8', "hc~(th)l~t(c)~(th)r~hc~(bh)l~b(c)~(bh)r~"
-          '9', "bol~b(c)~(h)r~ttbr~t(c)~ttbl~bbtc~ttbrSj"
+          '9', "bol~b(c)~(h)r~ttbr~t(c)~ttbl~bbtc~ttbrSJ"
 
-          'A', "bl-tc-br bhl3cj-bhcr3j"
+          'A', "bl-tc-br bhl3cJ-bhcr3J"
           'a', "xr-br xor~x(c)~(xb)l~b(c)~bor"
           'B', "hl-hlo~(bh)r~blo-bl-tl-tlo~(th)r~hlo-hl"
           'b', "tl-bl bol~b(c)~(xb)r~x(c)~xol"
@@ -119,7 +119,7 @@ let glyphMap =
           'D', "tl-bl-blo~(h)r~tlo-"
           'd', "tr-br xor~x(c)~(xb)l~b(c)~bor"
           'E', "tr-tl-bl-br hl-hr"
-          'e', "xblj-xbrN~x(c)~xblS~b(c)~bor5c"
+          'e', "xblJ-xbrN~x(c)~xblS~b(c)~bor5c"
           'F', "bl-tl-tr hl-hrc"
           'f', "bllc-xtllc~tcrW xl-xc"
           'G', "tor~t(c)~(h)l~b(c)~bhr-hr-hc"
@@ -133,18 +133,18 @@ let glyphMap =
           // Leg springs from the arm (like 'k' below), not from the stem: two strokes
           // both ending at the stem cap each other perpendicular to their own axis, and
           // the caps cross inside the stem, leaving the ink between them unfilled — a
-          // white bite out of the junction that widens with weight. `j` buries the leg's
+          // white bite out of the junction that widens with weight. `J` buries the leg's
           // cap inside the arm instead. The junction sits at `h9b` rather than `h`: `h`
           // takes the `balance` raise meant for crossbars and waists, which lifted this
           // vertex above the optical middle. `h8tl4r` is 1/5 along the arm, the point the
           // coordinate grid puts closest to the arm's spine once it is lowered (0.2 units
           // off) — springing from off the spine leaves a spur at hairline weights.
-          // Both interior ends are marked `j`: the arm's lands on the stem, so the
+          // Both interior ends are marked `J`: the arm's lands on the stem, so the
           // geometric heuristic already suppresses its cap while the `joints` axis is on,
           // but with that axis off the marker is what stops a serif bracket (or bulb)
           // sprouting out through the far side of the stem.
-          'K', "tl-bl tr-h9blj h8tl4rj-br"
-          'k', "tl-bl xb2l-xcr x2bc3lj-bcr"
+          'K', "tl-bl tr-h9blJ h8tl4rJ-br"
+          'k', "tl-bl xb2l-xcr x2bc3lJ-bcr"
           'L', "tl-bl-br"
           'l', "tl-xbl~bcW"
           'M', "bl-tl-blw-tw-bw"
@@ -154,7 +154,7 @@ let glyphMap =
           // crotch — the thinnest part of the junction — and stepped the outline there.
           // Of the three strokes meeting here, the leg is the one whose cap hides best:
           // it starts below the crotch with arch ink either side of it.
-          'm', "xl-bl xolj~x(llw)~xxblwK~x(rw)~xxbw-bw xxblwj-blw"
+          'm', "xl-bl xolJ~x(llw)~xxblwK~x(rw)~xxbw-bw xxblwJ-blw"
           'N', "bl-tl-br-tr"
           'n', "xl-bl xol~x(c)~xbr-br"
           'O', "(h)l~t(c)~(h)r~b(c)~"
@@ -163,7 +163,7 @@ let glyphMap =
           'p', "xl-dl bol~b(c)~(xb)r~x(c)~xol"
           'Q', "(h)l~t(c)~(h)r~b(c)~ br-hbc"
           'q', "xr-dr xor~x(c)~(xb)l~b(c)~bor"
-          'R', "bl-tl-tlo~(th)r~hlo-hlj hloj-br"
+          'R', "bl-tl-tlo~(th)r~hlo-hlJ hloJ-br"
           'r', "xl-bl xol~xlcc~xoccr"
           'S', "thr~t(c)~(ttb)l~hc~(tbb)r~b(c)~bhl"
           's', "xor~x(c)~(xxb)l~xbcE~(xbb)r~b(c)~bol"
@@ -177,7 +177,7 @@ let glyphMap =
           'w', "xl-bl3w-xlw-blw3-xw"
           'X', "tl-br tr-bl"
           'x', "xl-br xr-bl"
-          'Y', "tl-hc-tr hcj-bc"
+          'Y', "tl-hc-tr hcJ-bc"
           'y', "xl-xbl~b(c)~xbr-xr xr-br~d(c)~dol"
           'Z', "tl-tr-bl-br"
           'z', "xl-xr-bl-br" ]

--- a/src/generator/tests/FontTest.fs
+++ b/src/generator/tests/FontTest.fs
@@ -1328,7 +1328,7 @@ type CornerOutlineTests() =
         let legTop =
             curves
             |> List.collect id
-            |> List.filter (fun k -> k.label = Some "xxblwj")
+            |> List.filter (fun k -> k.label = Some "xxblwJ")
 
         Assert.That(legTop.Length, Is.EqualTo(1), "middle leg should start at the kink")
         Assert.That(legTop.Head.isJoint, Is.True, "middle leg top is a joint")

--- a/src/generator/tests/ParserTests.fs
+++ b/src/generator/tests/ParserTests.fs
@@ -125,22 +125,22 @@ type ParserTests() =
 
     [<Test>]
     member this.TestJointMarker() =
-        // A trailing `j` marks an explicit interior joint; the coordinate is
-        // unchanged and the `j` is consumed (not left in the remaining def).
+        // A trailing `J` marks an explicit interior joint; the coordinate is
+        // unchanged and the `J` is consumed (not left in the remaining def).
         let plain, _, _, plainJoint, _, _ = parse_point metrics "hc"
-        let jointed, _, _, isJoint, label, rest = parse_point metrics "hcj"
+        let jointed, _, _, isJoint, label, rest = parse_point metrics "hcJ"
         Assert.That(plainJoint, Is.False, "plain point is not a joint")
-        Assert.That(isJoint, Is.True, "`j` suffix should mark a joint")
+        Assert.That(isJoint, Is.True, "`J` suffix should mark a joint")
         Assert.That(jointed.x, Is.EqualTo(plain.x), "x unchanged by joint marker")
         Assert.That(jointed.y, Is.EqualTo(plain.y), "y unchanged by joint marker")
-        Assert.That(label, Is.EqualTo("hcj"))
-        Assert.That(rest, Is.EqualTo(""), "`j` should be consumed")
+        Assert.That(label, Is.EqualTo("hcJ"))
+        Assert.That(rest, Is.EqualTo(""), "`J` should be consumed")
 
     [<Test>]
     member this.TestJointMarkerOnKnotAndDetection() =
-        // The `j` marker survives into the parsed knot, and Font.isJoint reports
+        // The `J` marker survives into the parsed knot, and Font.isJoint reports
         // true at that point even when the geometric `joints` heuristic is off.
-        let elem = parse_curve metrics "hcj-br" false
+        let elem = parse_curve metrics "hcJ-br" false
 
         match elem with
         | Curve(knots, _) ->
@@ -159,7 +159,7 @@ type ParserTests() =
     [<Test>]
     member this.TestCornerMarker() =
         // A trailing `K` marks an explicit corner (kink); the coordinate is unchanged
-        // and the `K` is consumed. It composes with the joint marker (`Kj`).
+        // and the `K` is consumed. It composes with the joint marker (`KJ`).
         let plain, _, plainCorner, _, _, _ = parse_point metrics "hc"
         let kinked, _, isCorner, _, label, rest = parse_point metrics "hcK"
         Assert.That(plainCorner, Is.False, "plain point is not a corner")
@@ -169,9 +169,9 @@ type ParserTests() =
         Assert.That(label, Is.EqualTo("hcK"))
         Assert.That(rest, Is.EqualTo(""), "`K` should be consumed")
 
-        let _, _, bothCorner, bothJoint, _, _ = parse_point metrics "hcKj"
-        Assert.That(bothCorner, Is.True, "`K` before `j` is still a corner")
-        Assert.That(bothJoint, Is.True, "`j` after `K` is still a joint")
+        let _, _, bothCorner, bothJoint, _, _ = parse_point metrics "hcKJ"
+        Assert.That(bothCorner, Is.True, "`K` before `J` is still a corner")
+        Assert.That(bothJoint, Is.True, "`J` after `K` is still a joint")
 
     [<Test>]
     member this.TestCornerMarkerBreaksLineToCurve() =

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1940,7 +1940,7 @@ function App() {
                       <strong>Key:</strong> y: (t)op, (x)-height, (h)alf, (b)ottom, (d)escender, (o)ffset in, (e)xtended out. <br />
                       x: (l)eft, (c)enter, (r)ight, (w)ide. Solo point → dot. <br />
                       Dirs: N,S,E,W. Lines: (-) straight, (~) curve. Brackets: auto fit. <br />
-                      K: corner/kink. j: interior joint (suppresses end caps). <br />
+                      K: corner/kink. J: interior joint (suppresses end caps). <br />
                       Repeats average coordinates (e.g. "bt"="h"); a digit repeats the letter before it, so "b2t"="bbt". <br />
                       <a
                         href="https://github.com/terryspitz/dactyl-font/blob/master/docs/DactylGlyphs.md"


### PR DESCRIPTION
Capitalising the interior-joint marker matches `K` (the corner/kink marker) and separates the two **point modifiers** from the lowercase **coordinate letters**, which is how the rest of the language already reads.

`J` was free. The only other capitals in the glyph language are the cardinal tangents `[NSEW]` and `K`, so there is no collision in `point_re`.

## What changed

- **Parser** — `joint_re = "j"` → `"J"` (`GlyphStringDefs.fs`).
- **The nine glyph strings that use it** — `6 9 A e K k m R Y`.
- **Tests** — `ParserTests.TestJointMarker`, `TestJointMarkerOnKnotAndDetection`, the `K`+joint composition case (`hcKj` → `hcKJ`), and `m`'s knot-label assertion.
- **Docs** — `docs/DactylGlyphs.md`: the *Explicit Joints* section, the `m` and `hlKJ` examples, and the prose.
- **Glyphs tab key** — `J: interior joint (suppresses end caps)`.

While updating the docs I also corrected that section's `R` example, which cited `hcj` for the leg top where the glyph actually uses `hlo` — it now reads `R = "bl-tl-tlo~(th)r~hlo-hlJ hloJ-br"`, matching the source.

Comments in `Font.fs` and `GeneratorTypes.fs` that name the marker were updated too. The internal F# identifiers (`isJoint`, `isJointRaw`, the `joints` axis) are unchanged — they are not the marker.

## Verification

Purely cosmetic, and checked rather than assumed: every glyph in `glyphMap` was rendered across 7 axis presets (sans, bold, serif, round, italic, segpath, spiro) before and after, and the path data compared — **707 cells, 0 differences**.

- `dotnet test src/generator/tests` — 117 passed
- `cd web && npm test` — 116 passed
- `dotnet fable src/explorer` + `npm run build` clean; Glyphs tab key verified in the browser

## Compatibility

Nothing persists an old marker: the Glyphs tab regenerates its definitions from the live glyph map on load (only the *characters* are kept in `localStorage`), so there is no stale `j` to break. A glyph string with the old `j` pasted in by hand no longer parses — `rawDefToElem` catches that and renders a dot rather than throwing.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yRp2Dc5ByW122jGdooWNR

---
_Generated by [Claude Code](https://claude.ai/code/session_017yRp2Dc5ByW122jGdooWNR)_