### PR TITLE
Fix sidebar logo's D being clipped at the top

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1702,10 +1702,17 @@ function App() {
   // Constant inputs — memoized so this isn't recomputed on every render
   // (e.g. every slider tick), which was expensive enough to noticeably
   // delay the browser's touch-scroll response when dragging a slider.
-  const sidebarTitleSvg = useMemo(
-    () => generateTweenSvg("Dactyl", { ...defaultAxes, weight: 35 }),
-    []
-  )
+  const sidebarTitleSvg = useMemo(() => {
+    const svg = generateTweenSvg("Dactyl", { ...defaultAxes, weight: 35 })
+    // The D's rounded top slightly overshoots the generator's computed
+    // viewBox (measured ~15 units short on a 1000-unit-tall glyph), so its
+    // top edge gets clipped. Give it some headroom here rather than in the
+    // shared generator, which other, unaffected renders also depend on.
+    return svg.replace(/viewBox='(-?[\d.]+) (-?[\d.]+) ([\d.]+) ([\d.]+)'/, (_, x, y, w, h) => {
+      const margin = 20
+      return `viewBox='${x} ${parseFloat(y) - margin} ${w} ${parseFloat(h) + margin}'`
+    })
+  }, [])
 
   return (
     <div className="container">


### PR DESCRIPTION
## Summary

The "Dactyl" logo SVG in the sidebar (`.sidebar-title`) had its D's rounded top clipped off.

- Measured the actual generated geometry: `generateTweenSvg("Dactyl", { ...defaultAxes, weight: 35 })` produces a viewBox of `-10 65 2251 1000`, but the topmost rendered point across all six letters (the D's rounded top) is at y=50 — 15 units above the viewBox's top edge (65) on a 1000-unit-tall glyph, so it was clipped.
- Fixed by padding the viewBox's top by 20 units (15 measured + margin) for this one logo render, done as a string patch in `web/src/App.jsx` right after generating the SVG, rather than touching the shared `generateTweenSvg` computation — other call sites elsewhere in the app aren't affected by this and shouldn't be touched for a fix scoped to one logo instance.

## Test plan

- [x] `dotnet fable src/explorer --outDir web/src/lib/fable && cd web && npm run build` — production build succeeds
- [x] `npm test` (Vitest) — 116/116 tests pass
- [x] Verified via the browser's actual `SVGGraphicsElement.getBBox()` on the rendered logo (not just static path parsing): content top is now at y=50, viewBox top is at y=45 — a clean 5-unit margin instead of a 15-unit clip. Screenshot confirms the D's full rounded top is visible.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNjLmwCcW2TkotH3egsRns)_