### PR TITLE
Put each glyph's spacing strings on one line

### DIFF
--- a/web/src/proofs.js
+++ b/web/src/proofs.js
@@ -41,15 +41,13 @@ const SPACING_CONTROL_STRINGS = [
   'nnOOnonoOOoo',
 ]
 
-const spacingStringsForGlyph = (c) => [
-  `nn${c}nonouu${c}nono${c}oo`,
-  `HH${c}HOHO${c}OO`,
-]
+const spacingStringsForGlyph = (c) =>
+  `${c} nn${c}nonouu${c}nono${c}oo HH${c}HOHO${c}OO`
 
 const spacingStringsText = [
   ...SPACING_CONTROL_STRINGS,
   '',
-  ...Array.from(alphabetChars.replace(/\n/g, '')).flatMap(spacingStringsForGlyph),
+  ...Array.from(alphabetChars.replace(/\n/g, '')).map(spacingStringsForGlyph),
 ].join('\n')
 
 export const proofTexts = {


### PR DESCRIPTION
## Summary
- Each glyph's "Spacing Strings" proof line now starts with the glyph itself, followed by a space, then the straight- and round-neighbour comparison strings on that same line — previously these were split across two separate lines per glyph.

## Test plan
- [x] `cd web && npm test -- --run` — 101 tests pass (2 pre-existing failures unrelated to this change, due to a missing Fable-compiled `lib/fable/Api.js` module in this environment)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6Vy3yGf7fmxrNo55akJVV)_