### PR TITLE
Show more tween variations and default to a smaller zoom on mobile

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -166,7 +166,11 @@ function App() {
   const [tabZooms, setTabZooms] = useState(() => {
     const urlZoom = parseFloat(new URLSearchParams(window.location.search).get('zoom'))
     const zoom = isNaN(urlZoom) ? 1.0 : urlZoom
-    return { font: zoom, glyphs: zoom, tweens: zoom, visualDiffs: zoom, splines: zoom, splineGrid: zoom, proofs: zoom, generate: zoom }
+    // Narrow (mobile) screens only fit a couple of 150px tween boxes at zoom 1,
+    // so default the tweens tab to a smaller zoom there to fit more variations.
+    const isMobileWidth = window.innerWidth <= 768
+    const tweensZoom = isNaN(urlZoom) && isMobileWidth ? 0.5 : zoom
+    return { font: zoom, glyphs: zoom, tweens: tweensZoom, visualDiffs: zoom, splines: zoom, splineGrid: zoom, proofs: zoom, generate: zoom }
   })
   const [layerVisibility, setLayerVisibility] = useState({
     spiro: false,
@@ -1028,7 +1032,7 @@ function App() {
       typeReq = 'tweens'
       const boxWidth = 150 * zoom
       const availableWidth = previewRef.current?.clientWidth ?? window.innerWidth
-      const steps = Math.max(2, Math.floor((availableWidth + 10) / (boxWidth + 10)))
+      const steps = Math.max(4, Math.floor((availableWidth + 10) / (boxWidth + 10)))
       args = [char, axes, steps]
     } else if (activeTab === 'visualDiffs') {
       if (compareMode === 'font') {


### PR DESCRIPTION
## Summary
- On narrow (mobile-width) screens the Tweens tab only fit 2 glyph boxes per row at zoom 1.0, so floating-point axes (`height`, etc.) barely showed any variation across their range.
- The tweens tab now defaults to zoom `0.5` on screens `<= 768px` wide (when no explicit `?zoom=` URL param is set), shrinking the glyph boxes so more fit on screen.
- Raised the minimum computed step count for float axes from 2 to 4, so at least 4 variations are always generated/shown regardless of available width.

## Test plan
- [x] `dotnet fable src/explorer --outDir web/src/lib/fable` — compiles cleanly
- [x] `cd web && npm test` — 116 tests pass
- [x] `cd web && npm run build` — production build succeeds
- [x] Manually verified with Playwright at a 375×700 mobile viewport: the `height` axis row now renders 4 `.tween-item` boxes (up from 2) with the default zoom
- [x] Confirmed the existing Tweens visual-test snapshots pass an explicit `?zoom=0.85` URL param and use the 1280px desktop viewport, so this change doesn't affect committed snapshots


---
_Generated by [Claude Code](https://claude.ai/code/session_01KRkKGCxviFsUNXc8G5CRE4)_